### PR TITLE
Fix jerk model: curvature floor traps a_lat near zero when reversing

### DIFF
--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -2830,7 +2830,6 @@ void move_dynamics(Drive *env, int action_idx, int agent_idx) {
 
         // Calculate new steering angle
         float signed_curvature = a_lat_new / fmaxf(v_new * v_new, 1e-5f);
-        signed_curvature = copysignf(fmaxf(fabsf(signed_curvature), 1e-5f), signed_curvature);
         float steering_angle = atanf(signed_curvature * agent->wheelbase);
         float delta_steer = clip(steering_angle - agent->steering_angle, -0.6f * env->dt, 0.6f * env->dt);
         float new_steering_angle = clip(agent->steering_angle + delta_steer, -0.55f, 0.55f);


### PR DESCRIPTION
## Summary
- Removes the forced minimum curvature (`copysignf(fmaxf(...), 1e-5)`) in the jerk dynamics model
- This line creates a bug where `a_lat` can never cross zero while reversing at low speed, permanently locking the agent's steering direction

## Bug details
When reversing slowly and trying to change steering direction:
1. The "easy to stop" smoothing zeros `a_lat` when it changes sign
2. The forced minimum curvature (+1e-5) immediately biases `a_lat` back to `+v² × 1e-5 ≈ +4e-5`
3. Next step, the negative jerk crosses the sign again → smoothing zeros it → forced curvature biases it positive again
4. The agent is permanently stuck turning in one direction until it accelerates forward (higher v² breaks the cycle)

The near-zero curvature guard on line 2847 already handles the division-by-zero case for position updates, making this floor redundant.

## Test plan
- [ ] Verify jerk model agents can change steering direction while reversing at low speed
- [ ] Run existing tests to confirm no regression in forward-driving behavior