### PR TITLE
Add self-play/human-replay eval and allow CLI args to override ini

### DIFF
--- a/pufferlib/config/ocean/drive.ini
+++ b/pufferlib/config/ocean/drive.ini
@@ -143,7 +143,7 @@ human_replay_eval = False
 ; Control only the self-driving car
 human_replay_control_mode = "control_sdc_only"
 ; Number of scenarios for human replay evaluation equals the number of agents
-human_replay_num_agents = 16
+human_replay_num_agents = 256
 
 [sweep.train.learning_rate]
 distribution = log_normal

--- a/pufferlib/ocean/benchmark/evaluator.py
+++ b/pufferlib/ocean/benchmark/evaluator.py
@@ -762,37 +762,48 @@ class WOSACEvaluator:
 
 
 class HumanReplayEvaluator:
-    """Evaluates policies against human replays in PufferDrive."""
+    """Evaluates policies against human replays in PufferDrive.
 
-    def __init__(self, config: Dict):
+    Evaluate policy in two settings:
+    1. Self-play: All agents controlled by policy
+    2. Human replay: Only SDC controlled by policy, others replay human logs.
+
+    The delta between these modes provides an indication of how compatible
+    the policy is with human behavior.
+    """
+
+    def __init__(self, config: Dict, sp_env, hr_env):
         self.config = config
-        self.sim_steps = 91 - self.config["env"]["init_steps"]
+        self.sim_steps = 90
+        self.sp_env = sp_env
+        self.hr_env = hr_env
+        self.human_replay_stats = {}
+        self.self_play_stats = {}
 
-    def rollout(self, args, puffer_env, policy):
-        """Roll out policy in env with human replays. Store statistics.
-
-        In human replay mode, only the SDC (self-driving car) is controlled by the policy
-        while all other agents replay their human trajectories. This tests how compatible
-        the policy is with (static) human partners.
+    def rollout(self, args, policy, mode="self_play"):
+        """Roll out policy and collect episode statistics.
 
         Args:
-            args: Config dict with train settings (device, use_rnn, etc.)
-            puffer_env: PufferLib environment wrapper
-            policy: Trained policy to evaluate
+            args: Configuration dictionary
+            policy: Policy to evaluate
+            mode: Either "self_play" or "human_replay"
 
         Returns:
-            dict: Aggregated metrics including:
-                - avg_collisions_per_agent: Average collisions per agent
-                - avg_offroad_per_agent: Average offroad events per agent
+            Dictionary of aggregated statistics
         """
         import numpy as np
         import torch
         import pufferlib
 
-        num_agents = puffer_env.observation_space.shape[0]
+        env = self.sp_env if mode == "self_play" else self.hr_env
+
+        num_agents = env.observation_space.shape[0]
         device = args["train"]["device"]
 
-        obs, info = puffer_env.reset()
+        # Reset environment
+        obs, info = env.reset()
+
+        # Initialize RNN state if needed
         state = {}
         if args["train"]["use_rnn"]:
             state = dict(
@@ -800,19 +811,73 @@ class HumanReplayEvaluator:
                 lstm_c=torch.zeros(num_agents, policy.hidden_size, device=device),
             )
 
+        # Rollout
         for time_idx in range(self.sim_steps):
-            # Step policy
+            print(f"Time step: {time_idx}")
+            # Get action from policy
             with torch.no_grad():
                 ob_tensor = torch.as_tensor(obs).to(device)
                 logits, value = policy.forward_eval(ob_tensor, state)
                 action, logprob, _ = pufferlib.pytorch.sample_logits(logits)
-                action_np = action.cpu().numpy().reshape(puffer_env.action_space.shape)
+                action_np = action.cpu().numpy().reshape(env.action_space.shape)
 
+            # Clip continuous actions to valid range
             if isinstance(logits, torch.distributions.Normal):
-                action_np = np.clip(action_np, puffer_env.action_space.low, puffer_env.action_space.high)
+                action_np = np.clip(action_np, env.action_space.low, env.action_space.high)
 
-            obs, rewards, dones, truncs, info_list = puffer_env.step(action_np)
+            # Step environment
+            obs, rewards, dones, truncs, info_list = env.step(action_np)
 
-            if len(info_list) > 0:  # Happens at the end of episode
-                results = info_list[0]
-                return results
+            if truncs.all():
+                print(info_list)
+                break
+
+        # Aggregate final statistics
+        final_info = info_list[0] if info_list else {}
+
+        if mode == "human_replay":
+            self.human_replay_stats = final_info
+        else:
+            self.self_play_stats = final_info
+
+    def aggregate_stats(self):
+        """Aggregate statistics from both modes and compute deltas.
+
+        Returns:
+            Dictionary with self_play, human_replay, and delta statistics
+        """
+
+        if not self.self_play_stats or not self.human_replay_stats:
+            raise ValueError("Must run rollouts in both modes before aggregating stats")
+
+        # Extract metrics
+        sp = self.self_play_stats
+        hr = self.human_replay_stats
+
+        results = {
+            # Self-play metrics
+            "self_play": {
+                "collision_rate": sp["collision_rate"],
+                "offroad_rate": sp["offroad_rate"],
+                "completion_rate": sp["completion_rate"],
+                "score": sp["score"],
+                "num_agents": sp["n"],
+            },
+            # Human replay metrics
+            "human_replay": {
+                "collision_rate": hr["collision_rate"],
+                "offroad_rate": hr["offroad_rate"],
+                "completion_rate": hr["completion_rate"],
+                "score": hr["score"],
+                "num_agents": hr["n"],
+            },
+            # Delta metrics (self_play - human_replay)
+            "delta": {
+                "Δ_cr": sp["collision_rate"] - hr["collision_rate"],
+                "Δ_or": sp["offroad_rate"] - hr["offroad_rate"],
+                "Δ_comp": sp["completion_rate"] - hr["completion_rate"],
+                "Δ_score": sp["score"] - hr["score"],
+            },
+        }
+
+        return results

--- a/pufferlib/ocean/benchmark/evaluator.py
+++ b/pufferlib/ocean/benchmark/evaluator.py
@@ -813,7 +813,7 @@ class HumanReplayEvaluator:
 
         # Rollout
         for time_idx in range(self.sim_steps):
-            print(f"Time step: {time_idx}")
+            # print(f"Time step: {time_idx}")
             # Get action from policy
             with torch.no_grad():
                 ob_tensor = torch.as_tensor(obs).to(device)
@@ -829,7 +829,7 @@ class HumanReplayEvaluator:
             obs, rewards, dones, truncs, info_list = env.step(action_np)
 
             if truncs.all():
-                print(info_list)
+                # print(info_list)
                 break
 
         # Aggregate final statistics

--- a/pufferlib/ocean/drive/binding.c
+++ b/pufferlib/ocean/drive/binding.c
@@ -191,6 +191,37 @@ static int my_init(Env *env, PyObject *args, PyObject *kwargs) {
         PyErr_SetString(PyExc_ValueError, "episode_length must be > 0 (set in INI or kwargs)");
         return -1;
     }
+
+// Allow all settings to be overridden via kwargs (ini provides defaults)
+#define OVERRIDE_INT(field)                                                                                            \
+    if (kwargs && PyDict_GetItemString(kwargs, #field)) {                                                              \
+        conf.field = (int)unpack(kwargs, #field);                                                                      \
+    }
+#define OVERRIDE_FLOAT(field)                                                                                          \
+    if (kwargs && PyDict_GetItemString(kwargs, #field)) {                                                              \
+        conf.field = (float)unpack(kwargs, #field);                                                                    \
+    }
+
+    OVERRIDE_INT(action_type);
+    OVERRIDE_INT(dynamics_model);
+    OVERRIDE_FLOAT(reward_vehicle_collision);
+    OVERRIDE_FLOAT(reward_offroad_collision);
+    OVERRIDE_FLOAT(reward_goal);
+    OVERRIDE_FLOAT(reward_goal_post_respawn);
+    OVERRIDE_INT(collision_behavior);
+    OVERRIDE_INT(offroad_behavior);
+    OVERRIDE_FLOAT(dt);
+    OVERRIDE_INT(termination_mode);
+    OVERRIDE_INT(init_mode);
+    OVERRIDE_INT(control_mode);
+    OVERRIDE_INT(goal_behavior);
+    OVERRIDE_FLOAT(goal_target_distance);
+    OVERRIDE_FLOAT(goal_radius);
+    OVERRIDE_FLOAT(goal_speed);
+
+#undef OVERRIDE_INT
+#undef OVERRIDE_FLOAT
+
     env->action_type = conf.action_type;
     env->dynamics_model = conf.dynamics_model;
     env->reward_vehicle_collision = conf.reward_vehicle_collision;

--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -1126,6 +1126,7 @@ def eval(env_name, args=None, vecenv=None, policy=None):
         dataset_name = args["env"]["map_dir"].split("/")[-1]
         print(f"Running human replay evaluation with {dataset_name} dataset.\n")
         from pufferlib.ocean.benchmark.evaluator import HumanReplayEvaluator
+        import copy
 
         backend = args["eval"].get("backend", "PufferEnv")
         args["env"]["map_dir"] = args["eval"]["map_dir"]
@@ -1136,11 +1137,10 @@ def eval(env_name, args=None, vecenv=None, policy=None):
         args["env"]["num_maps"] = args["eval"]["human_replay_num_agents"]
 
         # Create two different envs
-        hr_args = args.copy()
+        hr_args = copy.deepcopy(args)
         hr_args["env"]["control_mode"] = "control_sdc_only"
         hr_env = load_env(env_name, hr_args)
-
-        sp_args = args.copy()
+        sp_args = copy.deepcopy(args)
         sp_args["env"]["control_mode"] = "control_vehicles"
         sp_env = load_env(env_name, sp_args)
 
@@ -1156,6 +1156,8 @@ def eval(env_name, args=None, vecenv=None, policy=None):
 
         # Get all stats including deltas
         all_stats = evaluator.aggregate_stats()
+        sp_env.close()
+        hr_env.close()
 
         # Log results
         import json

--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -1120,6 +1120,8 @@ def eval(env_name, args=None, vecenv=None, policy=None):
         return results_dict
 
     elif human_replay_enabled:
+        # Ensure the episode is only after a number of steps
+        args["env"]["termination_mode"] = 0
         args["env"]["map_dir"] = args["eval"]["map_dir"]
         dataset_name = args["env"]["map_dir"].split("/")[-1]
         print(f"Running human replay evaluation with {dataset_name} dataset.\n")
@@ -1130,26 +1132,39 @@ def eval(env_name, args=None, vecenv=None, policy=None):
         args["env"]["num_agents"] = args["eval"]["human_replay_num_agents"]
 
         args["vec"] = dict(backend=backend, num_envs=1)
-        args["env"]["control_mode"] = args["eval"]["human_replay_control_mode"]
         args["env"]["episode_length"] = 91  # WOMD scenario length
+        args["env"]["num_maps"] = args["eval"]["human_replay_num_agents"]
 
-        vecenv = vecenv or load_env(env_name, args)
-        policy = policy or load_policy(args, vecenv, env_name)
+        # Create two different envs
+        hr_args = args.copy()
+        hr_args["env"]["control_mode"] = "control_sdc_only"
+        hr_env = load_env(env_name, hr_args)
 
-        print(f"Effective number of scenarios used: {len(vecenv.driver_env.agent_offsets) - 1}")
+        sp_args = args.copy()
+        sp_args["env"]["control_mode"] = "control_vehicles"
+        sp_env = load_env(env_name, sp_args)
 
-        evaluator = HumanReplayEvaluator(args)
+        # Load policy
+        policy = policy or load_policy(args, sp_env, env_name)
 
-        # Run rollouts with human replays
-        results = evaluator.rollout(args, vecenv, policy)
+        # Create evaluator
+        evaluator = HumanReplayEvaluator(args, sp_env, hr_env)
 
+        # Run both rollouts
+        evaluator.rollout(args, policy, mode="self_play")
+        evaluator.rollout(args, policy, mode="human_replay")
+
+        # Get all stats including deltas
+        all_stats = evaluator.aggregate_stats()
+
+        # Log results
         import json
 
-        print("HUMAN_REPLAY_METRICS_START")
-        print(json.dumps(results))
+        print("\nHUMAN_REPLAY_METRICS_START")
+        print(json.dumps(all_stats, indent=2))
         print("HUMAN_REPLAY_METRICS_END")
+        return all_stats
 
-        return results
     else:  # Standard evaluation: Render
         backend = args["vec"]["backend"]
         if backend != "PufferEnv":


### PR DESCRIPTION
## Description

- Fixes a bug that made it impossible to override env .ini args from the CLI or Python
- Adds an eval to easily track performance on train or a test set on wandb


## Usage

- Prepare an eval dataset, link to it in `[eval]` -> `map_dir`
- Set `human_replay_eval` under `[eval]` to true
- Set the frequency

<img width="435" height="67" alt="Screenshot 2026-02-15 at 17 10 22" src="https://github.com/user-attachments/assets/829abde2-fafc-4227-8038-151c29279c16" />
