### PR TITLE
Add heading and speed distances to human logs

### DIFF
--- a/pufferlib/config/ocean/drive.ini
+++ b/pufferlib/config/ocean/drive.ini
@@ -24,6 +24,8 @@ action_type = "discrete" # discrete, continuous
 reward_vehicle_collision = -0.5
 reward_offroad_collision = -0.2
 reward_ade = 0.0
+reward_speed = 0.0
+reward_heading = 0.0
 spawn_immunity_timer = 50
 reward_goal_post_respawn = 0.25
 reward_vehicle_collision_post_respawn = -0.5
@@ -85,6 +87,20 @@ max = 0.0
 mean = -0.2
 
 [sweep.env.reward_ade]
+distribution = uniform
+min = -0.1
+max = 0.0
+mean = -0.02
+scale = auto
+
+[sweep.env.reward_speed]
+distribution = uniform
+min = -0.1
+max = 0.0
+mean = -0.02
+scale = auto
+
+[sweep.env.reward_heading]
 distribution = uniform
 min = -0.1
 max = 0.0

--- a/pufferlib/ocean/drive/binding.c
+++ b/pufferlib/ocean/drive/binding.c
@@ -144,6 +144,8 @@ static int my_init(Env* env, PyObject* args, PyObject* kwargs) {
     env->reward_goal_post_respawn = unpack(kwargs, "reward_goal_post_respawn");
     env->reward_vehicle_collision_post_respawn = unpack(kwargs, "reward_vehicle_collision_post_respawn");
     env->reward_ade = unpack(kwargs, "reward_ade");
+    env->reward_speed = unpack(kwargs, "reward_speed");
+    env->reward_heading = unpack(kwargs, "reward_heading");
     env->spawn_immunity_timer = unpack(kwargs, "spawn_immunity_timer");
     int map_id = unpack(kwargs, "map_id");
     int max_agents = unpack(kwargs, "max_agents");
@@ -169,5 +171,7 @@ static int my_log(PyObject* dict, Log* log) {
     assign_to_dict(dict, "completion_rate", log->completion_rate);
     assign_to_dict(dict, "clean_collision_rate", log->clean_collision_rate);
     assign_to_dict(dict, "avg_displacement_error", log->avg_displacement_error);
+    assign_to_dict(dict, "avg_heading_error", log->avg_heading_error);
+    assign_to_dict(dict, "avg_speed_error", log->avg_speed_error);
     return 0;
 }

--- a/pufferlib/ocean/drive/drive.c
+++ b/pufferlib/ocean/drive/drive.c
@@ -234,6 +234,8 @@ void demo() {
         .reward_vehicle_collision = -0.1f,
         .reward_offroad_collision = -0.1f,
         .reward_ade = -0.0f,
+        .reward_speed = -0.0f,
+        .reward_heading = -0.0f,
 	    .map_name = "resources/drive/binaries/map_942.bin",
         .spawn_immunity_timer = 50,
     };
@@ -337,6 +339,8 @@ void eval_gif(const char* map_name, int show_grid, int obs_only, int lasers, int
         .reward_vehicle_collision = -0.1f,
         .reward_offroad_collision = -0.1f,
         .reward_ade = -0.0f,
+        .reward_speed = -0.0f,
+        .reward_heading = -0.0f,
 	    .map_name = map_name,
         .spawn_immunity_timer = 50
     };

--- a/pufferlib/ocean/drive/drive.py
+++ b/pufferlib/ocean/drive/drive.py
@@ -20,6 +20,8 @@ class Drive(pufferlib.PufferEnv):
         reward_goal_post_respawn=0.5,
         reward_vehicle_collision_post_respawn=-0.25,
         reward_ade=0.0,
+        reward_speed=0.0,
+        reward_heading=0.0,
         spawn_immunity_timer=30,
         resample_frequency=91,
         num_maps=100,
@@ -37,6 +39,8 @@ class Drive(pufferlib.PufferEnv):
         self.reward_goal_post_respawn = reward_goal_post_respawn
         self.reward_vehicle_collision_post_respawn = reward_vehicle_collision_post_respawn
         self.reward_ade = reward_ade
+        self.reward_speed = reward_speed
+        self.reward_heading = reward_heading
         self.spawn_immunity_timer = spawn_immunity_timer
         self.human_agent_idx = human_agent_idx
         self.resample_frequency = resample_frequency
@@ -89,6 +93,8 @@ class Drive(pufferlib.PufferEnv):
                 reward_goal_post_respawn=reward_goal_post_respawn,
                 reward_vehicle_collision_post_respawn=reward_vehicle_collision_post_respawn,
                 reward_ade=reward_ade,
+                reward_speed=reward_speed,
+                reward_heading=reward_heading,
                 spawn_immunity_timer=spawn_immunity_timer,
                 map_id=map_ids[i],
                 max_agents=nxt - cur,
@@ -138,6 +144,8 @@ class Drive(pufferlib.PufferEnv):
                         reward_goal_post_respawn=self.reward_goal_post_respawn,
                         reward_vehicle_collision_post_respawn=self.reward_vehicle_collision_post_respawn,
                         reward_ade=self.reward_ade,
+                        reward_speed=self.reward_speed,
+                        reward_heading=self.reward_heading,
                         spawn_immunity_timer=self.spawn_immunity_timer,
                         map_id=map_ids[i],
                         max_agents=nxt - cur,

--- a/pufferlib/ocean/rewards.md
+++ b/pufferlib/ocean/rewards.md
@@ -1,0 +1,77 @@
+# PufferDrive rewards
+
+Overview of configurable rewards and what they do.
+
+## Reward components
+
+### Goal completion rewards
+
+#### **Goal reached (primary)**
+- **Type**: discrete
+- **Value**: `+1.0`
+- **Trigger**: agent reaches within 2.0 meters of goal position The "goal" position is currently taken as the end of it's corresponding log trajectory
+- **Description**: used to condition agent to drive to any (x,y)  target
+- **Frequency**: once per goal achievement
+
+#### **Goal reached (post-respawn)**
+- **Type**: discrete
+- **Value**: `reward_goal_post_respawn` (configurable)
+- **Trigger**: agent reaches goal after being respawned during episode
+- **Description**: potentially reduced reward for goal completion after respawn
+- **Range**: typically `[0.0, 1.0]`
+
+### Collision penalties
+
+#### **Vehicle collision (clean)**
+- **Type**: discrete
+- **Value**: `reward_vehicle_collision` (configurable)
+- **Trigger**: agent collides with another vehicle before reaching goal
+- **Description**: penalty for hitting other cars, affects "clean collision rate" metric
+- **Range**: typically `[-1.0, 0.0]`; set to positive value for encouraging collisions.
+
+#### **Vehicle collision (post-respawn)**
+- **Type**: discrete
+- **Value**: `reward_vehicle_collision_post_respawn` (configurable, negative)
+- **Trigger**: agent collides with vehicle after being respawned
+- **Description**: potentially reduced penalty for collisions after respawn
+- **Range**: typically `[-1.0, 0.0]`
+
+#### **Off-road collision**
+- **Type**: discrete
+- **Value**: `reward_offroad_collision` (configurable)
+- **Trigger**: agent's bounding box intersects with road edge boundaries
+- **Description**: penalty for leaving designated driving areas
+- **Range**: typically `[-1.0, 0.0]`
+
+### Human log rewards
+
+#### **Average displacement error (ade)**
+- **Type**: continuous
+- **Value**: `reward_ade * current_ade` (configurable weight × bounded error)
+- **Trigger**: applied every timestep when reference trajectory is available
+- **Error range**: `[0.0, 1.0)` (bounded by exponential transform)
+- **Transform**: `1.0 - exp(-squared_displacement_error)`
+- **Description**: penalizes spatial deviation from reference trajectory
+- **Total range**: depends on `reward_ade` weight (typically negative)
+
+#### **Heading error**
+- **Type**: continuous
+- **Value**: `reward_heading * current_heading_error` (configurable weight × error)
+- **Trigger**: applied every timestep when reference trajectory is available
+- **Error range**: `[0.0, 1.0)` (bounded by exponential transform)
+- **Transform**: `1.0 - exp(-squared_heading_difference)`
+- **Description**: penalizes angular deviation from reference heading
+- **Total range**: depends on `reward_heading` weight (typically negative)
+
+#### **Speed error**
+- **Type**: continuous
+- **Value**: `reward_speed * current_speed_error` (configurable weight × error)
+- **Trigger**: applied every timestep when reference trajectory is available
+- **Error range**: `[0.0, 1.0)` (bounded by exponential transform)
+- **Transform**: `1.0 - exp(-squared_speed_difference)`
+- **Description**: penalizes deviation from reference speed
+- **Total range**: depends on `reward_speed` weight (typically negative)
+
+### Lane alignment
+- **Type**: todo
+- **Description**: reward for maintaining proper lane positioning and orientation


### PR DESCRIPTION
- Adds metrics for the heading and speed targets to the human logs. 
- Combines all log distance metrics in a single function. 
- Add docs to explain reward components and their scale