### PR TITLE
Extend evaluator with render mode control

### DIFF
--- a/pufferlib/config/ocean/drive.ini
+++ b/pufferlib/config/ocean/drive.ini
@@ -107,6 +107,8 @@ num_eval_agents = 64
 self_play_eval = True
 ; If True, enable human replay evaluation (pair policy-controlled agent with human replays)
 human_replay_eval = False
+; Which env to render during eval. Options: "first" (by index), "worst_collision", "random"
+render_select_mode = "first"
 ; If True, render random scenarios. Note: Doing this frequency will slow down the training.
 render_human_replay_eval = False
 render_self_play_eval = True

--- a/pufferlib/ocean/benchmark/evaluator.py
+++ b/pufferlib/ocean/benchmark/evaluator.py
@@ -762,6 +762,10 @@ class WOSACEvaluator:
 
             plt.savefig(f"trajectory_comparison_agent_{agent_idx}.png")
 
+RENDER_FIRST = "first"
+RENDER_WORST_SCORE = "worst_score"
+RENDER_WORST_COLLISION = "worst_collision"
+RENDER_RANDOM = "random"
 
 class Evaluator:
     """Evaluates policies in self_play or human_replay mode, with optional rendering.
@@ -796,15 +800,64 @@ class Evaluator:
         self.hr_eval_config["env"]["control_mode"] = "control_sdc_only"
         self.sp_eval_config = copy.deepcopy(eval_config)
         self.sp_eval_config["env"]["control_mode"] = "control_agents"
-
+        self.render_select_mode = self.configs["eval"]["render_select_mode"]
         self.render_sp_rollout = self.configs["eval"]["render_self_play_eval"]
         self.render_hr_rollout = self.configs["eval"]["render_human_replay_eval"]
 
-    def rollout(self, policy, mode="self_play", render_rollout=False):
-        """Roll out the given policy in the specified eval env and collect statistics."""
+    def select_render_env(self, env_logs):
+        """Select which environment to render based on per-env rollout statistics.
+        Args:
+            env_logs: List of dicts, one per environment. Each dict contains
+                aggregated agent statistics (score, collision_rate, offroad_rate, etc.)
+                with 'n' being the number of controlled agents in that env.
+                Empty dicts indicate no data was collected for that env.
 
+        Returns:
+            int: Index of the environment to render.
+        """
+        mode = self.render_select_mode
+        if mode == RENDER_FIRST:
+            return 0
+        if mode == RENDER_RANDOM:
+            return np.random.randint(len(env_logs))
+
+        populated = [(i, log) for i, log in enumerate(env_logs) if log]
+
+        if not populated:
+            return 0
+
+        if mode == RENDER_WORST_SCORE:
+            return min(populated, key=lambda x: x[1].get("score", 1.0))[0]
+        elif mode == RENDER_WORST_COLLISION:
+            return max(populated, key=lambda x: x[1].get("collision_rate", 0.0))[0]
+        # Add other modes based on desiderata here
+        return 0
+
+    def rollout(self, policy, mode="self_play"):
         env = self.hr_env if mode == "human_replay" else self.sp_env
         render_eval = self.render_sp_rollout if mode == "self_play" else self.render_hr_rollout
+        driver = env.driver_env
+
+        needs_stats_first = render_eval and self.render_select_mode not in (RENDER_FIRST, RENDER_RANDOM)
+
+        if needs_stats_first:
+            env_logs = self._run_rollout(policy, env, per_env_logs=True)
+            render_env_idx = self.select_render_env(env_logs)
+        else:
+            render_env_idx = self.select_render_env([{}] * driver.num_envs)
+
+        info_list = self._run_rollout(policy, env, render_env_idx if render_eval else None)
+
+        final_info = info_list[0] if info_list else {}
+        if mode == "self_play":
+            self.self_play_stats = final_info
+            self.self_play_stats["render_env_idx"] = render_env_idx
+        elif mode == "human_replay":
+            self.human_replay_stats = final_info
+            self.human_replay_stats["render_env_idx"] = render_env_idx
+
+    def _run_rollout(self, policy, env, render_env_idx=None, per_env_logs=False):
+        """Run a single rollout. If render_env_idx is not None, render that env."""
         driver = env.driver_env
         num_agents = env.observation_space.shape[0]
         device = self.configs["train"]["device"]
@@ -820,10 +873,10 @@ class Evaluator:
                 lstm_c=torch.zeros(num_agents, policy.hidden_size, device=device),
             )
 
-        # Rollout
+        info_list = []
         for time_idx in range(self.sim_steps):
-            if render_rollout or render_eval:
-                driver.render()
+            if render_env_idx is not None:
+                driver.render(env_id=render_env_idx)
 
             # Get action from policy
             with torch.no_grad():
@@ -837,18 +890,12 @@ class Evaluator:
                 action_np = np.clip(action_np, env.action_space.low, env.action_space.high)
 
             # Step environment
-            obs, rewards, dones, truncs, info_list = env.step(action_np)
+            obs, rewards, dones, truncs, info_list = env.step(action_np, per_env_logs=True)
 
             if truncs.all():
                 break
 
-        # Aggregate final statistics
-        final_info = info_list[0] if info_list else {}
-
-        if mode == "self_play":
-            self.self_play_stats = final_info
-        elif mode == "human_replay":
-            self.human_replay_stats = final_info
+        return info_list
 
     def log_videos(self, eval_mode, epoch):
         """Log all mp4s in local path to wandb after env close has flushed ffmpeg pipes."""

--- a/pufferlib/ocean/benchmark/evaluator.py
+++ b/pufferlib/ocean/benchmark/evaluator.py
@@ -762,10 +762,12 @@ class WOSACEvaluator:
 
             plt.savefig(f"trajectory_comparison_agent_{agent_idx}.png")
 
+
 RENDER_FIRST = "first"
 RENDER_WORST_SCORE = "worst_score"
 RENDER_WORST_COLLISION = "worst_collision"
 RENDER_RANDOM = "random"
+
 
 class Evaluator:
     """Evaluates policies in self_play or human_replay mode, with optional rendering.

--- a/pufferlib/ocean/benchmark/evaluator.py
+++ b/pufferlib/ocean/benchmark/evaluator.py
@@ -763,12 +763,6 @@ class WOSACEvaluator:
             plt.savefig(f"trajectory_comparison_agent_{agent_idx}.png")
 
 
-RENDER_FIRST = "first"
-RENDER_WORST_SCORE = "worst_score"
-RENDER_WORST_COLLISION = "worst_collision"
-RENDER_RANDOM = "random"
-
-
 class Evaluator:
     """Evaluates policies in self_play or human_replay mode, with optional rendering.
 
@@ -776,6 +770,11 @@ class Evaluator:
     - human_replay_eval: creates sp_env + hr_env
     - render_eval: creates sp_env (if not already created)
     """
+
+    RENDER_FIRST = "first"
+    RENDER_RANDOM = "random"
+    RENDER_WORST_SCORE = "worst_score"
+    RENDER_WORST_COLLISION = "worst_collision"
 
     def __init__(self, configs, logger=None):
         self.configs = configs
@@ -818,9 +817,9 @@ class Evaluator:
             int: Index of the environment to render.
         """
         mode = self.render_select_mode
-        if mode == RENDER_FIRST:
+        if mode == self.RENDER_FIRST:
             return 0
-        if mode == RENDER_RANDOM:
+        if mode == self.RENDER_RANDOM:
             return np.random.randint(len(env_logs))
 
         populated = [(i, log) for i, log in enumerate(env_logs) if log]
@@ -828,9 +827,9 @@ class Evaluator:
         if not populated:
             return 0
 
-        if mode == RENDER_WORST_SCORE:
+        if mode == self.RENDER_WORST_SCORE:
             return min(populated, key=lambda x: x[1].get("score", 1.0))[0]
-        elif mode == RENDER_WORST_COLLISION:
+        elif mode == self.RENDER_WORST_COLLISION:
             return max(populated, key=lambda x: x[1].get("collision_rate", 0.0))[0]
         # Add other modes based on desiderata here
         return 0
@@ -840,7 +839,7 @@ class Evaluator:
         render_eval = self.render_sp_rollout if mode == "self_play" else self.render_hr_rollout
         driver = env.driver_env
 
-        needs_stats_first = render_eval and self.render_select_mode not in (RENDER_FIRST, RENDER_RANDOM)
+        needs_stats_first = render_eval and self.render_select_mode not in (self.RENDER_FIRST, self.RENDER_RANDOM)
 
         if needs_stats_first:
             env_logs = self._run_rollout(policy, env, per_env_logs=True)
@@ -917,12 +916,13 @@ class Evaluator:
             print("Warning: no render videos found in local path")
             return
 
+        render_mode = self.render_select_mode
         for p in video_files:
             scenario_id = os.path.splitext(os.path.basename(p))[0]
-            self.logger.wandb.log(
-                {f"render/{eval_mode}": wandb.Video(p, format="mp4", caption=f"scene_{scenario_id}_epoch_{epoch}")}
-            )
+            caption = f"scene_{scenario_id}_epoch_{epoch}_select_{render_mode}"
+            self.logger.wandb.log({f"render/{eval_mode}": wandb.Video(p, format="mp4", caption=caption)})
 
+        # Clean up
         for p in video_files:
             os.remove(p)
 

--- a/pufferlib/ocean/benchmark/evaluator.py
+++ b/pufferlib/ocean/benchmark/evaluator.py
@@ -891,7 +891,7 @@ class Evaluator:
                 action_np = np.clip(action_np, env.action_space.low, env.action_space.high)
 
             # Step environment
-            obs, rewards, dones, truncs, info_list = env.step(action_np, per_env_logs=True)
+            obs, rewards, dones, truncs, info_list = env.step(action_np, per_env_logs=per_env_logs)
 
             if truncs.all():
                 break

--- a/pufferlib/ocean/drive/drive.py
+++ b/pufferlib/ocean/drive/drive.py
@@ -169,7 +169,7 @@ class Drive(pufferlib.PufferEnv):
         self.map_ids = map_ids
         self.num_envs = num_envs
         super().__init__(buf=buf)
-        env_ids = []
+        self.env_ids = []
         for i in range(num_envs):
             cur = agent_offsets[i]
             nxt = agent_offsets[i + 1]
@@ -205,9 +205,9 @@ class Drive(pufferlib.PufferEnv):
                 max_controlled_agents=self.max_controlled_agents,
                 render_mode=render_mode,
             )
-            env_ids.append(env_id)
+            self.env_ids.append(env_id)
 
-        self.c_envs = binding.vectorize(*env_ids)
+        self.c_envs = binding.vectorize(*self.env_ids)
 
     def reset(self, seed=0):
         binding.vec_reset(self.c_envs, seed)
@@ -234,7 +234,7 @@ class Drive(pufferlib.PufferEnv):
         self.agent_offsets = agent_offsets
         self.map_ids = map_ids
         self.num_envs = num_envs
-        env_ids = []
+        self.env_ids = []
         seed = np.random.randint(0, 2**32 - 1)
         for i in range(num_envs):
             cur = agent_offsets[i]
@@ -271,14 +271,14 @@ class Drive(pufferlib.PufferEnv):
                 max_controlled_agents=self.max_controlled_agents,
                 render_mode=self.render_mode,
             )
-            env_ids.append(env_id)
-        self.c_envs = binding.vectorize(*env_ids)
+            self.env_ids.append(env_id)
+        self.c_envs = binding.vectorize(*self.env_ids)
 
         binding.vec_reset(self.c_envs, seed)
         self.terminals[:] = 1
         self.truncations[:] = 1
 
-    def step(self, actions):
+    def step(self, actions, per_env_logs=False):
         self.terminals[:] = 0
         self.truncations[:] = 0
         self.actions[:] = actions
@@ -286,9 +286,14 @@ class Drive(pufferlib.PufferEnv):
         self.tick += 1
         info = []
         if self.tick % self.report_interval == 0:
-            log = binding.vec_log(self.c_envs, self.num_agents)
-            if log:
-                info.append(log)
+            if per_env_logs: # Get the stats for every separate env
+                logs = self.get_env_logs()
+                if any(logs):
+                    info = logs
+            else: # Default: Aggregate across vectorized envs
+                log = binding.vec_log(self.c_envs, self.num_agents)
+                if log:
+                    info.append(log)
 
         if self.tick > 0 and self.resample_frequency > 0 and self.tick % self.resample_frequency == 0:
             self.resample_maps()
@@ -400,6 +405,15 @@ class Drive(pufferlib.PufferEnv):
 
     def close(self):
         binding.vec_close(self.c_envs)
+
+    def env_log(self, env_idx):
+        """Get log statistics for a single environment."""
+        num_agents = self.agent_offsets[env_idx + 1] - self.agent_offsets[env_idx]
+        return binding.env_log(self.env_ids[env_idx], num_agents)
+
+    def get_env_logs(self):
+        """Get log statistics for all environments (unaggregated)."""
+        return [self.env_log(i) for i in range(self.num_envs)]
 
     @property
     def scenario_ids(self) -> list[str]:
@@ -703,7 +717,7 @@ def test_performance(timeout=10, atn_cache=1024, num_agents=1024):
 if __name__ == "__main__":
     # test_performance()
     # Process the train dataset
-    process_all_maps(data_folder="data/processed/training")
+    process_all_maps(data_folder="data/training")
     # Process the validation/test dataset
     # process_all_maps(data_folder="data/processed/validation")
     # # Process the validation_interactive dataset

--- a/pufferlib/ocean/drive/drive.py
+++ b/pufferlib/ocean/drive/drive.py
@@ -717,7 +717,7 @@ def test_performance(timeout=10, atn_cache=1024, num_agents=1024):
 if __name__ == "__main__":
     # test_performance()
     # Process the train dataset
-    process_all_maps(data_folder="data/training")
+    process_all_maps(data_folder="data/processed/training")
     # Process the validation/test dataset
     # process_all_maps(data_folder="data/processed/validation")
     # # Process the validation_interactive dataset

--- a/pufferlib/ocean/drive/drive.py
+++ b/pufferlib/ocean/drive/drive.py
@@ -286,11 +286,11 @@ class Drive(pufferlib.PufferEnv):
         self.tick += 1
         info = []
         if self.tick % self.report_interval == 0:
-            if per_env_logs: # Get the stats for every separate env
+            if per_env_logs:  # Get the stats for every separate env
                 logs = self.get_env_logs()
                 if any(logs):
                     info = logs
-            else: # Default: Aggregate across vectorized envs
+            else:  # Default: Aggregate across vectorized envs
                 log = binding.vec_log(self.c_envs, self.num_agents)
                 if log:
                     info.append(log)

--- a/pufferlib/ocean/env_binding.h
+++ b/pufferlib/ocean/env_binding.h
@@ -662,7 +662,7 @@ static PyObject *env_log(PyObject *self, PyObject *args) {
         ((float *)&aggregate)[j] += ((float *)&env->log)[j];
     }
 
-    PyObject* dict = PyDict_New();
+    PyObject *dict = PyDict_New();
     if (aggregate.n == 0.0f) {
         return dict;
     }
@@ -670,7 +670,7 @@ static PyObject *env_log(PyObject *self, PyObject *args) {
     // Average across agents in env
     float n = aggregate.n;
     for (int i = 0; i < num_keys; i++) {
-        ((float*)&aggregate)[i] /= n;
+        ((float *)&aggregate)[i] /= n;
     }
     aggregate.n = (float)env->active_agent_count;
 

--- a/pufferlib/ocean/env_binding.h
+++ b/pufferlib/ocean/env_binding.h
@@ -642,6 +642,43 @@ static PyObject *vec_log(PyObject *self, PyObject *args) {
     return dict;
 }
 
+static PyObject *env_log(PyObject *self, PyObject *args) {
+    int num_args = PyTuple_Size(args);
+    if (num_args != 2) {
+        PyErr_SetString(PyExc_TypeError, "env_log requires 2 arguments");
+        return NULL;
+    }
+
+    Env *env = unpack_env(args);
+    if (!env) {
+        return NULL;
+    }
+
+    // Aggregate this env's per-agent logs (same as vec_log but for one env)
+    // Note: breaks horribly if you don't use floats
+    Log aggregate = {0};
+    int num_keys = sizeof(Log) / sizeof(float);
+    for (int j = 0; j < num_keys; j++) {
+        ((float *)&aggregate)[j] += ((float *)&env->log)[j];
+    }
+
+    PyObject* dict = PyDict_New();
+    if (aggregate.n == 0.0f) {
+        return dict;
+    }
+
+    // Average across agents in env
+    float n = aggregate.n;
+    for (int i = 0; i < num_keys; i++) {
+        ((float*)&aggregate)[i] /= n;
+    }
+    aggregate.n = (float)env->active_agent_count;
+
+    my_log(dict, &aggregate);
+
+    return dict;
+}
+
 static PyObject *vec_close(PyObject *self, PyObject *args) {
     VecEnv *vec = unpack_vecenv(args);
     if (!vec) {
@@ -1009,6 +1046,7 @@ static PyMethodDef methods[] = {
     {"env_close", env_close, METH_VARARGS, "Close the environment"},
     {"env_get", env_get, METH_VARARGS, "Get the environment state"},
     {"env_put", (PyCFunction)env_put, METH_VARARGS | METH_KEYWORDS, "Put stuff into env"},
+    {"env_log", env_log, METH_VARARGS, "Log stats for a single environment"},
     {"vectorize", vectorize, METH_VARARGS, "Make a vector of environment handles"},
     {"vec_init", (PyCFunction)vec_init, METH_VARARGS | METH_KEYWORDS, "Initialize a vector of environments"},
     {"vec_reset", vec_reset, METH_VARARGS, "Reset the vector of environments"},

--- a/tests/test_drive_train.py
+++ b/tests/test_drive_train.py
@@ -80,6 +80,7 @@ def test_drive_training():
             "render_human_replay_eval": False,
             "num_eval_agents": 8,
             "map_dir": "resources/drive/binaries",
+            "render_select_mode": "fixed",
         }
 
         # Load components


### PR DESCRIPTION
## Problem

It can be useful to render based on a particular criterion. For example, instead of always displaying the first env, you may want to continually show the worst scenario in a batch of scenes. This was not possible because `vec_log()`, which is used to collect stats from the envs, aggregates across agents and envs, losing per-env granularity.

## Solution
- Added `env_log()` C binding that returns statistics per environment without aggregating across envs.
- Added configurable render selection modes (`first`, `random`, `worst_score`, `worst_collision`) via `render_select_mode` in the eval config.
- For worst-case modes, the `Evaluator` runs a stats-only rollout first, selects the target env using `env_log`, then renders that env in a second rollout.

## Pipeline 

### Before
Before, the eval pipeline looked like this:

<img width="487" height="320" alt="Screenshot 2026-03-09 at 10 35 31 AM" src="https://github.com/user-attachments/assets/ad68e39c-ff26-4117-b889-2caa574338d8" />

### After

Now, if the render mode is not fixed nor random, it looks like this: 

<img width="618" height="328" alt="Screenshot 2026-03-09 at 10 35 38 AM" src="https://github.com/user-attachments/assets/d1ebbb03-2ec3-415a-b800-3394aaa73111" />

### Logging example

<img width="606" height="338" alt="Screenshot 2026-03-09 at 4 30 37 PM" src="https://github.com/user-attachments/assets/65dc87cf-e0bf-4054-bf40-65f187fd9b1f" />
