### PR TITLE
Github Logs in WANDB Notes Section

### DIFF
--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -1050,7 +1050,6 @@ class WandbLogger:
             git_notes = (
                 "Error fetching git info. Make sure you're running this in a git repository and have git installed."
             )
-            pass
 
         wandb.init(
             id=load_id or wandb.util.generate_id(),

--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -1038,6 +1038,20 @@ class WandbLogger:
     def __init__(self, args, load_id=None, resume="allow"):
         import wandb
 
+        try:
+            git_branch = subprocess.check_output(["git", "branch", "--show-current"], text=True).strip()
+            git_commit = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+            # Get the latest commit message (subject and body)
+            git_commit_message = subprocess.check_output(["git", "log", "-1", "--pretty=%B"], text=True).strip()
+
+            # Format notes for the overview section
+            git_notes = f"**Github Repo State**\n\n\n Branch Name: {git_branch} \n\nLatest Commit Id: {git_commit}\n\nLatest Commit Message: {git_commit_message}"
+        except:
+            git_notes = (
+                "Error fetching git info. Make sure you're running this in a git repository and have git installed."
+            )
+            pass
+
         wandb.init(
             id=load_id or wandb.util.generate_id(),
             project=args["wandb_project"],
@@ -1047,6 +1061,7 @@ class WandbLogger:
             resume=resume,
             config=args,
             name=args.get("wandb_name"),
+            notes=git_notes,
             tags=[args["tag"]] if args["tag"] is not None else [],
         )
         self.wandb = wandb

--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -1045,7 +1045,7 @@ class WandbLogger:
             git_commit_message = subprocess.check_output(["git", "log", "-1", "--pretty=%B"], text=True).strip()
 
             # Format notes for the overview section
-            git_notes = f"**Github Repo State**\n\n\n Branch Name: {git_branch} \n\nLatest Commit Id: {git_commit}\n\nLatest Commit Message: {git_commit_message}"
+            git_notes = f"**GitHub Repo State**\n\nBranch Name: {git_branch}\n\nLatest Commit Id: {git_commit}\n\nLatest Commit Message: {git_commit_message}"
         except:
             git_notes = (
                 "Error fetching git info. Make sure you're running this in a git repository and have git installed."


### PR DESCRIPTION
Added branch name, latest commit hash, latest commit message, for better tracking of wandb runs.
The details appear in the wandb notes section:
<img width="1600" height="490" alt="Screenshot 2026-02-23 at 2 38 45 PM" src="https://github.com/user-attachments/assets/34f67ee6-acdd-4d65-9037-837c27961b45" />
