### PR TITLE
Change default dynamics model to jerk

### DIFF
--- a/pufferlib/config/ocean/drive.ini
+++ b/pufferlib/config/ocean/drive.ini
@@ -23,7 +23,7 @@ num_agents = 1024
 ; Options: discrete, continuous
 action_type = discrete
 ; Options: classic, jerk
-dynamics_model = classic
+dynamics_model = jerk
 reward_vehicle_collision = -0.5
 reward_offroad_collision = -0.5     # Use -0.05 for carla maps
 reward_lane_align = 1

--- a/pufferlib/ocean/drive/drive.py
+++ b/pufferlib/ocean/drive/drive.py
@@ -41,7 +41,7 @@ class Drive(pufferlib.PufferEnv):
         num_maps=100,
         num_agents=512,
         action_type="discrete",
-        dynamics_model="classic",
+        dynamics_model="jerk",
         buf=None,
         seed=1,
         init_steps=0,


### PR DESCRIPTION
## Summary
- Changes default dynamics model from `classic` to `jerk` in both `drive.py` and `drive.ini`