### PR TITLE
replace deprecated dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -318,7 +318,7 @@ if not NO_TRAIN:
     install_requires += [
         "torch",
         "psutil",
-        "pynvml",
+        "nvidia-ml-py",
         "rich",
         "rich_argparse",
         "imageio",


### PR DESCRIPTION
Replaces `pynvml` (deprecated) with `nvidia-ml-py` in `setup.py`