### PR TITLE
Enable rendering world state and agent view during training

### DIFF
--- a/pufferlib/ocean/drive/drive.c
+++ b/pufferlib/ocean/drive/drive.c
@@ -356,7 +356,7 @@ void eval_gif(const char* map_name){
 
     float map_width = env.map_corners[2] - env.map_corners[0];
     float map_height = env.map_corners[3] - env.map_corners[1];
-    float scale = 6.0f;
+    float scale = 8.0f;
     float img_width = (int)(map_width * scale);
     float img_height = (int)(map_height * scale);
     RenderTexture2D target = LoadRenderTexture(img_width, img_height);
@@ -371,23 +371,49 @@ void eval_gif(const char* map_name){
     int rollout = 1;
     int rollout_trajectory_snapshot = 0;
     int log_trajectory = 1;
-    if (rollout){
-        for(int i = 0; i < frame_count; i++){
-            float* path_taken=NULL;
-            snprintf(filename, sizeof(filename), "resources/drive/frame_%03d.png", i);
+        if (rollout) {
+        // Generate top-down view frames
+        for(int i = 0; i < frame_count; i++) {
+            float* path_taken = NULL;
+            snprintf(filename, sizeof(filename), "resources/drive/frame_topdown_%03d.png", i);
             saveTopDownImage(&env, client, filename, target, map_height, obs_only, lasers, rollout_trajectory_snapshot, frame_count, path_taken, log_trajectory);
             int (*actions)[2] = (int(*)[2])env.actions;
             forward(net, env.observations, env.actions);
             c_step(&env);
         }
 
-        // generate gif
-        int gif_success = make_gif_from_frames("resources/drive/frame_%03d.png",
-                             30, // fps
-                             "resources/drive/palette.png",
-                             "resources/drive/output.gif");
-        if(gif_success == 0){
-            run_cmd("rm -f resources/drive/frame_*.png resources/drive/palette.png");
+        // Reset environment to initial state
+        c_reset(&env);
+
+        // Generate agent view frames
+        for(int i = 0; i < frame_count; i++) {
+            float* path_taken = NULL;
+            snprintf(filename, sizeof(filename), "resources/drive/frame_agent_%03d.png", i);
+            saveAgentViewImage(&env, client, filename, target, map_height, 1, 0); // obs_only=1, lasers=0
+            int (*actions)[2] = (int(*)[2])env.actions;
+            forward(net, env.observations, env.actions);
+            c_step(&env);
+        }
+
+        // Generate both GIFs
+        int gif_success_topdown = make_gif_from_frames(
+            "resources/drive/frame_topdown_%03d.png",
+            30, // fps
+            "resources/drive/palette_topdown.png",
+            "resources/drive/output_topdown.gif"
+        );
+
+        int gif_success_agent = make_gif_from_frames(
+            "resources/drive/frame_agent_%03d.png",
+                             15, // fps
+                             "resources/drive/palette_agent.png",
+                             "resources/drive/output_agent.gif");
+
+        if(gif_success_topdown == 0) {
+            run_cmd("rm -f resources/drive/frame_topdown_*.png resources/drive/palette_topdown.png");
+        }
+        if(gif_success_agent == 0) {
+            run_cmd("rm -f resources/drive/frame_agent_*.png resources/drive/palette_agent.png");
         }
     }
     if (rollout_trajectory_snapshot){
@@ -458,6 +484,6 @@ void performance_test() {
 int main() {
     // demo();
     // performance_test();
-    eval_gif();
+    eval_gif(NULL);
     return 0;
 }

--- a/pufferlib/ocean/drive/drive.c
+++ b/pufferlib/ocean/drive/drive.c
@@ -324,12 +324,19 @@ static int make_gif_from_frames(const char *pattern, int fps,
     return 0;
 }
 
-void eval_gif(){
-   Drive env = {
+void eval_gif(const char* map_name){
+
+    // Use default if no map provided
+    if (map_name == NULL) {
+        map_name = "resources/drive/binaries/map_942.bin";
+    }
+
+    // Make env
+    Drive env = {
         .dynamics_model = CLASSIC,
         .reward_vehicle_collision = -0.1f,
         .reward_offroad_collision = -0.1f,
-	    .map_name = "resources/drive/binaries/map_942.bin",
+	    .map_name = map_name,
         .spawn_immunity_timer = 50
     };
     allocate(&env);

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -2011,6 +2011,43 @@ void saveTopDownImage(Drive* env, Client* client, const char *filename, RenderTe
 
 }
 
+void saveAgentViewImage(Drive* env, Client* client, const char *filename, RenderTexture2D target, int map_height, int obs_only, int lasers) {
+    // Agent perspective camera following the human agent
+    int agent_idx = env->active_agent_indices[env->human_agent_idx];
+    Entity* agent = &env->entities[agent_idx];
+
+    Camera3D camera = {0};
+    // Position camera behind and above the agent
+    camera.position = (Vector3){
+        agent->x - (25.0f * cosf(agent->heading)),
+        agent->y - (25.0f * sinf(agent->heading)),
+        15.0f
+    };
+    camera.target = (Vector3){
+        agent->x + 40.0f * cosf(agent->heading),
+        agent->y + 40.0f * sinf(agent->heading),
+        1.0f
+    };
+    camera.up = (Vector3){ 0.0f, 0.0f, 1.0f };
+    camera.fovy = 45.0f;
+    camera.projection = CAMERA_PERSPECTIVE;
+
+    Color road = (Color){35, 35, 37, 255};
+
+    BeginTextureMode(target);
+        ClearBackground(road);
+        BeginMode3D(camera);
+            rlEnableDepthTest();
+            draw_scene(env, client, 0, obs_only, lasers); // mode=0 for agent view
+        EndMode3D();
+    EndTextureMode();
+
+    // Save to file
+    Image img = LoadImageFromTexture(target.texture);
+    ImageFlipVertical(&img);
+    ExportImage(img, filename);
+    UnloadImage(img);
+}
 
 void c_render(Drive* env) {
     if (env->client == NULL) {

--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -539,20 +539,30 @@ class PuffeRL:
                         )
 
                         if result.returncode == 1:
-                            # Move generated GIF to the model directory
-                            source_gif = "resources/drive/output.gif"
-                            if os.path.exists(source_gif):
-                                target_gif = os.path.join(gif_output_dir, f"epoch_{self.epoch:06d}.gif")
-                                shutil.move(source_gif, target_gif)
+                            # Move both generated GIFs to the model directory
+                            gifs = [
+                                ("resources/drive/output_topdown.gif", f"epoch_{self.epoch:06d}_topdown.gif"),
+                                ("resources/drive/output_agent.gif", f"epoch_{self.epoch:06d}_agent.gif"),
+                            ]
 
-                                # Log to wandb if available
-                                if hasattr(self.logger, "wandb") and self.logger.wandb:
-                                    import wandb
+                            for source_gif, target_filename in gifs:
+                                if os.path.exists(source_gif):
+                                    target_gif = os.path.join(gif_output_dir, target_filename)
+                                    shutil.move(source_gif, target_gif)
 
-                                    self.logger.wandb.log(
-                                        {"render/gif": wandb.Video(target_gif, format="gif")},
-                                        step=self.global_step,
-                                    )
+                                    # Log to wandb if available
+                                    if hasattr(self.logger, "wandb") and self.logger.wandb:
+                                        import wandb
+
+                                        view_type = "world_state" if "topdown" in target_filename else "agent_view"
+                                        self.logger.wandb.log(
+                                            {f"render/{view_type}": wandb.Video(target_gif, format="gif")},
+                                            step=self.global_step,
+                                        )
+
+                                else:
+                                    print(f"GIF generation completed but {source_gif} not found")
+
                             else:
                                 print("GIF generation completed but file not found")
                         else:


### PR DESCRIPTION
Extends eval_gif() functionality to include agent observation alongside the world state. 

Also makes `map_name` configurable (sorry, that should have been a separate PR). 