### PR TITLE
Integration with RLlib (v3.0)

### DIFF
--- a/pufferlib/ocean/drive/binding.c
+++ b/pufferlib/ocean/drive/binding.c
@@ -187,8 +187,26 @@ static int my_init(Env *env, PyObject *args, PyObject *kwargs) {
     env->human_agent_idx = unpack(kwargs, "human_agent_idx");
     env->ini_file = unpack_str(kwargs, "ini_file");
     env_init_config conf = {0};
+
+    // Check if INI file exists before parsing
+    FILE *ini_check = fopen(env->ini_file, "r");
+    if (ini_check == NULL) {
+        char error_msg[1024];
+        snprintf(error_msg, sizeof(error_msg),
+            "INI config file not found: '%s'. "
+            "Please ensure the file exists at this path.",
+            env->ini_file);
+        PyErr_SetString(PyExc_FileNotFoundError, error_msg);
+        return -1;
+    }
+    fclose(ini_check);
+
     if (ini_parse(env->ini_file, handler, &conf) < 0) {
-        printf("Error while loading %s", env->ini_file);
+        char error_msg[1024];
+        snprintf(error_msg, sizeof(error_msg),
+            "Failed to parse INI config file: '%s'", env->ini_file);
+        PyErr_SetString(PyExc_ValueError, error_msg);
+        return -1;
     }
     if (kwargs && PyDict_GetItemString(kwargs, "episode_length")) {
         conf.episode_length = (int)unpack(kwargs, "episode_length");

--- a/pufferlib/ocean/drive/binding.c
+++ b/pufferlib/ocean/drive/binding.c
@@ -193,9 +193,9 @@ static int my_init(Env *env, PyObject *args, PyObject *kwargs) {
     if (ini_check == NULL) {
         char error_msg[1024];
         snprintf(error_msg, sizeof(error_msg),
-            "INI config file not found: '%s'. "
-            "Please ensure the file exists at this path.",
-            env->ini_file);
+                 "INI config file not found: '%s'. "
+                 "Please ensure the file exists at this path.",
+                 env->ini_file);
         PyErr_SetString(PyExc_FileNotFoundError, error_msg);
         return -1;
     }
@@ -203,8 +203,7 @@ static int my_init(Env *env, PyObject *args, PyObject *kwargs) {
 
     if (ini_parse(env->ini_file, handler, &conf) < 0) {
         char error_msg[1024];
-        snprintf(error_msg, sizeof(error_msg),
-            "Failed to parse INI config file: '%s'", env->ini_file);
+        snprintf(error_msg, sizeof(error_msg), "Failed to parse INI config file: '%s'", env->ini_file);
         PyErr_SetString(PyExc_ValueError, error_msg);
         return -1;
     }

--- a/pufferlib/ocean/drive/drive.py
+++ b/pufferlib/ocean/drive/drive.py
@@ -11,6 +11,7 @@ from tqdm import tqdm
 _PACKAGE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 _INI_FILE = os.path.join(_PACKAGE_DIR, "config", "ocean", "drive.ini")
 
+
 class Drive(pufferlib.PufferEnv):
     def __init__(
         self,

--- a/pufferlib/ocean/drive/drive.py
+++ b/pufferlib/ocean/drive/drive.py
@@ -8,6 +8,8 @@ from pufferlib.ocean.drive import binding
 from multiprocessing import Pool, cpu_count
 from tqdm import tqdm
 
+_PACKAGE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+_INI_FILE = os.path.join(_PACKAGE_DIR, "config", "ocean", "drive.ini")
 
 class Drive(pufferlib.PufferEnv):
     def __init__(
@@ -83,7 +85,7 @@ class Drive(pufferlib.PufferEnv):
             + self.max_partner_objects * self.partner_features
             + self.max_road_objects * self.road_features
         )
-        self.single_observation_space = gymnasium.spaces.Box(low=-1, high=1, shape=(self.num_obs,), dtype=np.float32)
+        self.single_observation_space = gymnasium.spaces.Box(low=-1, high=2, shape=(self.num_obs,), dtype=np.float32)
 
         self.init_steps = init_steps
         self.init_mode_str = init_mode
@@ -209,7 +211,7 @@ class Drive(pufferlib.PufferEnv):
                 max_controlled_agents=self.max_controlled_agents,
                 map_path=self.map_files[map_ids[i]],
                 max_agents=nxt - cur,
-                ini_file="pufferlib/config/ocean/drive.ini",
+                ini_file=_INI_FILE,
                 init_steps=init_steps,
                 init_mode=self.init_mode,
                 control_mode=self.control_mode,
@@ -281,7 +283,7 @@ class Drive(pufferlib.PufferEnv):
                     max_controlled_agents=self.max_controlled_agents,
                     map_path=self.map_files[map_ids[i]],
                     max_agents=nxt - cur,
-                    ini_file="pufferlib/config/ocean/drive.ini",
+                    ini_file=_INI_FILE,
                     init_steps=self.init_steps,
                     init_mode=self.init_mode,
                     control_mode=self.control_mode,

--- a/setup.py
+++ b/setup.py
@@ -307,10 +307,10 @@ for key, value in cfg_vars.items():
 
 install_requires = [
     "setuptools",
-    "numpy<2.0",
+    "numpy",
     "shimmy[gym-v21]",
     "gym==0.23",
-    "gymnasium==0.29.1",
+    "gymnasium==1.2.2",
     "pettingzoo==1.24.1",
 ]
 


### PR DESCRIPTION
I've been integration PufferDrive with RLib and ran into these problems.
1. The INI file is relative, meaning that for projects where you pip install pufferdrive outside your current working directory, when loading PufferDrive this fails. I've added code within the bindings to help debug this for future users
2. RLlib uses Gymnasium 1.x where as puffer uses 0.x, I don't see a reason in the code and haven't run into any issues so far with changing the version number
3. The observation space I found did not contain all the observations which raised an error within PufferDrive about this

Also, I've made this PR for 3.0 rather than 2.0, is that correct? 