### PR TITLE
Restore reward clamping to [-1, 1] behind clamp_reward config option

### DIFF
--- a/pufferlib/config/ocean/drive.ini
+++ b/pufferlib/config/ocean/drive.ini
@@ -146,6 +146,7 @@ bptt_horizon = 32
 adam_beta1 = 0.9
 adam_beta2 = 0.999
 adam_eps = 1e-8
+; If true, rewards clamped to [-1, 1]. Remove once proper STOP training is implemented. 
 clamp_reward = True
 clip_coef = 0.2
 ent_coef = 0.005

--- a/pufferlib/config/ocean/drive.ini
+++ b/pufferlib/config/ocean/drive.ini
@@ -146,6 +146,7 @@ bptt_horizon = 32
 adam_beta1 = 0.9
 adam_beta2 = 0.999
 adam_eps = 1e-8
+clamp_reward = True
 clip_coef = 0.2
 ent_coef = 0.005
 gae_lambda = 0.95

--- a/pufferlib/config/ocean/drive.ini
+++ b/pufferlib/config/ocean/drive.ini
@@ -146,7 +146,7 @@ bptt_horizon = 32
 adam_beta1 = 0.9
 adam_beta2 = 0.999
 adam_eps = 1e-8
-; If true, rewards clamped to [-1, 1]. Remove once proper STOP training is implemented. 
+; If true, rewards clamped to [-1, 1]. Remove once proper STOP training is implemented.
 clamp_reward = True
 clip_coef = 0.2
 ent_coef = 0.005

--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -295,7 +295,8 @@ class PuffeRL:
 
                 logits, value = self.policy.forward_eval(o_device, state)
                 action, logprob, _ = pufferlib.pytorch.sample_logits(logits)
-                # REMOVED REWARD CLAMPING
+                if config.get("clamp_reward", True):
+                    r = torch.clamp(r, -1, 1)
 
             profile("eval_copy", epoch)
             with torch.no_grad():


### PR DESCRIPTION
Adds clamp_reward (default True) to [train] config. When enabled, rewards are clamped to [-1, 1] before being used in advantage estimation, matching the behavior before commit 98acb54c removed it. This is TEMPORARY. 