### PR TITLE
distance weighted score implementation

### DIFF
--- a/pufferlib/ocean/drive/binding.c
+++ b/pufferlib/ocean/drive/binding.c
@@ -207,6 +207,8 @@ static int my_log(PyObject* dict, Log* log) {
     assign_to_dict(dict, "completion_rate", log->completion_rate);
     assign_to_dict(dict, "lane_alignment_rate", log->lane_alignment_rate);
     assign_to_dict(dict, "score", log->score);
+    assign_to_dict(dict, "distance_weighted_score", log->distance_weighted_score);
+    assign_to_dict(dict, "total_goal_distance", log->total_goal_distance);
     // assign_to_dict(dict, "active_agent_count", log->active_agent_count);
     // assign_to_dict(dict, "expert_static_car_count", log->expert_static_car_count);
     // assign_to_dict(dict, "static_car_count", log->static_car_count);

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -107,6 +107,8 @@ struct Log {
     float episode_return;
     float episode_length;
     float score;
+    float distance_weighted_score;
+    float total_goal_distance;
     float offroad_rate;
     float collision_rate;
     float num_goals_reached;
@@ -375,8 +377,12 @@ void add_log(Drive* env) {
         env->log.avg_collisions_per_agent += avg_collisions_per_agent;
         int num_goals_reached = env->logs[i].num_goals_reached;
         env->log.num_goals_reached += num_goals_reached;
+        float goal_distance = ego_goal_distance_t0(e);
+        env->log.total_goal_distance += goal_distance;
         if(e->reached_goal_this_episode && !e->collided_before_goal){
             env->log.score += 1.0f;
+            float goal_distance = ego_goal_distance_t0(e);
+            env->log.distance_weighted_score += 1.0f * goal_distance;
         }
         if(!offroad && !collided && !e->reached_goal_this_episode){
             env->log.dnf_rate += 1.0f;


### PR DESCRIPTION
Implemented the distance_weighted_score and total_goal_distance metric.

For each agent:
total_goal_distance = 2d_distance(initial_pos, goal_pos) 
distance_weighted_score = total_goal_distance * score

The metrics collected are then averaged across agents as per current metric path. Example run: https://wandb.ai/emerge_/dc_pufferdrive/runs/5yyvzp3m?nw=nwuserrsavorgnanrs 

The below image shows the "normalised distance of solved goals" (blue line), computed as:
distance_weighted_score / (score * total_goal_distance)

We're still investigating this metric, but an initial observation is that at convergence the solved goals have the same distance on average as the total population of goals, indicating that the unsolved goals might be "unsolved at random" with respect to the goal distance.

<img width="1186" height="786" alt="Screenshot 2025-10-30 at 11 43 31" src="https://github.com/user-attachments/assets/f8205312-7769-4852-8d84-49d6bf2c48cd" />
