### PR TITLE
Fix: resample_maps should set truncations, not terminals

### DIFF
--- a/pufferlib/ocean/drive/drive.py
+++ b/pufferlib/ocean/drive/drive.py
@@ -578,7 +578,7 @@ class Drive(pufferlib.PufferEnv):
         self.c_envs = binding.vectorize(*env_ids)
 
         binding.vec_reset(self.c_envs, seed)
-        self.terminals[:] = 1
+        self.truncations[:] = 1
 
     def step(self, actions):
         self.terminals[:] = 0


### PR DESCRIPTION
## Summary
- `resample_maps()` was setting `self.terminals[:] = 1` but should set `self.truncations[:] = 1`
- Map resampling is a forced env reset (truncation), not a natural episode end (termination)
- With terminals=1, the advantage computation zeroes the bootstrap value, losing the value estimate at the truncation boundary
- With truncations=1, pufferl's truncation bootstrap heuristic correctly adds `gamma * V(s)` to the reward

## Test plan
- [x] One-line change, verified correct flag is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)