### PR TITLE
Temporarily disable lane check.

### DIFF
--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -877,8 +877,9 @@ void compute_agent_metrics(Drive* env, int agent_idx) {
     }
 
     // check if aligned with closest lane
-    int lane_aligned = check_lane_aligned(agent, &env->entities[closest_lane_idx]);
-    agent->metrics_array[LANE_ALIGNED_IDX] = lane_aligned ? 1.0f : 0.0f;
+    // This causes a bug in rendering, temporarily disabling it
+    //int lane_aligned = check_lane_aligned(agent, &env->entities[closest_lane_idx]);
+    agent->metrics_array[LANE_ALIGNED_IDX] = 0.0f;
 
     // Check for vehicle collisions
     int car_collided_with_index = collision_check(env, agent_idx);


### PR DESCRIPTION
## Description

The renderer doesn't run due to an issue in the lane alignment checking function. 

Don't exactly understand how to fix, so I'm temporarily commenting this out so that we can render.

### How to reproduce

run commands to produce gifs (also in readme):

```
bash scripts/build_ocean.sh drive local
```
then

```
xvfb-run -s "-screen 0 1280x720x24" ./drive
```