### PR TITLE
Add a Flag to build_ocean so Raylib can work on Debian 11

### DIFF
--- a/scripts/build_ocean.sh
+++ b/scripts/build_ocean.sh
@@ -101,6 +101,7 @@ FLAGS=(
     $LINK_ARCHIVES
     -lm
     -lpthread
+    -ldl
     $ERROR_LIMIT_FLAG
     -DPLATFORM_DESKTOP
 )


### PR DESCRIPTION
I found out that you can't build the visualizer on Debian if you don't specify this flag.

This is also mentionned in Raylib's doc:

<img width="951" height="389" alt="image" src="https://github.com/user-attachments/assets/7d7ccdfa-6dc7-47b6-93b1-7a989ebe58dd" />
