### PR TITLE
Add SafeEvaluator class for in-process safe eval

### DIFF
--- a/pufferlib/config/ocean/drive.ini
+++ b/pufferlib/config/ocean/drive.ini
@@ -219,6 +219,44 @@ human_replay_control_mode = "control_sdc_only"
 ; Number of scenarios for human replay evaluation equals the number of agents
 human_replay_num_agents = 16
 
+[safe_eval]
+; If True, periodically run policy with safe/law-abiding reward conditioning and log metrics
+enabled = True
+; How often to run safe eval (in training epochs). Defaults to render_interval.
+interval = 250
+; Number of agents to run in the eval environment
+num_agents = 64
+; Number of episodes to collect metrics over
+num_episodes = 100
+; episode length
+episode_length = 1000
+min_goal_distance = 0.5
+max_goal_distance = 1000.0
+
+; Reward conditioning values (min=max to fix the value).
+; Names match the env reward_bound_* keys.
+; High penalties for unsafe behavior
+collision = -3.0
+offroad = -3.0
+overspeed = -1.0
+traffic_light = -1.0
+reverse = -0.0075
+comfort = -0.1
+
+; Standard driving rewards
+goal_radius = 2.0
+lane_align = 0.025
+lane_center = -0.00075
+velocity = 0.005
+center_bias = 0.0
+vel_align = 1.0
+timestep = -0.00005
+
+; Neutral scaling factors
+throttle = 1.0
+steer = 1.0
+acc = 1.0
+
 [render]
 ; Mode to render a bunch of maps with a given policy
 ; Path to dataset used for rendering

--- a/pufferlib/config/ocean/drive.ini
+++ b/pufferlib/config/ocean/drive.ini
@@ -232,7 +232,7 @@ num_episodes = 100
 episode_length = 1000
 ; Map directory and count for safe eval (independent of training maps)
 map_dir = "resources/drive/binaries/carla_3D"
-num_maps = 3
+num_maps = 8
 min_goal_distance = 0.5
 max_goal_distance = 1000.0
 

--- a/pufferlib/config/ocean/drive.ini
+++ b/pufferlib/config/ocean/drive.ini
@@ -230,6 +230,9 @@ num_agents = 64
 num_episodes = 100
 ; episode length
 episode_length = 1000
+; Map directory and count for safe eval (independent of training maps)
+map_dir = "resources/drive/binaries/carla_3D"
+num_maps = 3
 min_goal_distance = 0.5
 max_goal_distance = 1000.0
 

--- a/pufferlib/ocean/benchmark/evaluator.py
+++ b/pufferlib/ocean/benchmark/evaluator.py
@@ -816,3 +816,132 @@ class HumanReplayEvaluator:
             if len(info_list) > 0:  # Happens at the end of episode
                 results = info_list[0]
                 return results
+
+
+class SafeEvaluator:
+    """Evaluates policies with fixed safe/law-abiding reward conditioning.
+
+    Runs the policy with deterministic reward bounds (reward_randomization=1,
+    min=max for each bound) so the conditioning observation vector is fixed to
+    safe driving values. Collects metrics over multiple episodes.
+    """
+
+    def __init__(self, config: Dict, logger=None):
+        self.config = config
+        self.logger = logger
+        self.safe_eval_config = config.get("safe_eval", {})
+        self.num_episodes = self.safe_eval_config.get("num_episodes", 100)
+        self.num_agents = self.safe_eval_config.get("num_agents", 64)
+        self.episode_length = self.safe_eval_config.get("episode_length", 1000)
+        self.device = config.get("train", {}).get("device", "cuda")
+        self.stats = None
+
+    def _build_eval_env_config(self):
+        """Build env config with safe reward conditioning values applied."""
+        import copy
+        import re
+
+        eval_config = copy.deepcopy(self.config)
+        eval_config["vec"] = dict(backend="PufferEnv", num_envs=1)
+        eval_config["env"]["num_agents"] = self.num_agents
+        eval_config["env"]["episode_length"] = self.episode_length
+        eval_config["env"]["resample_frequency"] = 0
+        eval_config["env"]["reward_randomization"] = 1
+        eval_config["env"]["reward_conditioning"] = 1
+
+        if "min_goal_distance" in self.safe_eval_config:
+            eval_config["env"]["min_goal_distance"] = self.safe_eval_config["min_goal_distance"]
+        if "max_goal_distance" in self.safe_eval_config:
+            eval_config["env"]["max_goal_distance"] = self.safe_eval_config["max_goal_distance"]
+
+        # Discover valid reward bound names from env config
+        valid_bounds = set()
+        for key in eval_config["env"]:
+            m = re.match(r"reward_bound_(.+)_min$", key)
+            if m:
+                valid_bounds.add(m.group(1))
+
+        # Set min=max for each reward bound to fix the conditioning values
+        for key, val in self.safe_eval_config.items():
+            if key not in valid_bounds:
+                continue
+            eval_config["env"][f"reward_bound_{key}_min"] = float(val)
+            eval_config["env"][f"reward_bound_{key}_max"] = float(val)
+
+        return eval_config
+
+    def evaluate(self, vecenv, policy):
+        """Run evaluation with safe reward conditioning and collect metrics.
+
+        Args:
+            vecenv: Vectorized environment (created with safe eval config)
+            policy: Trained policy to evaluate
+
+        Returns:
+            dict: Averaged metrics over collected episodes
+        """
+        from collections import defaultdict
+
+        policy.eval()
+        num_agents = vecenv.observation_space.shape[0]
+        use_rnn = self.config.get("train", {}).get("use_rnn", False)
+
+        ob, _ = vecenv.reset()
+        state = {}
+        dones = torch.zeros(num_agents, device=self.device)
+        prev_rewards = torch.zeros(num_agents, device=self.device)
+        if use_rnn:
+            state = dict(
+                lstm_h=torch.zeros(num_agents, policy.hidden_size, device=self.device),
+                lstm_c=torch.zeros(num_agents, policy.hidden_size, device=self.device),
+            )
+
+        all_stats = defaultdict(list)
+        episodes_collected = 0
+        max_steps = (self.num_episodes // max(num_agents, 1) + 2) * self.episode_length
+
+        for step in range(max_steps):
+            if episodes_collected >= self.num_episodes:
+                break
+
+            with torch.no_grad():
+                ob_t = torch.as_tensor(ob).to(self.device)
+                if use_rnn:
+                    state["reward"] = prev_rewards
+                    state["done"] = dones
+                logits, value = policy.forward_eval(ob_t, state)
+                action, logprob, _ = pufferlib.pytorch.sample_logits(logits)
+                action = action.cpu().numpy().reshape(vecenv.action_space.shape)
+
+            if isinstance(logits, torch.distributions.Normal):
+                action = np.clip(action, vecenv.action_space.low, vecenv.action_space.high)
+
+            ob, rewards, terminals, truncations, infos = vecenv.step(action)
+            prev_rewards = torch.as_tensor(rewards).float().to(self.device)
+            dones = torch.as_tensor(np.maximum(terminals, truncations)).float().to(self.device)
+
+            for entry in infos:
+                if isinstance(entry, dict):
+                    episodes_collected += int(entry.get("n", 1))
+                    for k, v in entry.items():
+                        try:
+                            float(v)
+                            all_stats[k].append(v)
+                        except (TypeError, ValueError):
+                            pass
+
+        self.stats = {k: float(np.mean(v)) for k, v in all_stats.items() if len(v) > 0}
+        return self.stats
+
+    def log_stats(self, global_step=None):
+        """Log collected metrics to wandb."""
+        if self.stats is None:
+            return
+
+        if not (self.logger and hasattr(self.logger, "wandb") and self.logger.wandb):
+            return
+
+        payload = {f"eval/safe_{k}": v for k, v in self.stats.items()}
+        if global_step is not None:
+            payload["train_step"] = global_step
+        self.logger.wandb.log(payload)

--- a/pufferlib/ocean/benchmark/evaluator.py
+++ b/pufferlib/ocean/benchmark/evaluator.py
@@ -824,38 +824,54 @@ class SafeEvaluator:
     Runs the policy with deterministic reward bounds (reward_randomization=1,
     min=max for each bound) so the conditioning observation vector is fixed to
     safe driving values. Collects metrics over multiple episodes.
+
+    Re-parses the INI config internally so it doesn't need the full training
+    args dict — only the env_name, safe_eval config, and device.
     """
 
-    def __init__(self, config: Dict, logger=None):
-        self.config = config
+    def __init__(self, env_name: str, safe_eval_config: Dict, device="cuda", logger=None):
+        self.env_name = env_name
         self.logger = logger
-        self.safe_eval_config = config.get("safe_eval", {})
-        self.num_episodes = self.safe_eval_config.get("num_episodes", 100)
-        self.num_agents = self.safe_eval_config.get("num_agents", 64)
-        self.episode_length = self.safe_eval_config.get("episode_length", 1000)
-        device = config.get("train", {}).get("device", "cuda")
+        self.safe_eval_config = safe_eval_config
+        self.num_episodes = safe_eval_config.get("num_episodes", 100)
+        self.num_agents = safe_eval_config.get("num_agents", 64)
+        self.episode_length = safe_eval_config.get("episode_length", 1000)
         if isinstance(device, int):
             device = f"cuda:{device}"
         self.device = device
         self.stats = None
 
     def _build_eval_env_config(self):
-        """Build env config with safe reward conditioning values applied."""
-        import copy
-        import re
+        """Build env config with safe reward conditioning values applied.
 
-        eval_config = copy.deepcopy(self.config)
+        Re-parses the INI file to get a fresh full config, then applies
+        safe_eval overrides for env, vec, and reward bounds.
+        """
+        import re
+        from pufferlib.pufferl import load_config
+
+        # Re-parse INI to get full config (env, vec, policy, rnn, etc.)
+        import sys
+
+        original_argv = sys.argv
+        sys.argv = ["pufferl"]
+        try:
+            eval_config = load_config(self.env_name)
+        finally:
+            sys.argv = original_argv
+
         eval_config["vec"] = dict(backend="PufferEnv", num_envs=1)
+        eval_config["train"]["device"] = self.device
         eval_config["env"]["num_agents"] = self.num_agents
         eval_config["env"]["episode_length"] = self.episode_length
         eval_config["env"]["resample_frequency"] = 0
         eval_config["env"]["reward_randomization"] = 1
         eval_config["env"]["reward_conditioning"] = 1
 
-        if "min_goal_distance" in self.safe_eval_config:
-            eval_config["env"]["min_goal_distance"] = self.safe_eval_config["min_goal_distance"]
-        if "max_goal_distance" in self.safe_eval_config:
-            eval_config["env"]["max_goal_distance"] = self.safe_eval_config["max_goal_distance"]
+        # Apply safe_eval overrides for map_dir, goal distances, etc.
+        for override_key in ("map_dir", "num_maps", "min_goal_distance", "max_goal_distance"):
+            if override_key in self.safe_eval_config:
+                eval_config["env"][override_key] = self.safe_eval_config[override_key]
 
         # Discover valid reward bound names from env config
         valid_bounds = set()
@@ -887,7 +903,7 @@ class SafeEvaluator:
 
         policy.eval()
         num_agents = vecenv.observation_space.shape[0]
-        use_rnn = self.config.get("train", {}).get("use_rnn", False)
+        use_rnn = hasattr(policy, "hidden_size")
 
         ob, _ = vecenv.reset()
         state = {}

--- a/pufferlib/ocean/benchmark/evaluator.py
+++ b/pufferlib/ocean/benchmark/evaluator.py
@@ -833,7 +833,10 @@ class SafeEvaluator:
         self.num_episodes = self.safe_eval_config.get("num_episodes", 100)
         self.num_agents = self.safe_eval_config.get("num_agents", 64)
         self.episode_length = self.safe_eval_config.get("episode_length", 1000)
-        self.device = config.get("train", {}).get("device", "cuda")
+        device = config.get("train", {}).get("device", "cuda")
+        if isinstance(device, int):
+            device = f"cuda:{device}"
+        self.device = device
         self.stats = None
 
     def _build_eval_env_config(self):

--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -605,9 +605,12 @@ class PuffeRL:
 
     def _run_safe_eval(self):
         """Run safe eval in-process using SafeEvaluator."""
+        import traceback
+
         try:
             from pufferlib.ocean.benchmark.evaluator import SafeEvaluator
 
+            self.msg = "Running safe eval..."
             evaluator = SafeEvaluator(self.config, logger=self.logger)
             eval_config = evaluator._build_eval_env_config()
 
@@ -618,7 +621,7 @@ class PuffeRL:
             model_dir = os.path.join(self.config["data_dir"], f"{self.config['env']}_{self.logger.run_id}")
             model_files = glob.glob(os.path.join(model_dir, "model_*.pt"))
             if not model_files:
-                print("No model files found for safe eval")
+                self.msg = "Safe eval: no model files found"
                 return
 
             latest_cpt = max(model_files, key=os.path.getctime)
@@ -629,9 +632,10 @@ class PuffeRL:
             evaluator.log_stats(global_step=self.global_step)
             vecenv.close()
 
-            print(f"Safe eval: {len(metrics)} metrics logged")
+            self.msg = f"Safe eval: {len(metrics)} metrics logged"
         except Exception as e:
-            print(f"Safe eval failed: {e}")
+            self.msg = f"Safe eval failed: {e}"
+            traceback.print_exc(file=sys.stderr)
 
     def check_render_queue(self):
         """Check if any async render jobs finished and log them."""

--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -597,6 +597,42 @@ class PuffeRL:
         ):
             pufferlib.utils.run_human_replay_eval_in_subprocess(self.config, self.logger, self.global_step)
 
+        safe_eval_config = self.config.get("safe_eval", {})
+        safe_eval_enabled = safe_eval_config.get("enabled", False)
+        safe_eval_interval = safe_eval_config.get("interval", self.render_interval)
+        if safe_eval_enabled and (self.epoch % safe_eval_interval == 0 or done_training):
+            self._run_safe_eval()
+
+    def _run_safe_eval(self):
+        """Run safe eval in-process using SafeEvaluator."""
+        try:
+            from pufferlib.ocean.benchmark.evaluator import SafeEvaluator
+
+            evaluator = SafeEvaluator(self.config, logger=self.logger)
+            eval_config = evaluator._build_eval_env_config()
+
+            vecenv = load_env(self.config["env"], eval_config)
+            policy = load_policy(eval_config, vecenv, self.config["env"])
+
+            # Load weights from latest checkpoint
+            model_dir = os.path.join(self.config["data_dir"], f"{self.config['env']}_{self.logger.run_id}")
+            model_files = glob.glob(os.path.join(model_dir, "model_*.pt"))
+            if not model_files:
+                print("No model files found for safe eval")
+                return
+
+            latest_cpt = max(model_files, key=os.path.getctime)
+            checkpoint = torch.load(latest_cpt, map_location=str(self.config["device"]), weights_only=False)
+            policy.load_state_dict(checkpoint["model_state_dict"])
+
+            metrics = evaluator.evaluate(vecenv, policy)
+            evaluator.log_stats(global_step=self.global_step)
+            vecenv.close()
+
+            print(f"Safe eval: {len(metrics)} metrics logged")
+        except Exception as e:
+            print(f"Safe eval failed: {e}")
+
     def check_render_queue(self):
         """Check if any async render jobs finished and log them."""
         if not self.render_async or not hasattr(self, "render_queue"):

--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -628,7 +628,10 @@ class PuffeRL:
             policy = load_policy(eval_config, vecenv, env_name)
 
             # Copy weights from in-memory policy (no checkpoint dependency)
-            policy.load_state_dict(copy.deepcopy(self.uncompiled_policy.state_dict()))
+            state_dict = copy.deepcopy(self.uncompiled_policy.state_dict())
+            # Strip DDP "module." prefix if present
+            state_dict = {k.replace("module.", ""): v for k, v in state_dict.items()}
+            policy.load_state_dict(state_dict)
 
             metrics = evaluator.evaluate(vecenv, policy)
             evaluator.log_stats(global_step=self.global_step)

--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -64,12 +64,11 @@ ADVANTAGE_CUDA = shutil.which("nvcc") is not None
 
 
 class PuffeRL:
-    def __init__(self, config, vecenv, policy, logger=None, full_args=None):
+    def __init__(self, config, vecenv, policy, logger=None):
         # Backend perf optimization
         torch.set_float32_matmul_precision("high")
         torch.backends.cudnn.deterministic = config["torch_deterministic"]
         torch.backends.cudnn.benchmark = True
-        self.full_args = full_args
 
         # Reproducibility
         seed = config["seed"]
@@ -620,10 +619,11 @@ class PuffeRL:
             from pufferlib.ocean.benchmark.evaluator import SafeEvaluator
 
             self.msg = "Running safe eval..."
-            evaluator = SafeEvaluator(self.full_args, logger=self.logger)
+            env_name = self.config["env"]
+            safe_eval_config = self.config.get("safe_eval", {})
+            evaluator = SafeEvaluator(env_name, safe_eval_config, device=self.config["device"], logger=self.logger)
             eval_config = evaluator._build_eval_env_config()
 
-            env_name = self.config["env"]
             vecenv = load_env(env_name, eval_config)
             policy = load_policy(eval_config, vecenv, env_name)
 
@@ -1195,11 +1195,10 @@ def train(env_name, args=None, vecenv=None, policy=None, logger=None):
         env=env_name,
         eval=args.get("eval", {}),
         safe_eval=args.get("safe_eval", {}),
-        env_config=args.get("env", {}),
     )
     if "vec" in args and "num_workers" in args["vec"]:
         train_config["num_workers"] = args["vec"]["num_workers"]
-    pufferl = PuffeRL(train_config, vecenv, policy, logger, full_args=args)
+    pufferl = PuffeRL(train_config, vecenv, policy, logger)
 
     all_logs = []
     while pufferl.global_step < train_config["total_timesteps"]:

--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -64,11 +64,12 @@ ADVANTAGE_CUDA = shutil.which("nvcc") is not None
 
 
 class PuffeRL:
-    def __init__(self, config, vecenv, policy, logger=None):
+    def __init__(self, config, vecenv, policy, logger=None, full_args=None):
         # Backend perf optimization
         torch.set_float32_matmul_precision("high")
         torch.backends.cudnn.deterministic = config["torch_deterministic"]
         torch.backends.cudnn.benchmark = True
+        self.full_args = full_args
 
         # Reproducibility
         seed = config["seed"]
@@ -599,43 +600,49 @@ class PuffeRL:
 
         safe_eval_config = self.config.get("safe_eval", {})
         safe_eval_enabled = safe_eval_config.get("enabled", False)
-        safe_eval_interval = safe_eval_config.get("interval", self.render_interval)
-        if safe_eval_enabled and (self.epoch % safe_eval_interval == 0 or done_training):
+        safe_eval_interval = int(safe_eval_config.get("interval", self.render_interval))
+        is_main = not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0
+        if (
+            is_main
+            and safe_eval_enabled
+            and safe_eval_interval > 0
+            and (self.epoch % safe_eval_interval == 0 or done_training)
+        ):
             self._run_safe_eval()
 
     def _run_safe_eval(self):
         """Run safe eval in-process using SafeEvaluator."""
+        import copy
         import traceback
 
+        vecenv = None
         try:
             from pufferlib.ocean.benchmark.evaluator import SafeEvaluator
 
             self.msg = "Running safe eval..."
-            evaluator = SafeEvaluator(self.config, logger=self.logger)
+            evaluator = SafeEvaluator(self.full_args, logger=self.logger)
             eval_config = evaluator._build_eval_env_config()
 
-            vecenv = load_env(self.config["env"], eval_config)
-            policy = load_policy(eval_config, vecenv, self.config["env"])
+            env_name = self.config["env"]
+            vecenv = load_env(env_name, eval_config)
+            policy = load_policy(eval_config, vecenv, env_name)
 
-            # Load weights from latest checkpoint
-            model_dir = os.path.join(self.config["data_dir"], f"{self.config['env']}_{self.logger.run_id}")
-            model_files = glob.glob(os.path.join(model_dir, "model_*.pt"))
-            if not model_files:
-                self.msg = "Safe eval: no model files found"
-                return
-
-            latest_cpt = max(model_files, key=os.path.getctime)
-            checkpoint = torch.load(latest_cpt, map_location=str(self.config["device"]), weights_only=False)
-            policy.load_state_dict(checkpoint["model_state_dict"])
+            # Copy weights from in-memory policy (no checkpoint dependency)
+            policy.load_state_dict(copy.deepcopy(self.uncompiled_policy.state_dict()))
 
             metrics = evaluator.evaluate(vecenv, policy)
             evaluator.log_stats(global_step=self.global_step)
-            vecenv.close()
 
             self.msg = f"Safe eval: {len(metrics)} metrics logged"
         except Exception as e:
             self.msg = f"Safe eval failed: {e}"
             traceback.print_exc(file=sys.stderr)
+        finally:
+            if vecenv is not None:
+                try:
+                    vecenv.close()
+                except Exception:
+                    pass
 
     def check_render_queue(self):
         """Check if any async render jobs finished and log them."""
@@ -1180,10 +1187,16 @@ def train(env_name, args=None, vecenv=None, policy=None, logger=None):
     else:
         logger = None
 
-    train_config = dict(**args["train"], env=env_name, eval=args.get("eval", {}))
+    train_config = dict(
+        **args["train"],
+        env=env_name,
+        eval=args.get("eval", {}),
+        safe_eval=args.get("safe_eval", {}),
+        env_config=args.get("env", {}),
+    )
     if "vec" in args and "num_workers" in args["vec"]:
         train_config["num_workers"] = args["vec"]["num_workers"]
-    pufferl = PuffeRL(train_config, vecenv, policy, logger)
+    pufferl = PuffeRL(train_config, vecenv, policy, logger, full_args=args)
 
     all_logs = []
     while pufferl.global_step < train_config["total_timesteps"]:


### PR DESCRIPTION
## Summary
- Adds `SafeEvaluator` class in `evaluator.py` alongside `WOSACEvaluator` and `HumanReplayEvaluator`
- Runs policy with fixed safe/law-abiding reward conditioning (min=max bounds) and collects metrics over multiple episodes
- Runs in-process (no subprocess) — creates a separate eval env with safe reward bounds, loads the latest checkpoint, and evaluates
- Adds `[safe_eval]` config section to `drive.ini` with reward conditioning values and eval parameters
- Enabled by default, triggers every `interval` epochs during training

## Test plan
- [x] Verify safe eval triggers during training and logs metrics to wandb

Wandb run: https://wandb.ai/emerge_/pufferdrive/runs/y14glvli?nw=nwusereugenevinitsky
I don't run a baseline for this because it doesn't touch any RL code or env code and so can't cause a regression there. 