### PR TITLE
Stagger map resampling across workers

### DIFF
--- a/pufferlib/ocean/drive/drive.py
+++ b/pufferlib/ocean/drive/drive.py
@@ -125,6 +125,7 @@ class Drive(pufferlib.PufferEnv):
         self.episode_length = episode_length
         self.termination_mode = termination_mode
         self.resample_frequency = resample_frequency
+        self._rng = np.random.default_rng(seed)
         self.dynamics_model = dynamics_model
         # reward randomization bounds
         self.reward_bound_goal_radius_min = reward_bound_goal_radius_min
@@ -423,7 +424,13 @@ class Drive(pufferlib.PufferEnv):
 
     def reset(self, seed=0):
         binding.vec_reset(self.c_envs, seed)
-        self.tick = 0
+        # Stagger initial tick so workers don't all resample maps at the same step.
+        # The first episode will be shorter than resample_frequency, but this
+        # desynchronizes resets across workers for the rest of training.
+        if self.resample_frequency > 0:
+            self.tick = int(self._rng.integers(self.resample_frequency))
+        else:
+            self.tick = 0
         self.truncations[:] = 0
         return self.observations, []
 


### PR DESCRIPTION
## Summary
- All workers started with `tick=0` and hit `resample_frequency` at the same step, causing every worker to reset maps simultaneously
- This produced a large correlated shift in the environment distribution within a single PPO update, destabilizing training and causing spiky losses
- Fix: on first `reset()`, randomize each worker's initial tick to `[0, resample_frequency)` using a seeded RNG
- The first episode per worker is shorter than usual, but workers stay desynchronized for the rest of training

## Test plan
- [ ] Verify losses are smoother (no periodic spikes at resample boundaries)
- [ ] Verify different workers resample at different global steps