### PR TITLE
Fixes: Align WOSAC metric calculation with original 

### DIFF
--- a/docs/src/wosac.md
+++ b/docs/src/wosac.md
@@ -62,6 +62,7 @@ We provide baselines on a small curated dataset from the WOMD validation set wit
 
 *Table: WOSAC baselines in PufferDrive on 229 selected clean held-out validation scenarios.*
 
+- **Random agent:** Following the [WOSAC 2023 paper](https://arxiv.org/abs/2305.12032), the random agent samples future trajectories by independently sampling $(x, y,\theta)$ at each timestep from a Gaussian distribution in the AV coordinate frame $(\mu=1.0, \sigma=0.1)$, producing uncorrelated random motion over the horizon of 80 steps.
 
 > ✏️ Download the dataset from [Hugging Face](https://huggingface.co/datasets/daphne-cornelisse/pufferdrive_wosac_val_clean) to reproduce these results or benchmark your policy.
 

--- a/docs/src/wosac.md
+++ b/docs/src/wosac.md
@@ -55,31 +55,18 @@ We provide baselines on a small curated dataset from the WOMD validation set wit
 
 | Method | Realism meta-score | Kinematic metrics | Interactive metrics | Map-based metrics | minADE | ADE |
 |--------|-------------------|-------------------|---------------------|-------------------|--------|------|
-| Ground-truth (UB) | 0.832 | 0.606 | 0.846 | 0.961 | 0 | 0 |
-| π_Base self-play RL | 0.737 | 0.319 | 0.789 | 0.938 | 10.834 | 11.317 |
-| [SMART-tiny-CLSFT](https://arxiv.org/abs/2412.05334) | 0.805 | 0.534 | 0.830 | 0.949 | 1.124 | 3.123 |
-| π_Random | 0.485 | 0.214 | 0.657 | 0.408 | 6.477 | 18.286 |
+| Ground-truth (UB) | 0.8179 | 0.6070 | 0.9590 | 0.8722 | 0 | 0 |
+| $\pi_{\text{self-play RL}}$ | 0.6750 | 0.2798 | 0.7966 | 0.7811 | 10.8057 | 11.4108 |
+| [SMART-tiny-CLSFT](https://arxiv.org/abs/2412.05334) | 0.7818 | 0.5200 | 0.8914 | 0.8378 | 1.1236 | 3.1231 |
+| $\pi_{\text{random}}$ | 0.4459 | 0.0506 | 0.7843 | 0.4704 | 23.5936 | 25.0097 |
 
 *Table: WOSAC baselines in PufferDrive on 229 selected clean held-out validation scenarios.*
 
-- **Random agent:** Following the [WOSAC 2023 paper](https://arxiv.org/abs/2305.12032), the random agent samples future trajectories by independently sampling $(x, y,\theta)$ at each timestep from a Gaussian distribution in the AV coordinate frame $(\mu=1.0, \sigma=0.1)$, producing uncorrelated random motion over the horizon of 80 steps.
+- **Random agent ($\pi_{\text{random}}$):** Following the [WOSAC 2023 paper](https://arxiv.org/abs/2305.12032), the random agent samples future trajectories by independently sampling $(x, y,\theta)$ at each timestep from a Gaussian distribution in the AV coordinate frame $(\mu=1.0, \sigma=0.1)$, producing uncorrelated random motion over the horizon of 80 steps.
+- **Goal-conditioned self-play agent ($\pi_{\text{self-play RL}}$)**: An agent trained through self-play RL to reach the end point points ("goals") without colliding or going off-road. Baseline can be reproduced using the default settings in the `drive.ini` file with the Waymo dataset. We also open-source the weights of this policy, see `pufferlib/resources/drive/puffer_drive_weights` `.bin` and `.pt`.
+
 
 > ✏️ Download the dataset from [Hugging Face](https://huggingface.co/datasets/daphne-cornelisse/pufferdrive_wosac_val_clean) to reproduce these results or benchmark your policy.
-
-
-| Method | Realism meta-score | Kinematic metrics | Interactive metrics | Map-based metrics | minADE | ADE |
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-| Ground-truth (UB) | 0.833 | 0.574 | 0.864 | 0.958 | 0 | 0 |
-| π_Base self-play RL | 0.737 | 0.323 | 0.792 | 0.930 | 8.530 | 9.088 |
-| [SMART-tiny-CLSFT](https://arxiv.org/abs/2412.05334) | 0.795 | 0.504 | 0.832 | 0.932 | 1.182 | 2.857 |
-| π_Random | 0.497 | 0.238 | 0.656 | 0.430 | 6.395 | 18.617 |
-
-*Table: WOSAC baselines in PufferDrive on validation 10k dataset.*
-
-
-> ✏️ Download the dataset from [Hugging Face](https://huggingface.co/datasets/daphne-cornelisse/pufferdrive_womd_val) to reproduce these results or benchmark your policy.
-
-
 
 ## Evaluating trajectories
 

--- a/docs/src/wosac.md
+++ b/docs/src/wosac.md
@@ -56,14 +56,14 @@ We provide baselines on a small curated dataset from the WOMD validation set wit
 | Method | Realism meta-score | Kinematic metrics | Interactive metrics | Map-based metrics | minADE | ADE |
 |--------|-------------------|-------------------|---------------------|-------------------|--------|------|
 | Ground-truth (UB) | 0.8179 | 0.6070 | 0.9590 | 0.8722 | 0 | 0 |
-| $\pi_{\text{self-play RL}}$ | 0.6750 | 0.2798 | 0.7966 | 0.7811 | 10.8057 | 11.4108 |
+| Self-play RL agent | 0.6750 | 0.2798 | 0.7966 | 0.7811 | 10.8057 | 11.4108 |
 | [SMART-tiny-CLSFT](https://arxiv.org/abs/2412.05334) | 0.7818 | 0.5200 | 0.8914 | 0.8378 | 1.1236 | 3.1231 |
-| $\pi_{\text{random}}$ | 0.4459 | 0.0506 | 0.7843 | 0.4704 | 23.5936 | 25.0097 |
+| Random | 0.4459 | 0.0506 | 0.7843 | 0.4704 | 23.5936 | 25.0097 |
 
 *Table: WOSAC baselines in PufferDrive on 229 selected clean held-out validation scenarios.*
 
-- **Random agent ($\pi_{\text{random}}$):** Following the [WOSAC 2023 paper](https://arxiv.org/abs/2305.12032), the random agent samples future trajectories by independently sampling $(x, y,\theta)$ at each timestep from a Gaussian distribution in the AV coordinate frame $(\mu=1.0, \sigma=0.1)$, producing uncorrelated random motion over the horizon of 80 steps.
-- **Goal-conditioned self-play agent ($\pi_{\text{self-play RL}}$)**: An agent trained through self-play RL to reach the end point points ("goals") without colliding or going off-road. Baseline can be reproduced using the default settings in the `drive.ini` file with the Waymo dataset. We also open-source the weights of this policy, see `pufferlib/resources/drive/puffer_drive_weights` `.bin` and `.pt`.
+- **Random agent:** Following the [WOSAC 2023 paper](https://arxiv.org/abs/2305.12032), the random agent samples future trajectories by independently sampling (x, y, θ) at each timestep from a Gaussian distribution in the AV coordinate frame `(mu=1.0, sigma=0.1)`, producing uncorrelated random motion over the horizon of 80 steps.
+- **Goal-conditioned self-play RL agent**: An agent trained through self-play RL to reach the end point points ("goals") without colliding or going off-road. Baseline can be reproduced using the default settings in the `drive.ini` file with the Waymo dataset. We also open-source the weights of this policy, see `pufferlib/resources/drive/puffer_drive_weights` `.bin` and `.pt`.
 
 
 > ✏️ Download the dataset from [Hugging Face](https://huggingface.co/datasets/daphne-cornelisse/pufferdrive_wosac_val_clean) to reproduce these results or benchmark your policy.

--- a/pufferlib/ocean/benchmark/evaluate_imported_trajectories.py
+++ b/pufferlib/ocean/benchmark/evaluate_imported_trajectories.py
@@ -73,7 +73,7 @@ def evaluate_trajectories(simulated_trajectory_file, args):
     env_name = "puffer_drive"
     args["env"]["map_dir"] = args["eval"]["map_dir"]
     args["env"]["num_maps"] = args["eval"]["num_maps"]
-    args["env"]["use_all_maps"] = True
+    args["env"]["sequential_map_sampling"] = True
     dataset_name = args["env"]["map_dir"].split("/")[-1]
 
     print(f"Running WOSAC realism evaluation with {dataset_name} dataset. \n")

--- a/pufferlib/ocean/benchmark/evaluate_imported_trajectories.py
+++ b/pufferlib/ocean/benchmark/evaluate_imported_trajectories.py
@@ -72,7 +72,7 @@ def evaluate_trajectories(simulated_trajectory_file, args):
     """
     env_name = "puffer_drive"
     args["env"]["map_dir"] = args["eval"]["map_dir"]
-    args["env"]["num_maps"] = args["eval"]["num_maps"]
+    args["env"]["num_maps"] = args["eval"]["wosac_num_maps"]
     args["env"]["sequential_map_sampling"] = True
     dataset_name = args["env"]["map_dir"].split("/")[-1]
 

--- a/pufferlib/ocean/benchmark/evaluator.py
+++ b/pufferlib/ocean/benchmark/evaluator.py
@@ -48,7 +48,8 @@ class WOSACEvaluator:
             weight = self.metrics_config.getfloat(field_name, "metametric_weight")
             metric_score = metrics[likelihood_field_name]
             metametric += weight * metric_score
-        return metametric
+        weight_sum = sum(self.metrics_config.getfloat(fn, "metametric_weight") for fn in _METRIC_FIELD_NAMES)
+        return metametric / weight_sum
 
     def _get_histogram_params(self, metric_name: str):
         return (

--- a/pufferlib/ocean/benchmark/evaluator.py
+++ b/pufferlib/ocean/benchmark/evaluator.py
@@ -48,9 +48,7 @@ class WOSACEvaluator:
             weight = self.metrics_config.getfloat(field_name, "metametric_weight")
             metric_score = metrics[likelihood_field_name]
             metametric += weight * metric_score
-
-        weight_sum = sum(self.metrics_config.getfloat(fn, "metametric_weight") for fn in _METRIC_FIELD_NAMES)
-        return metametric / weight_sum
+        return metametric
 
     def _get_histogram_params(self, metric_name: str):
         return (

--- a/pufferlib/ocean/benchmark/evaluator.py
+++ b/pufferlib/ocean/benchmark/evaluator.py
@@ -121,6 +121,53 @@ class WOSACEvaluator:
 
         return trajectories
 
+    def collect_wosac_random_baseline(self, puffer_env):
+        """
+        Random Baseline from Wosac 2023 paper
+        """
+        driver = puffer_env.driver_env
+        num_agents = puffer_env.observation_space.shape[0]
+
+        trajectories = {
+            "x": np.zeros((num_agents, self.num_rollouts, self.sim_steps), dtype=np.float32),
+            "y": np.zeros((num_agents, self.num_rollouts, self.sim_steps), dtype=np.float32),
+            "heading": np.zeros((num_agents, self.num_rollouts, self.sim_steps), dtype=np.float32),
+            "id": np.zeros((num_agents, self.num_rollouts, self.sim_steps), dtype=np.int32),
+        }
+
+        for rollout_idx in range(self.num_rollouts):
+            obs, info = puffer_env.reset()
+
+            # Do Initialization
+            agent_state = driver.get_global_agent_state()
+            trajectories["x"][:, rollout_idx, 0] = agent_state["x"]
+            trajectories["y"][:, rollout_idx, 0] = agent_state["y"]
+            trajectories["heading"][:, rollout_idx, 0] = agent_state["heading"]
+            trajectories["id"][:, rollout_idx, 0] = agent_state["id"]
+
+            # Update using Gaussian:
+            samples = np.random.normal(loc=1, scale=0.1, size=(num_agents, self.sim_steps, 3))
+            for time_idx in range(1, self.sim_steps):
+                dx, dy, d_heading = samples[:, time_idx, 0], samples[:, time_idx, 1], samples[:, time_idx, 2]
+                x, y, heading = (
+                    trajectories["x"][:, rollout_idx, time_idx - 1],
+                    trajectories["y"][:, rollout_idx, time_idx - 1],
+                    trajectories["heading"][:, rollout_idx, time_idx - 1],
+                )
+
+                cos_h = np.cos(heading)
+                sin_h = np.sin(heading)
+
+                x += dx * cos_h - dy * sin_h
+                y += dx * sin_h + dy * cos_h
+                heading += d_heading
+
+                trajectories["x"][:, rollout_idx, time_idx] = x
+                trajectories["y"][:, rollout_idx, time_idx] = y
+                trajectories["heading"][:, rollout_idx, time_idx] = heading
+
+        return trajectories
+
     def compute_metrics(
         self,
         ground_truth_trajectories: Dict,
@@ -337,60 +384,46 @@ class WOSACEvaluator:
             sanity_check=False,
         )
 
-        speed_likelihood = np.exp(
-            metrics._reduce_average_with_validity(
-                linear_speed_log_likelihood,
-                speed_validity[:, 0, :],
-                axis=1,
-            )
+        speed_log_likelihood = metrics._reduce_average_with_validity(
+            linear_speed_log_likelihood,
+            speed_validity[:, 0, :],
+            axis=1,
         )
 
-        accel_likelihood = np.exp(
-            metrics._reduce_average_with_validity(
-                linear_accel_log_likelihood,
-                acceleration_validity[:, 0, :],
-                axis=1,
-            )
+        accel_log_likelihood = metrics._reduce_average_with_validity(
+            linear_accel_log_likelihood,
+            acceleration_validity[:, 0, :],
+            axis=1,
         )
 
-        angular_speed_likelihood = np.exp(
-            metrics._reduce_average_with_validity(
-                angular_speed_log_likelihood,
-                speed_validity[:, 0, :],
-                axis=1,
-            )
+        angular_speed_log_likelihood = metrics._reduce_average_with_validity(
+            angular_speed_log_likelihood,
+            speed_validity[:, 0, :],
+            axis=1,
         )
 
-        angular_accel_likelihood = np.exp(
-            metrics._reduce_average_with_validity(
-                angular_accel_log_likelihood,
-                acceleration_validity[:, 0, :],
-                axis=1,
-            )
+        angular_accel_log_likelihood = metrics._reduce_average_with_validity(
+            angular_accel_log_likelihood,
+            acceleration_validity[:, 0, :],
+            axis=1,
         )
 
-        distance_to_nearest_object_likelihood = np.exp(
-            metrics._reduce_average_with_validity(
-                distance_to_nearest_object_log_likelihood,
-                eval_ref_valid[:, 0, :],
-                axis=1,
-            )
+        distance_to_nearest_object_log_likelihood = metrics._reduce_average_with_validity(
+            distance_to_nearest_object_log_likelihood,
+            eval_ref_valid[:, 0, :],
+            axis=1,
         )
 
-        time_to_collision_likelihood = np.exp(
-            metrics._reduce_average_with_validity(
-                time_to_collision_log_likelihood,
-                eval_ref_valid[:, 0, :],
-                axis=1,
-            )
+        time_to_collision_log_likelihood = metrics._reduce_average_with_validity(
+            time_to_collision_log_likelihood,
+            eval_ref_valid[:, 0, :],
+            axis=1,
         )
 
-        distance_to_road_edge_likelihood = np.exp(
-            metrics._reduce_average_with_validity(
-                distance_to_road_edge_log_likelihood,
-                eval_ref_valid[:, 0, :],
-                axis=1,
-            )
+        distance_to_road_edge_log_likelihood = metrics._reduce_average_with_validity(
+            distance_to_road_edge_log_likelihood,
+            eval_ref_valid[:, 0, :],
+            axis=1,
         )
 
         # Collision likelihood is computed by aggregating in time. For invalid objects
@@ -411,7 +444,6 @@ class WOSACEvaluator:
             num_bins=2,
             use_bernoulli=True,
         )
-        collision_likelihood = np.exp(collision_log_likelihood)
 
         # Offroad likelihood (same pattern as collision)
         sim_offroad_indication = np.any(np.where(eval_ref_valid, sim_offroad_per_step, False), axis=2)
@@ -428,7 +460,6 @@ class WOSACEvaluator:
             num_bins=2,
             use_bernoulli=True,
         )
-        offroad_likelihood = np.exp(offroad_log_likelihood)
 
         # Get agent IDs
         eval_agent_ids = ground_truth_trajectories["id"][eval_mask]
@@ -443,15 +474,15 @@ class WOSACEvaluator:
                 "num_offroad_ref": ref_num_offroad.flatten(),
                 "ade": ade,
                 "min_ade": min_ade,
-                "likelihood_linear_speed": speed_likelihood,
-                "likelihood_linear_acceleration": accel_likelihood,
-                "likelihood_angular_speed": angular_speed_likelihood,
-                "likelihood_angular_acceleration": angular_accel_likelihood,
-                "likelihood_distance_to_nearest_object": distance_to_nearest_object_likelihood,
-                "likelihood_time_to_collision": time_to_collision_likelihood,
-                "likelihood_collision_indication": collision_likelihood,
-                "likelihood_distance_to_road_edge": distance_to_road_edge_likelihood,
-                "likelihood_offroad_indication": offroad_likelihood,
+                "likelihood_linear_speed": speed_log_likelihood,
+                "likelihood_linear_acceleration": accel_log_likelihood,
+                "likelihood_angular_speed": angular_speed_log_likelihood,
+                "likelihood_angular_acceleration": angular_accel_log_likelihood,
+                "likelihood_distance_to_nearest_object": distance_to_nearest_object_log_likelihood,
+                "likelihood_time_to_collision": time_to_collision_log_likelihood,
+                "likelihood_collision_indication": collision_log_likelihood,
+                "likelihood_distance_to_road_edge": distance_to_road_edge_log_likelihood,
+                "likelihood_offroad_indication": offroad_log_likelihood,
             }
         )
 
@@ -474,6 +505,10 @@ class WOSACEvaluator:
                 "likelihood_offroad_indication",
             ]
         ].mean()
+
+        # Transform log-likelihoods to positive scores:
+        likelihood_cols = [c for c in scene_level_results.columns if "likelihood" in c]
+        scene_level_results[likelihood_cols] = np.exp(scene_level_results[likelihood_cols])
 
         scene_level_results["realism_meta_score"] = scene_level_results.apply(self._compute_metametric, axis=1)
         scene_level_results["num_agents"] = df.groupby("scenario_id").size()

--- a/pufferlib/ocean/benchmark/evaluator.py
+++ b/pufferlib/ocean/benchmark/evaluator.py
@@ -48,8 +48,7 @@ class WOSACEvaluator:
             weight = self.metrics_config.getfloat(field_name, "metametric_weight")
             metric_score = metrics[likelihood_field_name]
             metametric += weight * metric_score
-        weight_sum = sum(self.metrics_config.getfloat(fn, "metametric_weight") for fn in _METRIC_FIELD_NAMES)
-        return metametric / weight_sum
+        return metametric
 
     def _get_histogram_params(self, metric_name: str):
         return (

--- a/pufferlib/ocean/benchmark/evaluator.py
+++ b/pufferlib/ocean/benchmark/evaluator.py
@@ -205,6 +205,7 @@ class WOSACEvaluator:
         ref_valid = ground_truth_trajectories["valid"]
         agent_length = agent_state["length"]
         agent_width = agent_state["width"]
+        is_vehicle = ground_truth_trajectories["is_vehicle"]
         scenario_ids = ground_truth_trajectories["scenario_id"]
 
         # We evaluate the metrics only for the Tracks to Predict.
@@ -218,6 +219,7 @@ class WOSACEvaluator:
         eval_agent_length = agent_length[eval_mask]
         eval_agent_width = agent_width[eval_mask]
         eval_scenario_ids = scenario_ids[eval_mask]
+        eval_is_vehicle = is_vehicle[eval_mask]
 
         # Compute features
         # Kinematics-related features
@@ -413,9 +415,11 @@ class WOSACEvaluator:
             axis=1,
         )
 
+        # TTC is computed only for vehicles
+        ttc_valid = eval_ref_valid & eval_is_vehicle[..., None]
         time_to_collision_log_likelihood = metrics._reduce_average_with_validity(
             time_to_collision_log_likelihood,
-            eval_ref_valid[:, 0, :],
+            ttc_valid[:, 0, :],
             axis=1,
         )
 

--- a/pufferlib/ocean/benchmark/metrics_sanity_check.py
+++ b/pufferlib/ocean/benchmark/metrics_sanity_check.py
@@ -90,7 +90,7 @@ def main():
     config["eval"]["enabled"] = True
     config["eval"]["wosac_num_rollouts"] = 32
     config["env"]["map_dir"] = config["eval"]["map_dir"]
-    config["env"]["num_maps"] = config["eval"]["num_maps"]
+    config["env"]["num_maps"] = config["eval"]["wosac_num_maps"]
     config["env"]["sequential_map_sampling"] = True
 
     config["env"]["init_mode"] = config["eval"]["wosac_init_mode"]

--- a/pufferlib/ocean/benchmark/metrics_sanity_check.py
+++ b/pufferlib/ocean/benchmark/metrics_sanity_check.py
@@ -26,11 +26,11 @@ def replace_rollouts_with_gt(simulated_traj, gt_traj, num_replacements):
     return modified
 
 
-def run_validation_experiment(config, vecenv, policy):
+def run_validation_experiment(config, vecenv):
     evaluator = WOSACEvaluator(config)
 
     gt_trajectories = evaluator.collect_ground_truth_trajectories(vecenv)
-    simulated_trajectories = evaluator.collect_simulated_trajectories(config, vecenv, policy)
+    simulated_trajectories = evaluator.collect_wosac_random_baseline(vecenv)
     agent_state = vecenv.driver_env.get_global_agent_state()
     road_edge_polylines = vecenv.driver_env.get_road_edge_polylines()
 
@@ -93,16 +93,14 @@ def main():
     config["env"]["num_maps"] = config["eval"]["num_maps"]
     config["env"]["use_all_maps"] = True
 
-    config["env"]["num_agents"] = config["eval"]["wosac_num_agents"]
     config["env"]["init_mode"] = config["eval"]["wosac_init_mode"]
     config["env"]["control_mode"] = config["eval"]["wosac_control_mode"]
     config["env"]["init_steps"] = config["eval"]["wosac_init_steps"]
     config["env"]["goal_behavior"] = config["eval"]["wosac_goal_behavior"]
 
     vecenv = load_env(args.env, config)
-    policy = load_policy(config, vecenv, args.env)
 
-    results = run_validation_experiment(config, vecenv, policy)
+    results = run_validation_experiment(config, vecenv)
     print("\n" + format_results_table(results))
 
 

--- a/pufferlib/ocean/benchmark/metrics_sanity_check.py
+++ b/pufferlib/ocean/benchmark/metrics_sanity_check.py
@@ -91,7 +91,7 @@ def main():
     config["eval"]["wosac_num_rollouts"] = 32
     config["env"]["map_dir"] = config["eval"]["map_dir"]
     config["env"]["num_maps"] = config["eval"]["num_maps"]
-    config["env"]["use_all_maps"] = True
+    config["env"]["sequential_map_sampling"] = True
 
     config["env"]["init_mode"] = config["eval"]["wosac_init_mode"]
     config["env"]["control_mode"] = config["eval"]["wosac_control_mode"]

--- a/pufferlib/ocean/benchmark/visual_sanity_check.py
+++ b/pufferlib/ocean/benchmark/visual_sanity_check.py
@@ -104,7 +104,7 @@ def main():
     config["env"]["goal_behavior"] = config["eval"]["wosac_goal_behavior"]
 
     config["env"]["map_dir"] = config["eval"]["map_dir"]
-    config["env"]["num_maps"] = config["eval"]["num_maps"]
+    config["env"]["num_maps"] = config["eval"]["wosac_num_maps"]
     config["env"]["sequential_map_sampling"] = True
 
     vecenv = load_env(args.env, config)

--- a/pufferlib/ocean/benchmark/visual_sanity_check.py
+++ b/pufferlib/ocean/benchmark/visual_sanity_check.py
@@ -105,7 +105,7 @@ def main():
 
     config["env"]["map_dir"] = config["eval"]["map_dir"]
     config["env"]["num_maps"] = config["eval"]["num_maps"]
-    config["env"]["use_all_maps"] = True
+    config["env"]["sequential_map_sampling"] = True
 
     vecenv = load_env(args.env, config)
     policy = load_policy(config, vecenv, args.env)

--- a/pufferlib/ocean/benchmark/wosac.ini
+++ b/pufferlib/ocean/benchmark/wosac.ini
@@ -1,5 +1,6 @@
-# Taken from WOSAC 2025 Sim Agents Challenge configuration
-# Link: https://github.com/waymo-research/waymo-open-dataset/blob/master/src/waymo_open_dataset/wdl_limited/sim_agents_metrics/challenge_2025_sim_agents_config.textproto
+# Taken from WOSAC 2024 Sim Agents Challenge configuration
+# Note: 2024 challenge does not include traffic_light_violation metric (weight = 0.0)
+# Traffic light violation was added in 2025 challenge with weight 0.05
 
 [linear_speed]
 histogram.min_val = 0.0
@@ -51,7 +52,7 @@ histogram.max_val = 40
 histogram.num_bins = 10
 histogram.additive_smoothing_pseudocount = 0.1
 independent_timesteps = true
-metametric_weight = 0.05
+metametric_weight = 0.1
 
 [offroad_indication]
 bernoulli = true
@@ -67,4 +68,4 @@ metametric_weight = 0.1
 
 [traffic_light_violation]
 bernoulli = true
-metametric_weight = 0.05
+metametric_weight = 0.0

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -1692,11 +1692,12 @@ void c_get_global_agent_state(Drive *env, float *x_out, float *y_out, float *z_o
 }
 
 void c_get_global_ground_truth_trajectories(Drive *env, float *x_out, float *y_out, float *z_out, float *heading_out,
-                                            int *valid_out, int *id_out, int *scenario_id_out) {
+                                            int *valid_out, int *id_out, int *is_vehicle_out, int *scenario_id_out) {
     for (int i = 0; i < env->active_agent_count; i++) {
         int agent_idx = env->active_agent_indices[i];
         Entity *agent = &env->entities[agent_idx];
         id_out[i] = get_track_id_or_placeholder(env, agent_idx);
+        is_vehicle_out[i] = agent->type == VEHICLE;
         scenario_id_out[i] = agent->scenario_id;
 
         for (int t = env->init_steps; t < agent->array_size; t++) {

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -1210,10 +1210,6 @@ bool should_control_agent(Drive *env, int agent_idx) {
 
     Entity *entity = &env->entities[agent_idx];
 
-    // TODO: Move this elsewhere or remove
-    entity->width *= 0.7f;
-    entity->length *= 0.7f;
-
     if (env->control_mode == CONTROL_SDC_ONLY) {
         return agent_idx == env->sdc_track_index;
     }

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -1258,7 +1258,7 @@ bool should_control_agent(Drive *env, int agent_idx) {
 void set_active_agents(Drive *env) {
 
     // Initialize
-    env->active_agent_count = 0;        // Policy-controlled agents
+    env->active_agent_count = 1;        // Policy-controlled agents
     env->static_agent_count = 0;        // Non-moving background agents
     env->expert_static_agent_count = 0; // Expert replay agents (non-controlled)
     env->num_actors = 1;                // Total agents created (there is always the SDC)
@@ -1272,11 +1272,12 @@ void set_active_agents(Drive *env) {
     }
 
     // Create and initialize the SDC first to ensure we always have at least
-    // one controllable agent. Take the SDC index (WOMD files) or the last
-    // entity (CARLA files don't have a designated SDC).
-    int sdc_index = env->sdc_track_index;
+    // one controllable agent.
+    int sdc_index = env->sdc_track_index; // For WOMD, we have the exact index
+    if (sdc_index == -1) {                // For other data sources, take the last entity
+        sdc_index = env->num_objects - 1;
+    }
     active_agent_indices[0] = sdc_index;
-    env->active_agent_count++;
     env->entities[sdc_index].active_agent = 1;
 
     // Iterate through entities to find agents to create and/or control

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -72,7 +72,7 @@
 
 // Maximum number of agents per scene
 #ifndef MAX_AGENTS
-#define MAX_AGENTS 64
+#define MAX_AGENTS 32
 #endif
 #define STOP_AGENT 1
 #define REMOVE_AGENT 2

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -72,7 +72,7 @@
 
 // Maximum number of agents per scene
 #ifndef MAX_AGENTS
-#define MAX_AGENTS 32
+#define MAX_AGENTS 64
 #endif
 #define STOP_AGENT 1
 #define REMOVE_AGENT 2
@@ -1272,7 +1272,8 @@ void set_active_agents(Drive *env) {
     }
 
     // Create and initialize the SDC first to ensure we always have at least
-    // one controllable agent.
+    // one controllable agent. Take the SDC index (WOMD files) or the last
+    // entity (CARLA files don't have a designated SDC).
     int sdc_index = env->sdc_track_index;
     active_agent_indices[0] = sdc_index;
     env->active_agent_count++;

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -1258,10 +1258,10 @@ bool should_control_agent(Drive *env, int agent_idx) {
 void set_active_agents(Drive *env) {
 
     // Initialize
-    env->active_agent_count = 1;        // Policy-controlled agents
+    env->active_agent_count = 0;        // Policy-controlled agents
     env->static_agent_count = 0;        // Non-moving background agents
     env->expert_static_agent_count = 0; // Expert replay agents (non-controlled)
-    env->num_actors = 1;                // Total agents created (there is always the SDC)
+    env->num_actors = 0;                // Total agents created (there is always the SDC)
 
     int active_agent_indices[MAX_AGENTS];
     int static_agent_indices[MAX_AGENTS];
@@ -1271,14 +1271,15 @@ void set_active_agents(Drive *env) {
         env->num_agents = MAX_AGENTS;
     }
 
-    // Create and initialize the SDC first to ensure we always have at least
-    // one controllable agent.
-    int sdc_index = env->sdc_track_index; // For WOMD, we have the exact index
-    if (sdc_index == -1) {                // For other data sources, take the last entity
-        sdc_index = env->num_objects - 1;
+    // If we have a SDC index (WOMD), initialize it first:
+    int sdc_index = env->sdc_track_index;
+
+    if (sdc_index >= 0) {
+        active_agent_indices[0] = sdc_index;
+        env->num_actors++;
+        env->active_agent_count++;
+        env->entities[sdc_index].active_agent = 1;
     }
-    active_agent_indices[0] = sdc_index;
-    env->entities[sdc_index].active_agent = 1;
 
     // Iterate through entities to find agents to create and/or control
     for (int i = 0; i < env->num_objects && env->num_actors < MAX_AGENTS; i++) {

--- a/pufferlib/ocean/drive/drive.py
+++ b/pufferlib/ocean/drive/drive.py
@@ -42,7 +42,7 @@ class Drive(pufferlib.PufferEnv):
         init_mode="create_all_valid",
         control_mode="control_vehicles",
         map_dir="resources/drive/binaries/training",
-        use_all_maps=False,
+        sequential_map_sampling=False,
     ):
         # env
         self.dt = dt
@@ -154,11 +154,11 @@ class Drive(pufferlib.PufferEnv):
             max_controlled_agents=self.max_controlled_agents,
             goal_behavior=self.goal_behavior,
             goal_target_distance=self.goal_target_distance,
-            use_all_maps=use_all_maps,
+            sequential_map_sampling=sequential_map_sampling,
         )
 
-        # agent_offsets[-1] works in both cases, just making it explicit that num_agents is ignored if use_all_maps
-        self.num_agents = num_agents if not use_all_maps else agent_offsets[-1]
+        # agent_offsets[-1] works in both cases, just making it explicit that num_agents is ignored if sequential_map_sampling is True
+        self.num_agents = num_agents if not sequential_map_sampling else agent_offsets[-1]
         self.agent_offsets = agent_offsets
         self.map_ids = map_ids
         self.num_envs = num_envs
@@ -232,7 +232,7 @@ class Drive(pufferlib.PufferEnv):
                 goal_target_distance=self.goal_target_distance,
                 goal_speed=self.goal_speed,
                 map_dir=self.map_dir,
-                use_all_maps=False,
+                sequential_map_sampling=False,  # Always use random sampling with replacement
             )
             self.agent_offsets = agent_offsets
             self.map_ids = map_ids

--- a/pufferlib/ocean/drive/drive.py
+++ b/pufferlib/ocean/drive/drive.py
@@ -326,6 +326,7 @@ class Drive(pufferlib.PufferEnv):
             "heading": np.zeros((num_agents, self.episode_length - self.init_steps), dtype=np.float32),
             "valid": np.zeros((num_agents, self.episode_length - self.init_steps), dtype=np.int32),
             "id": np.zeros(num_agents, dtype=np.int32),
+            "is_vehicle": np.zeros(num_agents, dtype=np.int32),
             "scenario_id": np.zeros(num_agents, dtype=np.int32),
         }
 
@@ -337,6 +338,7 @@ class Drive(pufferlib.PufferEnv):
             trajectories["heading"],
             trajectories["valid"],
             trajectories["id"],
+            trajectories["is_vehicle"],
             trajectories["scenario_id"],
         )
 

--- a/pufferlib/ocean/env_binding.h
+++ b/pufferlib/ocean/env_binding.h
@@ -727,8 +727,8 @@ static PyObject *vec_get_global_agent_state(PyObject *self, PyObject *args) {
 }
 
 static PyObject *get_ground_truth_trajectories(PyObject *self, PyObject *args) {
-    if (PyTuple_Size(args) != 7) {
-        PyErr_SetString(PyExc_TypeError, "get_ground_truth_trajectories requires 7 arguments");
+    if (PyTuple_Size(args) != 8) {
+        PyErr_SetString(PyExc_TypeError, "get_ground_truth_trajectories requires 8 arguments");
         return NULL;
     }
 
@@ -746,10 +746,12 @@ static PyObject *get_ground_truth_trajectories(PyObject *self, PyObject *args) {
     PyObject *heading_arr = PyTuple_GetItem(args, 4);
     PyObject *valid_arr = PyTuple_GetItem(args, 5);
     PyObject *id_arr = PyTuple_GetItem(args, 6);
-    PyObject *scenario_id_arr = PyTuple_GetItem(args, 7);
+    PyObject *is_vehicle_arr = PyTuple_GetItem(args, 7);
+    PyObject *scenario_id_arr = PyTuple_GetItem(args, 8);
 
     if (!PyArray_Check(x_arr) || !PyArray_Check(y_arr) || !PyArray_Check(z_arr) || !PyArray_Check(heading_arr) ||
-        !PyArray_Check(valid_arr) || !PyArray_Check(id_arr) || !PyArray_Check(scenario_id_arr)) {
+        !PyArray_Check(valid_arr) || !PyArray_Check(id_arr) || !PyArray_Check(is_vehicle_arr) ||
+        !PyArray_Check(scenario_id_arr)) {
         PyErr_SetString(PyExc_TypeError, "All output arrays must be NumPy arrays");
         return NULL;
     }
@@ -760,17 +762,18 @@ static PyObject *get_ground_truth_trajectories(PyObject *self, PyObject *args) {
     float *heading_data = (float *)PyArray_DATA((PyArrayObject *)heading_arr);
     int *valid_data = (int *)PyArray_DATA((PyArrayObject *)valid_arr);
     int *id_data = (int *)PyArray_DATA((PyArrayObject *)id_arr);
+    int *is_vehicle_data = (int *)PyArray_DATA((PyArrayObject *)is_vehicle_arr);
     int *scenario_id_data = (int *)PyArray_DATA((PyArrayObject *)scenario_id_arr);
 
     c_get_global_ground_truth_trajectories(drive, x_data, y_data, z_data, heading_data, valid_data, id_data,
-                                           scenario_id_data);
+                                           is_vehicle_data, scenario_id_data);
 
     Py_RETURN_NONE;
 }
 
 static PyObject *vec_get_global_ground_truth_trajectories(PyObject *self, PyObject *args) {
-    if (PyTuple_Size(args) != 8) {
-        PyErr_SetString(PyExc_TypeError, "vec_get_global_ground_truth_trajectories requires 8 arguments");
+    if (PyTuple_Size(args) != 9) {
+        PyErr_SetString(PyExc_TypeError, "vec_get_global_ground_truth_trajectories requires 9 arguments");
         return NULL;
     }
 
@@ -786,10 +789,12 @@ static PyObject *vec_get_global_ground_truth_trajectories(PyObject *self, PyObje
     PyObject *heading_arr = PyTuple_GetItem(args, 4);
     PyObject *valid_arr = PyTuple_GetItem(args, 5);
     PyObject *id_arr = PyTuple_GetItem(args, 6);
-    PyObject *scenario_id_arr = PyTuple_GetItem(args, 7);
+    PyObject *is_vehicle_arr = PyTuple_GetItem(args, 7);
+    PyObject *scenario_id_arr = PyTuple_GetItem(args, 8);
 
     if (!PyArray_Check(x_arr) || !PyArray_Check(y_arr) || !PyArray_Check(z_arr) || !PyArray_Check(heading_arr) ||
-        !PyArray_Check(valid_arr) || !PyArray_Check(id_arr) || !PyArray_Check(scenario_id_arr)) {
+        !PyArray_Check(valid_arr) || !PyArray_Check(id_arr) || !PyArray_Check(is_vehicle_arr) ||
+        !PyArray_Check(scenario_id_arr)) {
         PyErr_SetString(PyExc_TypeError, "All output arrays must be NumPy arrays");
         return NULL;
     }
@@ -800,6 +805,7 @@ static PyObject *vec_get_global_ground_truth_trajectories(PyObject *self, PyObje
     PyArrayObject *heading_array = (PyArrayObject *)heading_arr;
     PyArrayObject *valid_array = (PyArrayObject *)valid_arr;
     PyArrayObject *id_array = (PyArrayObject *)id_arr;
+    PyArrayObject *is_vehicle_array = (PyArrayObject *)is_vehicle_arr;
     PyArrayObject *scenario_id_array = (PyArrayObject *)scenario_id_arr;
 
     // Get base pointers to the arrays
@@ -809,6 +815,7 @@ static PyObject *vec_get_global_ground_truth_trajectories(PyObject *self, PyObje
     float *heading_base = (float *)PyArray_DATA(heading_array);
     int *valid_base = (int *)PyArray_DATA(valid_array);
     int *id_base = (int *)PyArray_DATA(id_array);
+    int *is_vehicle_base = (int *)PyArray_DATA(is_vehicle_array);
     int *scenario_id_base = (int *)PyArray_DATA(scenario_id_array);
 
     // Get number of timesteps from array shape
@@ -824,7 +831,8 @@ static PyObject *vec_get_global_ground_truth_trajectories(PyObject *self, PyObje
 
         c_get_global_ground_truth_trajectories(drive, &x_base[traj_offset], &y_base[traj_offset], &z_base[traj_offset],
                                                &heading_base[traj_offset], &valid_base[traj_offset],
-                                               &id_base[agent_offset], &scenario_id_base[agent_offset]);
+                                               &id_base[agent_offset], &is_vehicle_base[agent_offset],
+                                               &scenario_id_base[agent_offset]);
 
         // Move offsets forward
         agent_offset += drive->active_agent_count;

--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -1041,7 +1041,7 @@ def eval(env_name, args=None, vecenv=None, policy=None):
     human_replay_enabled = args["eval"]["human_replay_eval"]
     args["env"]["map_dir"] = args["eval"]["map_dir"]
     args["env"]["num_maps"] = args["eval"]["wosac_num_maps"]
-    args["env"]["use_all_maps"] = True
+    args["env"]["sequential_map_sampling"] = True
     dataset_name = args["env"]["map_dir"].split("/")[-1]
 
     if wosac_enabled:


### PR DESCRIPTION
## Description

We observed a discrepancy between the WOSAC meta-scores from the original implementation and those produced by PufferDrive. This PR resolves the majority of these discrepancies by addressing the bugs below.

## Updates

- Random agent baseline is now the same as the random agent in WOSAC (Gaussian independent noise, description added in docs).
- Three main fixes that lead to a more representative score.
- Evaluations are rerun, and the baseline tables are updated.

## Updated baseline table and scores

The baseline scores are now more representative:

<img width="1105" height="528" alt="Screenshot 2026-01-16 at 20 07 16" src="https://github.com/user-attachments/assets/90c17459-71f1-4906-8aa4-2a65f4142395" />

The goal-conditioned self-play RL policy has a meta-score of ~ 0.67, which is close to the score reported in [an earlier paper using a similar approach in GPUDrive](https://arxiv.org/pdf/2502.14706) (score is 0.629, Table 2). The SMART meta-score is almost exactly the same as its score on the real WOSAC leaderboard. We should note that the current scores may still be slightly optimistic as compared to the original. It is not implausible that this optimism comes from the known differences written down below.

## Summary of known differences and status

---

> 🟢: Resolved in this PR; 🔴: Outstanding.

---

- 🟢 `[status=fixed]` Order of operations: We were averaging log-likelihood metrics before exponentiating; WOSAC exponentiates first and then averages.
- 🟢  `[status=fixed]`  PufferDrive computes the ttc for _all agents_ whereas the [original only computes ttc for vehicles](https://github.com/waymo-research/waymo-open-dataset/blob/99a4cb3ff07e2fe06c2ce73da001f850f628e45a/src/waymo_open_dataset/wdl_limited/sim_agents_metrics/metrics.py#L179-L183)
- 🟢  `[status=fixed]*` PufferDrive used to multiply the final meta-score by the total weight (0.95) to compensate for the missing traffic light violation metric. What we do now instead is use the weights from the WOSAC 2024 challenge that did not have a traffic light metric.
- 🔴  `[status=diff]` PufferDrive does not include the traffic light violation as part of the WOSAC meta-score.
- 🔴  `[status=diff]` Original implementation uses the z-axis. PufferDrive omits the z-axis from metric computation since the z-axis is currently not supported.

