### PR TITLE
Add daily 3.0 cron script for nightly training runs

### DIFF
--- a/scripts/daily_3p0.sh
+++ b/scripts/daily_3p0.sh
@@ -7,27 +7,33 @@
 
 set -euo pipefail
 
-REPO=/scratch/ev2237/code/PufferDrive
+MAIN_REPO=/scratch/ev2237/code/PufferDrive
 OVERLAY=/scratch/ev2237/images/PufferDrive/overlay-15GB-500K.ext3
 IMAGE=/share/apps/images/cuda12.8.1-cudnn9.8.0-ubuntu24.04.2.sif
 SAVE_DIR=/scratch/ev2237/experiments
-COMPUTE_CONFIG=$REPO/scripts/cluster_configs/nyu_greene.yaml
-PROGRAM_CONFIG=$REPO/scripts/cluster_configs/train_base.yaml
 WANDB_PROJECT=Daily3p0Runs
 DATE=$(date +%Y-%m-%d)
 SEEDS="42 55 1"
 ACCOUNTS="torch_pr_355_general torch_pr_355_tandon_advanced torch_pr_355_tandon_priority torch_pr_104_general torch_pr_104_tandon_advanced torch_pr_102_general torch_pr_102_tandon_advanced torch_pr_45_general torch_pr_45_tandon_advanced"
+WORKTREE=/scratch/ev2237/daily_builds/${DATE}
 
 echo "=== Daily 3.0 build: $DATE ==="
 
-# Checkout and pull latest 3.0
-cd $REPO
+# Create an isolated worktree so we never touch the main repo's state
+cd $MAIN_REPO
 git fetch origin
-git checkout 3.0
-git pull origin 3.0
+if [ -d "$WORKTREE" ]; then
+  echo "Worktree $WORKTREE already exists, removing stale one"
+  git worktree remove --force "$WORKTREE" 2>/dev/null || rm -rf "$WORKTREE"
+fi
+git worktree add "$WORKTREE" origin/3.0 --detach
+
+REPO=$WORKTREE
+COMPUTE_CONFIG=$REPO/scripts/cluster_configs/nyu_greene.yaml
+PROGRAM_CONFIG=$REPO/scripts/cluster_configs/train_base.yaml
 
 # Rebuild C extension on a compute node
-echo "Rebuilding C extension..."
+echo "Rebuilding C extension in worktree..."
 srun --account=torch_pr_355_general --gres=gpu:1 --cpus-per-task=4 --mem=16gb --time=15 \
   singularity exec --nv --overlay ${OVERLAY}:ro $IMAGE \
   bash -c "source /ext3/env.sh && cd $REPO && python setup.py build_ext --inplace --force"
@@ -80,5 +86,9 @@ for seed in $SEEDS; do
     echo "Seed $seed: no job running yet, keeping all pending"
   fi
 done
+
+# Clean up worktrees older than 7 days
+find /scratch/ev2237/daily_builds -maxdepth 1 -mindepth 1 -type d -mtime +7 -exec bash -c \
+  'cd '"$MAIN_REPO"' && git worktree remove --force "$1" 2>/dev/null || rm -rf "$1"' _ {} \;
 
 echo "=== Daily 3.0 launch complete: $DATE ==="

--- a/scripts/daily_3p0.sh
+++ b/scripts/daily_3p0.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Daily 3.0 training jobs: rebuild from 3.0 and launch 3 seeds.
+# Intended to be run via cron on the torch cluster login node.
+#
+# Crontab entry (runs at 6am daily):
+#   0 6 * * * /scratch/ev2237/code/PufferDrive/scripts/daily_3p0.sh >> /scratch/ev2237/logs/daily_3p0.log 2>&1
+
+set -euo pipefail
+
+REPO=/scratch/ev2237/code/PufferDrive
+OVERLAY=/scratch/ev2237/images/PufferDrive/overlay-15GB-500K.ext3
+IMAGE=/share/apps/images/cuda12.8.1-cudnn9.8.0-ubuntu24.04.2.sif
+SAVE_DIR=/scratch/ev2237/experiments
+COMPUTE_CONFIG=$REPO/scripts/cluster_configs/nyu_greene.yaml
+PROGRAM_CONFIG=$REPO/scripts/cluster_configs/train_base.yaml
+WANDB_PROJECT=Daily3p0Runs
+DATE=$(date +%Y-%m-%d)
+SEEDS="42 55 1"
+ACCOUNTS="torch_pr_355_general torch_pr_355_tandon_advanced torch_pr_355_tandon_priority torch_pr_104_general torch_pr_104_tandon_advanced torch_pr_102_general torch_pr_102_tandon_advanced torch_pr_45_general torch_pr_45_tandon_advanced"
+
+echo "=== Daily 3.0 build: $DATE ==="
+
+# Checkout and pull latest 3.0
+cd $REPO
+git fetch origin
+git checkout 3.0
+git pull origin 3.0
+
+# Rebuild C extension on a compute node
+echo "Rebuilding C extension..."
+srun --account=torch_pr_355_general --gres=gpu:1 --cpus-per-task=4 --mem=16gb --time=15 \
+  singularity exec --nv --overlay ${OVERLAY}:ro $IMAGE \
+  bash -c "source /ext3/env.sh && cd $REPO && python setup.py build_ext --inplace --force"
+
+echo "Build complete. Launching jobs..."
+
+# Activate login venv for submitit
+source /scratch/ev2237/login_venv/bin/activate
+
+# Launch 3 seeds, each on all accounts (first to start wins, rest get cancelled)
+for seed in $SEEDS; do
+  PREFIX="${DATE}-3p0-seed${seed}"
+  JOBS=""
+
+  for acct in $ACCOUNTS; do
+    JOB_OUTPUT=$(python $REPO/scripts/submit_cluster.py \
+      --save_dir $SAVE_DIR \
+      --compute_config $COMPUTE_CONFIG \
+      --program_config $PROGRAM_CONFIG \
+      --prefix "$PREFIX" \
+      --wandb-project "$WANDB_PROJECT" \
+      --container \
+      --container_overlay $OVERLAY \
+      --account $acct \
+      --args "env.map_dir=resources/drive/binaries/carla_3D" "env.num_maps=3" "train.seed=${seed}" 2>&1)
+
+    JOB_ID=$(echo "$JOB_OUTPUT" | grep -oP 'Submitted job \K\d+')
+    if [ -n "$JOB_ID" ]; then
+      JOBS="$JOBS $JOB_ID"
+    fi
+  done
+
+  echo "Seed $seed: submitted jobs:$JOBS"
+
+  # Wait briefly for one to start, then cancel the rest
+  sleep 15
+  RUNNING_JOB=""
+  for jid in $JOBS; do
+    STATE=$(squeue -j $jid -h -o '%T' 2>/dev/null || echo "GONE")
+    if [ "$STATE" = "RUNNING" ] && [ -z "$RUNNING_JOB" ]; then
+      RUNNING_JOB=$jid
+    elif [ "$STATE" != "GONE" ] && [ "$jid" != "$RUNNING_JOB" ]; then
+      scancel $jid 2>/dev/null || true
+    fi
+  done
+
+  if [ -n "$RUNNING_JOB" ]; then
+    echo "Seed $seed: keeping job $RUNNING_JOB, cancelled rest"
+  else
+    echo "Seed $seed: no job running yet, keeping all pending"
+  fi
+done
+
+echo "=== Daily 3.0 launch complete: $DATE ==="

--- a/scripts/daily_3p0.sh
+++ b/scripts/daily_3p0.sh
@@ -68,14 +68,22 @@ for seed in $SEEDS; do
 
   echo "Seed $seed: submitted jobs:$JOBS"
 
-  # Wait briefly for one to start, then cancel the rest
-  sleep 15
+  # Poll until one job starts running, then cancel the rest
   RUNNING_JOB=""
+  for attempt in $(seq 1 12); do
+    for jid in $JOBS; do
+      STATE=$(squeue -j $jid -h -o '%T' 2>/dev/null || echo "GONE")
+      if [ "$STATE" = "RUNNING" ]; then
+        RUNNING_JOB=$jid
+        break 2
+      fi
+    done
+    sleep 5
+  done
+
+  # Cancel all jobs except the running one
   for jid in $JOBS; do
-    STATE=$(squeue -j $jid -h -o '%T' 2>/dev/null || echo "GONE")
-    if [ "$STATE" = "RUNNING" ] && [ -z "$RUNNING_JOB" ]; then
-      RUNNING_JOB=$jid
-    elif [ "$STATE" != "GONE" ] && [ "$jid" != "$RUNNING_JOB" ]; then
+    if [ "$jid" != "$RUNNING_JOB" ]; then
       scancel $jid 2>/dev/null || true
     fi
   done
@@ -83,7 +91,7 @@ for seed in $SEEDS; do
   if [ -n "$RUNNING_JOB" ]; then
     echo "Seed $seed: keeping job $RUNNING_JOB, cancelled rest"
   else
-    echo "Seed $seed: no job running yet, keeping all pending"
+    echo "Seed $seed: WARNING — no job started after 60s, all jobs left as-is"
   fi
 done
 

--- a/scripts/daily_3p0.sh
+++ b/scripts/daily_3p0.sh
@@ -58,6 +58,7 @@ for seed in $SEEDS; do
     --program_config $PROGRAM_CONFIG \
     --prefix "$PREFIX" \
     --wandb-project "$WANDB_PROJECT" \
+    --wandb-group "$DATE" \
     --container \
     --container_overlay $OVERLAY \
     --account $ACCOUNT \

--- a/scripts/daily_3p0.sh
+++ b/scripts/daily_3p0.sh
@@ -62,7 +62,7 @@ for seed in $SEEDS; do
     --container \
     --container_overlay $OVERLAY \
     --account $ACCOUNT \
-    --args "env.map_dir=resources/drive/binaries/carla_3D" "env.num_maps=3" "train.seed=${seed}" 2>&1)
+    --args "env.map_dir=resources/drive/binaries/carla_3D" "env.num_maps=3" "train.seed=${seed}" "train.render_interval=250" "train.checkpoint_interval=250" 2>&1)
 
   JOB_ID=$(echo "$JOB_OUTPUT" | grep -oP 'Submitted job \K\d+')
   echo "Seed $seed: submitted job $JOB_ID"

--- a/scripts/daily_3p0.sh
+++ b/scripts/daily_3p0.sh
@@ -14,7 +14,7 @@ SAVE_DIR=/scratch/ev2237/experiments
 WANDB_PROJECT=Daily3p0Runs
 DATE=$(date +%Y-%m-%d)
 SEEDS="42 55 1"
-ACCOUNTS="torch_pr_355_general torch_pr_355_tandon_advanced torch_pr_355_tandon_priority torch_pr_104_general torch_pr_104_tandon_advanced torch_pr_102_general torch_pr_102_tandon_advanced torch_pr_45_general torch_pr_45_tandon_advanced"
+ACCOUNT=torch_pr_355_tandon_advanced
 WORKTREE=/scratch/ev2237/daily_builds/${DATE}
 
 echo "=== Daily 3.0 build: $DATE ==="
@@ -48,56 +48,23 @@ echo "Build complete. Launching jobs..."
 # Activate login venv for submitit
 source /scratch/ev2237/login_venv/bin/activate
 
-# Launch 3 seeds, each on all accounts (first to start wins, rest get cancelled)
+# Launch 3 seeds
 for seed in $SEEDS; do
   PREFIX="${DATE}-3p0-seed${seed}"
-  JOBS=""
 
-  for acct in $ACCOUNTS; do
-    JOB_OUTPUT=$(python $REPO/scripts/submit_cluster.py \
-      --save_dir $SAVE_DIR \
-      --compute_config $COMPUTE_CONFIG \
-      --program_config $PROGRAM_CONFIG \
-      --prefix "$PREFIX" \
-      --wandb-project "$WANDB_PROJECT" \
-      --container \
-      --container_overlay $OVERLAY \
-      --account $acct \
-      --args "env.map_dir=resources/drive/binaries/carla_3D" "env.num_maps=3" "train.seed=${seed}" 2>&1)
+  JOB_OUTPUT=$(python $REPO/scripts/submit_cluster.py \
+    --save_dir $SAVE_DIR \
+    --compute_config $COMPUTE_CONFIG \
+    --program_config $PROGRAM_CONFIG \
+    --prefix "$PREFIX" \
+    --wandb-project "$WANDB_PROJECT" \
+    --container \
+    --container_overlay $OVERLAY \
+    --account $ACCOUNT \
+    --args "env.map_dir=resources/drive/binaries/carla_3D" "env.num_maps=3" "train.seed=${seed}" 2>&1)
 
-    JOB_ID=$(echo "$JOB_OUTPUT" | grep -oP 'Submitted job \K\d+')
-    if [ -n "$JOB_ID" ]; then
-      JOBS="$JOBS $JOB_ID"
-    fi
-  done
-
-  echo "Seed $seed: submitted jobs:$JOBS"
-
-  # Poll until one job starts running, then cancel the rest
-  RUNNING_JOB=""
-  for attempt in $(seq 1 12); do
-    for jid in $JOBS; do
-      STATE=$(squeue -j $jid -h -o '%T' 2>/dev/null || echo "GONE")
-      if [ "$STATE" = "RUNNING" ]; then
-        RUNNING_JOB=$jid
-        break 2
-      fi
-    done
-    sleep 5
-  done
-
-  # Cancel all jobs except the running one
-  for jid in $JOBS; do
-    if [ "$jid" != "$RUNNING_JOB" ]; then
-      scancel $jid 2>/dev/null || true
-    fi
-  done
-
-  if [ -n "$RUNNING_JOB" ]; then
-    echo "Seed $seed: keeping job $RUNNING_JOB, cancelled rest"
-  else
-    echo "Seed $seed: WARNING — no job started after 60s, all jobs left as-is"
-  fi
+  JOB_ID=$(echo "$JOB_OUTPUT" | grep -oP 'Submitted job \K\d+')
+  echo "Seed $seed: submitted job $JOB_ID"
 done
 
 # Clean up worktrees older than 7 days

--- a/scripts/daily_3p0.sh
+++ b/scripts/daily_3p0.sh
@@ -62,7 +62,7 @@ for seed in $SEEDS; do
     --container \
     --container_overlay $OVERLAY \
     --account $ACCOUNT \
-    --args "env.map_dir=resources/drive/binaries/carla_3D" "env.num_maps=3" "train.seed=${seed}" "train.render_interval=250" "train.checkpoint_interval=250" 2>&1)
+    --args "env.map_dir=resources/drive/binaries/carla_3D" "env.num_maps=3" "train.seed=${seed}" "train.render_interval=250" "train.checkpoint_interval=250" "train.total_timesteps=4000000000" 2>&1)
 
   JOB_ID=$(echo "$JOB_OUTPUT" | grep -oP 'Submitted job \K\d+')
   echo "Seed $seed: submitted job $JOB_ID"

--- a/scripts/daily_3p0.sh
+++ b/scripts/daily_3p0.sh
@@ -32,6 +32,11 @@ REPO=$WORKTREE
 COMPUTE_CONFIG=$REPO/scripts/cluster_configs/nyu_greene.yaml
 PROGRAM_CONFIG=$REPO/scripts/cluster_configs/train_base.yaml
 
+# Symlink resources from main repo into worktree (maps are not in git)
+if [ ! -d "$REPO/resources" ]; then
+  ln -s "$MAIN_REPO/resources" "$REPO/resources"
+fi
+
 # Rebuild C extension on a compute node
 echo "Rebuilding C extension in worktree..."
 srun --account=torch_pr_355_general --gres=gpu:1 --cpus-per-task=4 --mem=16gb --time=15 \

--- a/scripts/daily_3p0.sh
+++ b/scripts/daily_3p0.sh
@@ -32,10 +32,10 @@ REPO=$WORKTREE
 COMPUTE_CONFIG=$REPO/scripts/cluster_configs/nyu_greene.yaml
 PROGRAM_CONFIG=$REPO/scripts/cluster_configs/train_base.yaml
 
-# Symlink resources from main repo into worktree (maps are not in git)
-if [ ! -d "$REPO/resources" ]; then
-  ln -s "$MAIN_REPO/resources" "$REPO/resources"
-fi
+# Replace worktree's pufferlib/resources with symlink to main repo's copy
+# (map binaries are .gitignored so the worktree doesn't have them)
+rm -rf "$REPO/pufferlib/resources"
+ln -s "$MAIN_REPO/pufferlib/resources" "$REPO/pufferlib/resources"
 
 # Rebuild C extension on a compute node
 echo "Rebuilding C extension in worktree..."


### PR DESCRIPTION
## Summary
- Adds `scripts/daily_3p0.sh` — a cron-friendly script that runs daily on the torch cluster
- Pulls latest 3.0, rebuilds C extension on a compute node, launches 3 seeds (42, 55, 1)
- Logs to wandb project `Daily3p0Runs` with date-prefixed run names (e.g. `2026-03-22-3p0-seed42`)
- Submits each seed on all SLURM accounts for fast scheduling, keeps first runner

## Setup
```
crontab -e
# Add:
0 6 * * * /scratch/ev2237/code/PufferDrive/scripts/daily_3p0.sh >> /scratch/ev2237/logs/daily_3p0.log 2>&1
```