### PR TITLE
Fix a harmless typo in torch.py

### DIFF
--- a/pufferlib/ocean/torch.py
+++ b/pufferlib/ocean/torch.py
@@ -72,7 +72,7 @@ class Drive(nn.Module):
     def encode_observations(self, observations, state=None):
         ego_dim = self.ego_dim
         partner_dim = self.max_partner_objects * self.partner_features
-        road_dim = self.max_road_objects * self.road_features_after_onehot
+        road_dim = self.max_road_objects * self.road_features
         ego_obs = observations[:, :ego_dim]
         partner_obs = observations[:, ego_dim : ego_dim + partner_dim]
         road_obs = observations[:, ego_dim + partner_dim : ego_dim + partner_dim + road_dim]


### PR DESCRIPTION
The road features aren't one-hot encoded inside the observation, so this number:
`road_dim = self.max_road_objects * self.road_features_after_onehot`

Is bigger than the actual road_dim in the observation. This error is harmless because when we do:
`road_obs = observations[:, ego_dim + partner_dim : ego_dim + partner_dim + road_dim]`

We take the end of the observation array, so even if ego_dim+partner_dim+road_dim is bigger than the actual shape of the array we still take all elements until the end.

But we should still fix it.