### PR TITLE
Check for any .bin files in map directory instead of requiring map_000.bin

### DIFF
--- a/docs/src/data.md
+++ b/docs/src/data.md
@@ -55,7 +55,7 @@ Refer to [Simulator](simulator.md) for how the binaries are consumed during rese
 ## Verifying data availability
 
 - After conversion, `ls resources/drive/binaries | head` should show numbered `.bin` files.
-- If you see `Required directory resources/drive/binaries/map_000.bin not found` during training, rerun the conversion or check paths.
+- If you see `No .bin map files found in <map_dir>` during training, rerun the conversion or check paths.
 - With binaries in place, run `puffer train puffer_drive` from [Getting Started](getting-started.md) as a smoke test that the build, data, and bindings are wired together.
 - To inspect the binary output, convert a single JSON file with `load_map(<json>, <id>, <output_path>)` inside `drive.py`.
 

--- a/pufferlib/ocean/drive/drive.py
+++ b/pufferlib/ocean/drive/drive.py
@@ -129,15 +129,19 @@ class Drive(pufferlib.PufferEnv):
 
         self._action_type_flag = 0 if action_type == "discrete" else 1
 
-        # Check if resources directory exists
-        binary_path = f"{map_dir}/map_000.bin"
-        if not os.path.exists(binary_path):
+        # Check if map directory contains any bin files
+        if not os.path.isdir(map_dir):
             raise FileNotFoundError(
-                f"Required directory {binary_path} not found. Please ensure the Drive maps are downloaded and installed correctly per docs."
+                f"Map directory {map_dir} not found. Please ensure the Drive maps are downloaded and installed correctly per docs."
+            )
+        bin_files = [name for name in os.listdir(map_dir) if name.endswith(".bin")]
+        if not bin_files:
+            raise FileNotFoundError(
+                f"No .bin map files found in {map_dir}. Please ensure the Drive maps are downloaded and installed correctly per docs."
             )
 
         # Check maps availability
-        available_maps = len([name for name in os.listdir(map_dir) if name.endswith(".bin")])
+        available_maps = len(bin_files)
         if num_maps > available_maps:
             if allow_map_resampling:
                 print("\n" + "=" * 80)


### PR DESCRIPTION
## Summary
- Changed map validation to check for any `.bin` files in the directory rather than requiring a specific `map_000.bin` file
- Added separate error for missing directory vs empty directory
- Updated docs to reflect new error message

Generated heavily with Claude Code