### PR TITLE
Modify Reward Normalization

### DIFF
--- a/pufferlib/config/ocean/drive.ini
+++ b/pufferlib/config/ocean/drive.ini
@@ -71,7 +71,7 @@ spawn_length_max = 5.5
 spawn_height = 1.5
 
 turn_off_normalization = 1
-; Options: 0 - Use normalized reward coefs as input to NN, 0 - Dont
+; Options: 0 - Use normalized reward coefs as input to NN, 1 - Dont
 
 
 ; Reward settings

--- a/pufferlib/config/ocean/drive.ini
+++ b/pufferlib/config/ocean/drive.ini
@@ -70,6 +70,10 @@ spawn_length_min = 2.0
 spawn_length_max = 5.5
 spawn_height = 1.5
 
+turn_off_normalization = 1
+; Options: 0 - Use normalized reward coefs as input to NN, 0 - Dont
+
+
 ; Reward settings
 reward_randomization = 1
 ; Options: 0 - Fixed reward values, 1 - Random reward values

--- a/pufferlib/ocean/drive/binding.c
+++ b/pufferlib/ocean/drive/binding.c
@@ -88,6 +88,7 @@ static PyObject *my_shared(PyObject *self, PyObject *args, PyObject *kwargs) {
     int goal_behavior = unpack(kwargs, "goal_behavior");
     int reward_randomization = unpack(kwargs, "reward_randomization");
     int reward_conditioning = unpack(kwargs, "reward_conditioning");
+    int turn_off_normalization = unpack(kwargs, "turn_off_normalization");
     float min_goal_distance = unpack(kwargs, "min_goal_distance");
     float max_goal_distance = unpack(kwargs, "max_goal_distance");
 
@@ -194,6 +195,7 @@ static PyObject *my_shared(PyObject *self, PyObject *args, PyObject *kwargs) {
         env->init_steps = init_steps;
         env->goal_behavior = goal_behavior;
         env->reward_randomization = reward_randomization;
+        env->turn_off_normalization = turn_off_normalization;
         env->reward_conditioning = reward_conditioning;
         env->min_goal_distance = min_goal_distance;
         env->max_goal_distance = max_goal_distance;
@@ -331,6 +333,7 @@ static int my_init(Env *env, PyObject *args, PyObject *kwargs) {
     env->control_mode = (int)unpack(kwargs, "control_mode");
     env->goal_behavior = (int)unpack(kwargs, "goal_behavior");
     env->reward_randomization = (int)unpack(kwargs, "reward_randomization");
+    env->turn_off_normalization = (int)unpack(kwargs, "turn_off_normalization");
     env->reward_conditioning = (int)unpack(kwargs, "reward_conditioning");
     env->min_goal_distance = (float)unpack(kwargs, "min_goal_distance");
     env->max_goal_distance = (float)unpack(kwargs, "max_goal_distance");

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -348,6 +348,7 @@ struct Drive {
     int control_mode;
     int reward_randomization;
     int reward_conditioning;
+    int turn_off_normalization;
     RewardBound reward_bounds[NUM_REWARD_COEFS];
     float min_avg_speed_to_consider_goal_attempt;
 };
@@ -2499,7 +2500,11 @@ void compute_observations(Drive *env) {
         //  Encoder -> Conditioning and goal waypoints
         if (env->reward_conditioning) {
             for (int c = 0; c < NUM_REWARD_COEFS; c++) {
-                obs[obs_idx++] = normalize_reward_coef(ego_entity->reward_coefs[c], c, env);
+                if (env->turn_off_normalization) {
+                    obs[obs_idx++] = ego_entity->reward_coefs[c];
+                } else {
+                    obs[obs_idx++] = normalize_reward_coef(ego_entity->reward_coefs[c], c, env);
+                }
             }
         }
         //

--- a/pufferlib/ocean/drive/drive.py
+++ b/pufferlib/ocean/drive/drive.py
@@ -25,6 +25,7 @@ class Drive(pufferlib.PufferEnv):
         reward_goal_post_respawn=0.5,
         goal_behavior=0,
         reward_randomization=0,
+        turn_off_normalization=1,
         reward_conditioning=0,
         min_goal_distance=5.0,
         max_goal_distance=20.0,
@@ -108,6 +109,7 @@ class Drive(pufferlib.PufferEnv):
         self.max_goal_speed = float(max_goal_speed) if max_goal_speed is not None else -1.0
         self.goal_behavior = goal_behavior
         self.reward_randomization = reward_randomization
+        self.turn_off_normalization = turn_off_normalization
         self.reward_conditioning = reward_conditioning
         self.min_goal_distance = min_goal_distance
         self.max_goal_distance = max_goal_distance
@@ -276,6 +278,7 @@ class Drive(pufferlib.PufferEnv):
             init_steps=self.init_steps,
             goal_behavior=self.goal_behavior,
             reward_randomization=self.reward_randomization,
+            turn_off_normalization=self.turn_off_normalization,
             reward_conditioning=self.reward_conditioning,
             min_goal_distance=self.min_goal_distance,
             max_goal_distance=self.max_goal_distance,
@@ -346,6 +349,7 @@ class Drive(pufferlib.PufferEnv):
                 max_goal_speed=self.max_goal_speed,
                 goal_behavior=self.goal_behavior,
                 reward_randomization=self.reward_randomization,
+                turn_off_normalization=self.turn_off_normalization,
                 reward_conditioning=self.reward_conditioning,
                 min_goal_distance=self.min_goal_distance,
                 max_goal_distance=self.max_goal_distance,
@@ -427,6 +431,7 @@ class Drive(pufferlib.PufferEnv):
             init_steps=self.init_steps,
             goal_behavior=self.goal_behavior,
             reward_randomization=self.reward_randomization,
+            turn_off_normalization=self.turn_off_normalization,
             reward_conditioning=self.reward_conditioning,
             min_goal_distance=self.min_goal_distance,
             max_goal_distance=self.max_goal_distance,
@@ -495,6 +500,7 @@ class Drive(pufferlib.PufferEnv):
                 goal_behavior=self.goal_behavior,
                 reward_randomization=self.reward_randomization,
                 reward_conditioning=self.reward_conditioning,
+                turn_off_normalization=self.turn_off_normalization,
                 min_goal_distance=self.min_goal_distance,
                 max_goal_distance=self.max_goal_distance,
                 min_goal_speed=self.min_goal_speed,

--- a/pufferlib/ocean/drive/visualize.c
+++ b/pufferlib/ocean/drive/visualize.c
@@ -252,6 +252,7 @@ int eval_gif(const char *map_name, const char *policy_name, int show_grid, int o
         .goal_behavior = conf.goal_behavior,
         .reward_randomization = conf.reward_randomization,
         .reward_conditioning = conf.reward_conditioning,
+        .turn_off_normalization = conf.turn_off_normalization,
         .min_goal_distance = conf.min_goal_distance,
         .max_goal_distance = conf.max_goal_distance,
         .max_goal_speed = conf.max_goal_speed,

--- a/pufferlib/ocean/env_config.h
+++ b/pufferlib/ocean/env_config.h
@@ -27,6 +27,7 @@ typedef struct {
     int goal_behavior;
     int reward_randomization;
     int reward_conditioning;
+    int turn_off_normalization;
     float min_goal_distance;
     float max_goal_distance;
 
@@ -107,6 +108,8 @@ static int handler(void *config, const char *section, const char *name, const ch
         env_config->goal_behavior = atoi(value);
     } else if (MATCH("env", "reward_randomization")) {
         env_config->reward_randomization = atoi(value);
+    } else if (MATCH("env", "turn_off_normalization")) {
+        env_config->turn_off_normalization = atoi(value);
     } else if (MATCH("env", "reward_conditioning")) {
         env_config->reward_conditioning = atoi(value);
     } else if (MATCH("env", "min_goal_distance")) {

--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -295,8 +295,7 @@ class PuffeRL:
 
                 logits, value = self.policy.forward_eval(o_device, state)
                 action, logprob, _ = pufferlib.pytorch.sample_logits(logits)
-                # Removed reward clamping
-                # r = torch.clamp(r, -1, 1)
+                r = torch.clamp(r, -1, 1)
 
             profile("eval_copy", epoch)
             with torch.no_grad():

--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -295,7 +295,7 @@ class PuffeRL:
 
                 logits, value = self.policy.forward_eval(o_device, state)
                 action, logprob, _ = pufferlib.pytorch.sample_logits(logits)
-                r = torch.clamp(r, -1, 1)
+                # REMOVED REWARD CLAMPING
 
             profile("eval_copy", epoch)
             with torch.no_grad():

--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -295,7 +295,8 @@ class PuffeRL:
 
                 logits, value = self.policy.forward_eval(o_device, state)
                 action, logprob, _ = pufferlib.pytorch.sample_logits(logits)
-                r = torch.clamp(r, -1, 1)
+                # Removed reward clamping
+                # r = torch.clamp(r, -1, 1)
 
             profile("eval_copy", epoch)
             with torch.no_grad():


### PR DESCRIPTION
This PR adds an option to turn off reward coefficient normalization when feeding data into the NN during reward conditioning. It uses `turn_off_normalization` for the same.