### PR TITLE
Rename the final weight file for readability

### DIFF
--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -678,7 +678,16 @@ class PuffeRL:
 
         model_path = self.save_checkpoint()
         run_id = self.logger.run_id
-        path = os.path.join(self.config["data_dir"], f"{self.config['env']}_{run_id}.pt")
+        project_name = "puffer_drive"
+        group_name = ""
+
+        if hasattr(self.logger, "wandb"):
+            run = self.logger.wandb.run
+            project_name = run.project or project_name
+            group_name = run.group or ""
+
+        file_name = "_".join([name for name in [run_id, project_name, group_name] if name]) + ".pt"
+        path = os.path.join(self.config["data_dir"], file_name)
         shutil.copy(model_path, path)
         return path
 

--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -686,7 +686,7 @@ class PuffeRL:
             project_name = run.project or project_name
             group_name = run.group or ""
 
-        file_name = "_".join([name for name in [run_id, project_name, group_name] if name]) + ".pt"
+        file_name = "_".join([name for name in [project_name, group_name, run_id] if name]) + ".pt"
         path = os.path.join(self.config["data_dir"], file_name)
         shutil.copy(model_path, path)
         return path


### PR DESCRIPTION
Works only for WanDB, but won't crash if you are not using wandb.

The model weights will no be in experiments/{project_name}_{group_name}_{runid}.pt

If group name isnt set it is ignored.