### PR TITLE
Fix headless rendering Xvfb display bugs

### DIFF
--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -1,3 +1,4 @@
+#include <signal.h>
 #include <sys/types.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -2237,6 +2238,8 @@ struct Client {
     Vector3 default_camera_target;
     int recorder_pipefd[2];
     pid_t recorder_pid;
+    pid_t xvfb_pid;
+    int xvfb_display_num;
 };
 
 Client *make_client(Drive *env) {
@@ -2244,14 +2247,31 @@ Client *make_client(Drive *env) {
     Client *client = (Client *)calloc(1, sizeof(Client));
 
     if (env->render_mode == RENDER_HEADLESS && getenv("DISPLAY") == NULL) {
-        // Start Xvfb and set DISPLAY
-        pid_t xvfb_pid = fork();
-        if (xvfb_pid == 0) {
-            execlp("Xvfb", "Xvfb", ":99", "-screen", "0", "1x1x24", NULL);
+        // Hardcode to single display because we only run this in one process at once
+        client->xvfb_display_num = 99;
+
+        // Clean up stale lock if process is dead
+        FILE *f = fopen("/tmp/.X99-lock", "r");
+        if (f) {
+            pid_t pid = -1;
+            fscanf(f, "%d", &pid);
+            fclose(f);
+            if (pid > 0 && kill(pid, 0) != 0)
+                unlink("/tmp/.X99-lock");
+        }
+
+        client->xvfb_pid = fork();
+        if (client->xvfb_pid == 0) {
+            close(STDOUT_FILENO);
+            close(STDERR_FILENO);
+            execlp("Xvfb", "Xvfb", ":99", "-screen", "0", "1280x720x24", "+extension", "GLX", "-ac", "-noreset", NULL);
             _exit(1);
         }
+
         setenv("DISPLAY", ":99", 1);
-        usleep(500000); // Give Xvfb 500ms to start
+        for (int i = 0; i < 20 && access("/tmp/.X99-lock", F_OK) != 0; i++)
+            usleep(100000); // Give Xvfb 500ms to start
+        usleep(200000);
     }
 
     if (env->render_mode == RENDER_WINDOW) {
@@ -3140,9 +3160,17 @@ void close_client(Client *client) {
         close(client->recorder_pipefd[1]);
         waitpid(client->recorder_pid, NULL, 0);
     }
-    for (int i = 0; i < 6; i++) {
+    for (int i = 0; i < 6; i++)
         UnloadModel(client->cars[i]);
-    }
+    UnloadModel(client->cyclist);
+    UnloadModel(client->pedestrian);
     CloseWindow();
+    if (client->xvfb_pid > 0) {
+        kill(client->xvfb_pid, SIGTERM);
+        waitpid(client->xvfb_pid, NULL, 0);
+        unlink("/tmp/.X99-lock");
+        unsetenv("DISPLAY");
+    }
+
     free(client);
 }

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -2269,8 +2269,11 @@ Client *make_client(Drive *env) {
         }
 
         setenv("DISPLAY", ":99", 1);
+        // Xvfb starts asynchronously after fork(), so we poll until it creates its
+        // lock file (max 2s) then wait an extra 200ms for GLX to finish initializing.
+        // Without this, raylib's InitWindow() would try to connect before Xvfb is ready.
         for (int i = 0; i < 20 && access("/tmp/.X99-lock", F_OK) != 0; i++)
-            usleep(100000); // Give Xvfb 500ms to start
+            usleep(100000);
         usleep(200000);
     }
 


### PR DESCRIPTION
## Make headless rendering more robust

I just encountered two bugs after launching many subsequent runs with rendering enabled:

1. **Crash on startup**: Xvfb was being launched with a 1x1 pixel screen, which was too small for the graphics library to initialize. Fixed by changing the default to 1280x720.

2. **Crash on second run**: Xvfb was never shut down when rendering finished, leaving a stale lock file behind. The next run would then fail because display `:99` was still marked as "in use". Fixed by killing Xvfb and cleaning up its lock file when the client closes (inside `close_client()`).

**Testing**: Verified by launching many wandb runs with rendering enabled, all of which now complete successfully.