### PR TITLE
Clean up job names and wire prefix as wandb run name

### DIFF
--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -1739,6 +1739,7 @@ def load_config(env_name, config_dir=None):
     parser.add_argument("--wandb", action="store_true", help="Use wandb for logging")
     parser.add_argument("--wandb-project", type=str, default="pufferlib")
     parser.add_argument("--wandb-group", type=str, default="debug")
+    parser.add_argument("--wandb-name", type=str, default=None, help="Wandb run name")
     parser.add_argument("--neptune", action="store_true", help="Use neptune for logging")
     parser.add_argument("--neptune-name", type=str, default="pufferai")
     parser.add_argument("--neptune-project", type=str, default="ablations")

--- a/scripts/submit_cluster.py
+++ b/scripts/submit_cluster.py
@@ -51,7 +51,10 @@ def parse_args():
 
     # Job management
     parser.add_argument("--save_dir", type=str, required=True, help="Base directory for experiment outputs")
-    parser.add_argument("--prefix", type=str, default=None, help="Prefix for job names")
+    parser.add_argument("--prefix", type=str, default=None, help="Prefix for job names and wandb run name")
+    parser.add_argument("--wandb-name", type=str, default=None, help="Wandb run name (defaults to --prefix)")
+    parser.add_argument("--wandb-group", type=str, default=None, help="Wandb group name (overrides program config)")
+    parser.add_argument("--wandb-project", type=str, default=None, help="Wandb project name (overrides program config)")
     parser.add_argument("--dry", action="store_true", help="Dry run (don't submit, just print commands)")
 
     # Config files
@@ -196,8 +199,15 @@ def get_all_commands(args) -> Dict[str, Tuple[List[str], str]]:
 
         if args.prefix is not None:
             job_name = f"{args.prefix}_{job_name}"
-            # Use prefix as the wandb run name for easy identification
-            cmd.extend(["--wandb-name", args.prefix])
+
+        # Wandb overrides: explicit flags take priority, then prefix for name
+        wandb_name = args.wandb_name or args.prefix
+        if wandb_name is not None:
+            cmd.extend(["--wandb-name", wandb_name])
+        if args.wandb_group is not None:
+            cmd.extend(["--wandb-group", args.wandb_group])
+        if args.wandb_project is not None:
+            cmd.extend(["--wandb-project", args.wandb_project])
 
         save_dir = os.path.join(args.save_dir, job_name)
         name2commands[job_name] = (cmd, save_dir)

--- a/scripts/submit_cluster.py
+++ b/scripts/submit_cluster.py
@@ -163,7 +163,9 @@ def get_all_commands(args) -> Dict[str, Tuple[List[str], str]]:
                 cmd.append(f"--{cli_key}")
                 cmd.append(str(val))
 
-            if key in overrides and key not in ["config", "config_path"]:
+            # Skip noisy keys from job name (paths, wandb config)
+            name_skip_keys = {"config", "config_path", "map_dir", "env.map_dir", "init_mode", "env.init_mode", "wandb_project", "wandb_group", "wandb_name"}
+            if key in overrides and key not in name_skip_keys:
                 display_key = key.split(".")[-1] if "." in key else key
                 name_entries.append(f"{display_key}{val}")
 
@@ -182,6 +184,8 @@ def get_all_commands(args) -> Dict[str, Tuple[List[str], str]]:
 
         if args.prefix is not None:
             job_name = f"{args.prefix}_{job_name}"
+            # Use prefix as the wandb run name for easy identification
+            cmd.extend(["--wandb-name", args.prefix])
 
         save_dir = os.path.join(args.save_dir, job_name)
         name2commands[job_name] = (cmd, save_dir)

--- a/scripts/submit_cluster.py
+++ b/scripts/submit_cluster.py
@@ -143,15 +143,29 @@ def get_all_commands(args) -> Dict[str, Tuple[List[str], str]]:
     all_main_args, overrides = process_main_args(args.args, args.program_config)
     name2commands = {}
 
+    # Keys to exclude from auto-generated job name (paths, wandb config, common overrides)
+    name_skip_keys = {
+        "config",
+        "config_path",
+        "map_dir",
+        "env.map_dir",
+        "init_mode",
+        "env.init_mode",
+        "total_timesteps",
+        "train.total_timesteps",
+        "wandb_project",
+        "wandb_group",
+        "wandb_name",
+    }
+    # Boolean flags that don't take values (store_true)
+    boolean_flags = {"wandb", "neptune"}
+
     for main_args in all_main_args:
         cmd = []
         name_entries = []
 
         if args.program_config is not None:
             name_entries.append(args.program_config.split("/")[-1].rsplit(".", 1)[0])
-
-        # Boolean flags that don't take values (store_true)
-        boolean_flags = {"wandb", "neptune"}
 
         for key, val in main_args.items():
             # Convert underscores to dashes for CLI compatibility
@@ -166,20 +180,6 @@ def get_all_commands(args) -> Dict[str, Tuple[List[str], str]]:
                 cmd.append(f"--{cli_key}")
                 cmd.append(str(val))
 
-            # Skip noisy keys from job name (paths, wandb config, common overrides)
-            name_skip_keys = {
-                "config",
-                "config_path",
-                "map_dir",
-                "env.map_dir",
-                "init_mode",
-                "env.init_mode",
-                "total_timesteps",
-                "train.total_timesteps",
-                "wandb_project",
-                "wandb_group",
-                "wandb_name",
-            }
             if key in overrides and key not in name_skip_keys:
                 display_key = key.split(".")[-1] if "." in key else key
                 name_entries.append(f"{display_key}{val}")

--- a/scripts/submit_cluster.py
+++ b/scripts/submit_cluster.py
@@ -163,7 +163,7 @@ def get_all_commands(args) -> Dict[str, Tuple[List[str], str]]:
                 cmd.append(f"--{cli_key}")
                 cmd.append(str(val))
 
-            # Skip noisy keys from job name (paths, wandb config)
+            # Skip noisy keys from job name (paths, wandb config, common overrides)
             name_skip_keys = {
                 "config",
                 "config_path",
@@ -171,6 +171,8 @@ def get_all_commands(args) -> Dict[str, Tuple[List[str], str]]:
                 "env.map_dir",
                 "init_mode",
                 "env.init_mode",
+                "total_timesteps",
+                "train.total_timesteps",
                 "wandb_project",
                 "wandb_group",
                 "wandb_name",

--- a/scripts/submit_cluster.py
+++ b/scripts/submit_cluster.py
@@ -164,7 +164,17 @@ def get_all_commands(args) -> Dict[str, Tuple[List[str], str]]:
                 cmd.append(str(val))
 
             # Skip noisy keys from job name (paths, wandb config)
-            name_skip_keys = {"config", "config_path", "map_dir", "env.map_dir", "init_mode", "env.init_mode", "wandb_project", "wandb_group", "wandb_name"}
+            name_skip_keys = {
+                "config",
+                "config_path",
+                "map_dir",
+                "env.map_dir",
+                "init_mode",
+                "env.init_mode",
+                "wandb_project",
+                "wandb_group",
+                "wandb_name",
+            }
             if key in overrides and key not in name_skip_keys:
                 display_key = key.split(".")[-1] if "." in key else key
                 name_entries.append(f"{display_key}{val}")


### PR DESCRIPTION
- Filter noisy keys (map_dir, init_mode, wandb config) from SLURM job name suffix
- Pass `--prefix` as `--wandb-name` so runs are identifiable on the wandb dashboard
