### PR TITLE
Separate bptt_horizon logic from rollout_horizon

### DIFF
--- a/pufferlib/config/default.ini
+++ b/pufferlib/config/default.ini
@@ -49,7 +49,7 @@ minibatch_size = 8192
 
 # Accumulate gradients above this size
 max_minibatch_size = 32768
-bptt_horizon = 64
+rollout_horizon = 64
 compile = False
 compile_mode = max-autotune-no-cudagraphs
 compile_fullgraph = True
@@ -81,7 +81,7 @@ downsample = 10
 ; mean = 1e8
 ; scale = time
 
-; [sweep.train.bptt_horizon]
+; [sweep.train.rollout_horizon]
 ; distribution = uniform_pow2
 ; min = 16
 ; max = 64

--- a/pufferlib/config/ocean/drive.ini
+++ b/pufferlib/config/ocean/drive.ini
@@ -62,10 +62,12 @@ total_timesteps = 2_000_000_000
 ; gamma = 0.985
 anneal_lr = True
 anneal_entropy = False
-; Needs to be: num_agents * num_workers * BPTT horizon
+; Needs to be: num_agents * num_workers * rollout_horizon
 batch_size = 524288
 minibatch_size = 32768
 max_minibatch_size = 32768
+rollout_horizon = 32
+; Memory of the LSTM
 bptt_horizon = 32
 adam_beta1 = 0.9
 adam_beta2 = 0.999

--- a/pufferlib/config/ocean/drive.ini
+++ b/pufferlib/config/ocean/drive.ini
@@ -69,7 +69,7 @@ anneal_entropy = False
 batch_size = 524288
 minibatch_size = 32768
 max_minibatch_size = 32768
-; Rollout horizon is equal to the bptt_horizon at the moment.
+; bptt_horizon equals rollout_horizon at the moment.
 ; If you want to turn off recurrence, set rnn_name = None in [base]
 rollout_horizon = 32
 adam_beta1 = 0.9

--- a/pufferlib/config/ocean/drive.ini
+++ b/pufferlib/config/ocean/drive.ini
@@ -2,6 +2,9 @@
 package = ocean
 env_name = puffer_drive
 policy_name = Drive
+; Set to None to disable recurrence. In case this the policy will only see
+; the current observation (o_t). Set to "Recurrent" to provide the policy with
+; memory through an LSTM.
 rnn_name = Recurrent
 
 [vec]
@@ -66,9 +69,9 @@ anneal_entropy = False
 batch_size = 524288
 minibatch_size = 32768
 max_minibatch_size = 32768
+; Rollout horizon is equal to the bptt_horizon at the moment.
+; If you want to turn off recurrence, set rnn_name = None in [base]
 rollout_horizon = 32
-; Memory of the LSTM
-bptt_horizon = 32
 adam_beta1 = 0.9
 adam_beta2 = 0.999
 adam_eps = 1e-8

--- a/pufferlib/ocean/torch.py
+++ b/pufferlib/ocean/torch.py
@@ -69,6 +69,11 @@ class Drive(nn.Module):
     def forward_train(self, x, state=None):
         return self.forward(x, state)
 
+    def forward_eval(self, observations, state=None):
+        hidden = self.encode_observations(observations, state=state)
+        logits, values = self.decode_actions(hidden)
+        return logits, values
+
     def encode_observations(self, observations, state=None):
         ego_dim = self.ego_dim
         partner_dim = self.max_partner_objects * self.partner_features

--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -91,6 +91,7 @@ class PuffeRL:
         batch_size = config["batch_size"]
         rollout_horizon = config["rollout_horizon"]
         bptt_horizon = config["rollout_horizon"]  # LSTM backprop horizon
+        config["bptt_horizon"] = bptt_horizon
         segments = batch_size // rollout_horizon  # Use rollout_horizon
 
         # Number of independent rollout sequences stored in the experience buffer

--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -76,28 +76,33 @@ class PuffeRL:
         vecenv.async_reset(seed)
         obs_space = vecenv.single_observation_space
         atn_space = vecenv.single_action_space
+        # The number of concurrent agents running in the vectorized environments
         total_agents = vecenv.num_agents
         self.total_agents = total_agents
 
         # Experience
-        if config["batch_size"] == "auto" and config["bptt_horizon"] == "auto":
-            raise pufferlib.APIUsageError("Must specify batch_size or bptt_horizon")
+        if config["batch_size"] == "auto" and config["rollout_horizon"] == "auto":
+            raise pufferlib.APIUsageError("Must specify batch_size or rollout_horizon")
         elif config["batch_size"] == "auto":
-            config["batch_size"] = total_agents * config["bptt_horizon"]
-        elif config["bptt_horizon"] == "auto":
-            config["bptt_horizon"] = config["batch_size"] // total_agents
+            config["batch_size"] = total_agents * config["rollout_horizon"]
+        elif config["rollout_horizon"] == "auto":
+            config["rollout_horizon"] = config["batch_size"] // total_agents
 
         batch_size = config["batch_size"]
-        horizon = config["bptt_horizon"]
-        segments = batch_size // horizon
+        rollout_horizon = config["rollout_horizon"]
+        bptt_horizon = config["bptt_horizon"]  # LSTM backprop horizon
+        segments = batch_size // rollout_horizon  # Use rollout_horizon
+
+        # Number of independent rollout sequences stored in the experience buffer
         self.segments = segments
+
         if total_agents > segments:
             raise pufferlib.APIUsageError(f"Total agents {total_agents} <= segments {segments}")
 
         device = config["device"]
         self.observations = torch.zeros(
             segments,
-            horizon,
+            rollout_horizon,
             *obs_space.shape,
             dtype=pufferlib.pytorch.numpy_to_torch_dtype_dict[obs_space.dtype],
             pin_memory=device == "cuda" and config["cpu_offload"],
@@ -105,18 +110,18 @@ class PuffeRL:
         )
         self.actions = torch.zeros(
             segments,
-            horizon,
+            rollout_horizon,
             *atn_space.shape,
             device=device,
             dtype=pufferlib.pytorch.numpy_to_torch_dtype_dict[atn_space.dtype],
         )
-        self.values = torch.zeros(segments, horizon, device=device)
-        self.logprobs = torch.zeros(segments, horizon, device=device)
-        self.rewards = torch.zeros(segments, horizon, device=device)
-        self.terminals = torch.zeros(segments, horizon, device=device)
-        self.truncations = torch.zeros(segments, horizon, device=device)
-        self.ratio = torch.ones(segments, horizon, device=device)
-        self.importance = torch.ones(segments, horizon, device=device)
+        self.values = torch.zeros(segments, rollout_horizon, device=device)
+        self.logprobs = torch.zeros(segments, rollout_horizon, device=device)
+        self.rewards = torch.zeros(segments, rollout_horizon, device=device)
+        self.terminals = torch.zeros(segments, rollout_horizon, device=device)
+        self.truncations = torch.zeros(segments, rollout_horizon, device=device)
+        self.ratio = torch.ones(segments, rollout_horizon, device=device)
+        self.importance = torch.ones(segments, rollout_horizon, device=device)
         self.ep_lengths = torch.zeros(total_agents, device=device, dtype=torch.int32)
         self.ep_indices = torch.arange(total_agents, device=device, dtype=torch.int32)
         self.free_idx = total_agents
@@ -147,10 +152,10 @@ class PuffeRL:
 
         self.accumulate_minibatches = max(1, minibatch_size // max_minibatch_size)
         self.total_minibatches = int(config["update_epochs"] * batch_size / self.minibatch_size)
-        self.minibatch_segments = self.minibatch_size // horizon
-        if self.minibatch_segments * horizon != self.minibatch_size:
+        self.minibatch_segments = self.minibatch_size // rollout_horizon
+        if self.minibatch_segments * rollout_horizon != self.minibatch_size:
             raise pufferlib.APIUsageError(
-                f"minibatch_size {self.minibatch_size} must be divisible by bptt_horizon {horizon}"
+                f"minibatch_size {self.minibatch_size} must be divisible by bptt_horizon {rollout_horizon}"
             )
 
         # Torch compile

--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -90,7 +90,7 @@ class PuffeRL:
 
         batch_size = config["batch_size"]
         rollout_horizon = config["rollout_horizon"]
-        bptt_horizon = config["bptt_horizon"]  # LSTM backprop horizon
+        bptt_horizon = config["rollout_horizon"]  # LSTM backprop horizon
         segments = batch_size // rollout_horizon  # Use rollout_horizon
 
         # Number of independent rollout sequences stored in the experience buffer

--- a/tests/test_drive_config.py
+++ b/tests/test_drive_config.py
@@ -79,7 +79,7 @@ class TestDriveConfig(unittest.TestCase):
         if ASSERTION_LEVEL >= 3:
             self.assertEqual(args["train"]["total_timesteps"], 3_000_000_000)
             self.assertEqual(args["train"]["batch_size"], "auto")
-            self.assertEqual(args["train"]["bptt_horizon"], 91)
+            self.assertEqual(args["train"]["rollout_horizon"], 91)
             self.assertEqual(args["train"]["minibatch_size"], 11648)
             self.assertEqual(args["train"]["learning_rate"], 0.001)
             self.assertEqual(args["train"]["gamma"], 0.98)

--- a/tests/test_drive_train.py
+++ b/tests/test_drive_train.py
@@ -27,7 +27,7 @@ def test_drive_training():
                 "compile": False,
                 "total_timesteps": 100000,
                 "batch_size": 128,
-                "bptt_horizon": 8,
+                "rollout_horizon": 8,
                 "minibatch_size": 128,
                 "max_minibatch_size": 128,
                 "update_epochs": 1,


### PR DESCRIPTION
## Description

**Context**: The `bptt_horizon` in puffer is a bit confusingly named. It serves two purposes:
1. It is the backpropagation through time horizon for RNN training
2. It is the rollout collection horizon for determining when agent episodes are considered "full" during advantage computation

To clarify its usage, I renamed `bptt_horizon` to `rollout_horizon`. Currently, they are the same. A future PR should support having a different `bptt_horizon` and `rollout_horizon`. This is not done in the current PR since it will require some restructuring of the training/rollout code.

For now, if you want to train a policy without memory, set `rnn_name=None` in the .ini file. Comments are provided.

### Effect of not using memory on score

A couple of runs show that you can still obtain reasonable performance without memory. The colored lines are runs without memory. Looks like decent performance can be achieved.

<img width="666" height="198" alt="Screenshot 2026-02-13 at 08 58 21" src="https://github.com/user-attachments/assets/cb3c51c0-42d5-4164-b155-a0f99d1d4c6a" />


