### PR TITLE
clip speed at limit, remove overspeed reward, move advantages out of loop

### DIFF
--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -3239,9 +3239,10 @@ void c_step(Drive *env) {
         }
 
         if (within_distance && within_speed && !agent->current_goal_reached) {
-            if (env->goal_behavior == GOAL_RESPAWN && agent->respawn_timestep != -1) {
-                env->rewards[i] += env->reward_goal_post_respawn;
-                env->logs[i].episode_return += env->reward_goal_post_respawn;
+            if (env->goal_behavior == GOAL_RESPAWN) {
+                float goal_reward = (agent->respawn_timestep == -1) ? env->reward_goal : env->reward_goal_post_respawn;
+                env->rewards[i] += goal_reward;
+                env->logs[i].episode_return += goal_reward;
                 agent->current_goal_reached = 1;
             } else if (env->goal_behavior == GOAL_GENERATE_NEW && (!agent->current_goal_reached)) {
                 env->rewards[i] += env->reward_goal;

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -3267,7 +3267,7 @@ void c_step(Drive *env) {
                 agent->last_goal_reached_timestep = env->timestep;
                 agent->cumulative_displacement_since_last_goal = 0.0f;
             } else { // Zero out the velocity so that the agent stops at the goal
-                env->rewards[i] = env->reward_goal;
+                env->rewards[i] += env->reward_goal;
                 env->logs[i].episode_return += env->reward_goal;
                 agent->stopped = 1;
                 agent->sim_vx = agent->sim_vy = 0.0f;

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -814,7 +814,8 @@ void init_grid_map(Drive *env) {
                 float x_center = (road->x[j] + road->x[j + 1]) / 2;
                 float y_center = (road->y[j] + road->y[j + 1]) / 2;
                 int grid_index = getGridIndex(env, x_center, y_center);
-                if (grid_index < 0) continue;
+                if (grid_index < 0)
+                    continue;
                 env->grid_map->cell_entities_count[grid_index]++;
             }
         }

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -369,7 +369,7 @@ struct Drive {
 void move_expert(Drive *env, float *actions, int agent_idx);
 float point_to_segment_distance_2d(float px, float py, float x1, float y1, float x2, float y2);
 void init_goal_positions(Drive *env);
-float clipSpeed(float speed);
+float clipSpeed(float speed, float maxSpeed);
 void sample_new_goal(Drive *env, int agent_idx);
 int check_lane_aligned(Agent *car, RoadMapElement *lane, int geometry_idx);
 void reset_goal_positions(Drive *env);
@@ -2930,7 +2930,7 @@ void move_dynamics(Drive *env, int action_idx, int agent_idx) {
 
         // Update speed with acceleration
         signed_speed = signed_speed + acceleration * env->dt;
-        signed_speed = clipSpeed(signed_speed);
+        signed_speed = clipSpeed(signed_speed, SPEED_LIMIT);
         // Compute yaw rate
         float beta = tanh(.5 * tanf(steering));
 
@@ -3010,7 +3010,7 @@ void move_dynamics(Drive *env, int action_idx, int agent_idx) {
         if (signed_v * v_new < 0) {
             v_new = 0.0f;
         } else {
-            v_new = clip(v_new, -2.0f, 20.0f);
+            v_new = clip(v_new, -2.0f, SPEED_LIMIT);
         }
 
         // Calculate new steering angle
@@ -3363,11 +3363,7 @@ void c_step(Drive *env) {
                 env->logs[i].episode_return += reverse_penalty;
             }
 
-            // Over speed reward (GIGAFLOW++)
-            float speed_reward = agent->reward_coefs[REWARD_COEF_OVERSPEED] * agent->metrics_array[SPEED_LIMIT_IDX];
-
-            env->rewards[i] += speed_reward;
-            env->logs[i].episode_return += speed_reward;
+            // Overspeed penalty removed — speed is now hard-clamped at SPEED_LIMIT in dynamics.
         }
     }
 
@@ -4296,8 +4292,7 @@ void init_goal_positions(Drive *env) {
     }
 }
 
-float clipSpeed(float speed) {
-    const float maxSpeed = MAX_SPEED;
+float clipSpeed(float speed, float maxSpeed) {
     if (speed > maxSpeed)
         return maxSpeed;
     if (speed < -maxSpeed)

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -814,6 +814,7 @@ void init_grid_map(Drive *env) {
                 float x_center = (road->x[j] + road->x[j + 1]) / 2;
                 float y_center = (road->y[j] + road->y[j + 1]) / 2;
                 int grid_index = getGridIndex(env, x_center, y_center);
+                if (grid_index < 0) continue;
                 env->grid_map->cell_entities_count[grid_index]++;
             }
         }
@@ -2843,6 +2844,8 @@ void respawn_agent(Drive *env, int agent_idx) {
 
     agent->respawn_timestep = env->timestep;
     agent->collided_before_goal = 0;
+    agent->current_goal_reached = 0;
+    agent->score_for_current_goal = 0.0f;
     agent->cumulative_displacement = 0.0f;
     agent->cumulative_displacement_since_last_goal = 0.0f;
     agent->stopped = 0;

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -3182,6 +3182,11 @@ void c_step(Drive *env) {
         Agent *agent = &env->agents[agent_idx];
         agent->collision_state = 0;
         agent->aabb_collision_state = 0;
+        // Skip metrics and rewards for stopped/removed agents — they can't act
+        if (agent->stopped || agent->removed) {
+            env->rewards[i] = 0.0f;
+            continue;
+        }
         compute_agent_metrics(env, agent_idx);
         int collision_state = agent->collision_state;
         if (collision_state == NO_COLLISION) {

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -814,8 +814,6 @@ void init_grid_map(Drive *env) {
                 float x_center = (road->x[j] + road->x[j + 1]) / 2;
                 float y_center = (road->y[j] + road->y[j + 1]) / 2;
                 int grid_index = getGridIndex(env, x_center, y_center);
-                if (grid_index < 0)
-                    continue;
                 env->grid_map->cell_entities_count[grid_index]++;
             }
         }
@@ -3372,8 +3370,6 @@ void c_step(Drive *env) {
                 env->rewards[i] += reverse_penalty;
                 env->logs[i].episode_return += reverse_penalty;
             }
-
-            // Overspeed penalty removed — speed is now hard-clamped at SPEED_LIMIT in dynamics.
         }
     }
 

--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -376,32 +376,40 @@ class PuffeRL:
         vf_clip = config["vf_clip_coef"]
         anneal_beta = b0 + (1 - b0) * a * self.epoch / self.total_epochs
         self.ratio[:] = 1
-        explained_var = None
+
+        # Compute explained variance before training (pre-update values, ratio=1)
+        shape = self.values.shape
+        initial_advantages = compute_puff_advantage(
+            self.values,
+            self.rewards,
+            self.terminals,
+            self.ratio,
+            torch.zeros(shape, device=device),
+            config["gamma"],
+            config["gae_lambda"],
+            config["vtrace_rho_clip"],
+            config["vtrace_c_clip"],
+        )
+        y_pred = self.values.flatten()
+        y_true = initial_advantages.flatten() + y_pred
+        var_y = y_true.var()
+        explained_var = torch.nan if var_y == 0 else 1 - (y_true - y_pred).var() / var_y
 
         for mb in range(self.total_minibatches):
             profile("train_misc", epoch, nest=True)
             self.amp_context.__enter__()
 
-            shape = self.values.shape
-            advantages = torch.zeros(shape, device=device)
             advantages = compute_puff_advantage(
                 self.values,
                 self.rewards,
                 self.terminals,
                 self.ratio,
-                advantages,
+                torch.zeros(shape, device=device),
                 config["gamma"],
                 config["gae_lambda"],
                 config["vtrace_rho_clip"],
                 config["vtrace_c_clip"],
             )
-
-            # Capture explained variance on first minibatch (pre-update values, ratio=1)
-            if explained_var is None:
-                y_pred = self.values.flatten()
-                y_true = advantages.flatten() + y_pred
-                var_y = y_true.var()
-                explained_var = torch.nan if var_y == 0 else 1 - (y_true - y_pred).var() / var_y
 
             profile("train_copy", epoch)
             adv = advantages.abs().sum(axis=1)

--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -119,8 +119,6 @@ class PuffeRL:
         self.rewards = torch.zeros(segments, horizon, device=device)
         self.terminals = torch.zeros(segments, horizon, device=device)
         self.truncations = torch.zeros(segments, horizon, device=device)
-        self.ratio = torch.ones(segments, horizon, device=device)
-        self.importance = torch.ones(segments, horizon, device=device)
         self.ep_lengths = torch.zeros(total_agents, device=device, dtype=torch.int32)
         self.ep_indices = torch.arange(total_agents, device=device, dtype=torch.int32)
         self.free_idx = total_agents
@@ -375,41 +373,29 @@ class PuffeRL:
         clip_coef = config["clip_coef"]
         vf_clip = config["vf_clip_coef"]
         anneal_beta = b0 + (1 - b0) * a * self.epoch / self.total_epochs
-        self.ratio[:] = 1
-
-        # Compute explained variance before training (pre-update values, ratio=1)
+        # Compute GAE once before training (like SB3)
         shape = self.values.shape
-        initial_advantages = compute_puff_advantage(
+        advantages = compute_puff_advantage(
             self.values,
             self.rewards,
             self.terminals,
-            self.ratio,
+            torch.ones(shape, device=device),
             torch.zeros(shape, device=device),
             config["gamma"],
             config["gae_lambda"],
             config["vtrace_rho_clip"],
             config["vtrace_c_clip"],
         )
+
+        # Explained variance from pre-update values
         y_pred = self.values.flatten()
-        y_true = initial_advantages.flatten() + y_pred
+        y_true = advantages.flatten() + y_pred
         var_y = y_true.var()
         explained_var = torch.nan if var_y == 0 else 1 - (y_true - y_pred).var() / var_y
 
         for mb in range(self.total_minibatches):
             profile("train_misc", epoch, nest=True)
             self.amp_context.__enter__()
-
-            advantages = compute_puff_advantage(
-                self.values,
-                self.rewards,
-                self.terminals,
-                self.ratio,
-                torch.zeros(shape, device=device),
-                config["gamma"],
-                config["gae_lambda"],
-                config["vtrace_rho_clip"],
-                config["vtrace_c_clip"],
-            )
 
             profile("train_copy", epoch)
             adv = advantages.abs().sum(axis=1)
@@ -423,7 +409,6 @@ class PuffeRL:
             mb_rewards = self.rewards[idx]
             mb_terminals = self.terminals[idx]
             mb_truncations = self.truncations[idx]
-            mb_ratio = self.ratio[idx]
             mb_values = self.values[idx]
             mb_returns = advantages[idx] + mb_values
             mb_advantages = advantages[idx]
@@ -445,25 +430,12 @@ class PuffeRL:
             newlogprob = newlogprob.reshape(mb_logprobs.shape)
             logratio = newlogprob - mb_logprobs
             ratio = logratio.exp()
-            self.ratio[idx] = ratio.detach()
 
             with torch.no_grad():
                 old_approx_kl = (-logratio).mean()
                 approx_kl = ((ratio - 1) - logratio).mean()
                 clipfrac = ((ratio - 1.0).abs() > config["clip_coef"]).float().mean()
 
-            adv = advantages[idx]
-            adv = compute_puff_advantage(
-                mb_values,
-                mb_rewards,
-                mb_terminals,
-                ratio,
-                adv,
-                config["gamma"],
-                config["gae_lambda"],
-                config["vtrace_rho_clip"],
-                config["vtrace_c_clip"],
-            )
             adv = mb_advantages
             adv = mb_prio * (adv - adv.mean()) / (adv.std() + 1e-8)
 

--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -376,6 +376,7 @@ class PuffeRL:
         vf_clip = config["vf_clip_coef"]
         anneal_beta = b0 + (1 - b0) * a * self.epoch / self.total_epochs
         self.ratio[:] = 1
+        explained_var = None
 
         for mb in range(self.total_minibatches):
             profile("train_misc", epoch, nest=True)
@@ -394,6 +395,13 @@ class PuffeRL:
                 config["vtrace_rho_clip"],
                 config["vtrace_c_clip"],
             )
+
+            # Capture explained variance on first minibatch (pre-update values, ratio=1)
+            if explained_var is None:
+                y_pred = self.values.flatten()
+                y_true = advantages.flatten() + y_pred
+                var_y = y_true.var()
+                explained_var = torch.nan if var_y == 0 else 1 - (y_true - y_pred).var() / var_y
 
             profile("train_copy", epoch)
             adv = advantages.abs().sum(axis=1)
@@ -493,10 +501,6 @@ class PuffeRL:
         if config["anneal_lr"]:
             self.scheduler.step()
 
-        y_pred = self.values.flatten()
-        y_true = advantages.flatten() + self.values.flatten()
-        var_y = y_true.var()
-        explained_var = torch.nan if var_y == 0 else 1 - (y_true - y_pred).var() / var_y
         losses["explained_variance"] = explained_var.item()
 
         profile.end()

--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -455,9 +455,6 @@ class PuffeRL:
             loss = pg_loss + config["vf_coef"] * v_loss - config["ent_coef"] * entropy_loss
             self.amp_context.__enter__()  # TODO: AMP needs some debugging
 
-            # This breaks vloss clipping?
-            self.values[idx] = newvalue.detach().float()
-
             # Logging
             profile("train_misc", epoch)
             losses["policy_loss"] += pg_loss.item() / self.total_minibatches


### PR DESCRIPTION
## Summary
- `clipSpeed` now takes a configurable max speed parameter
- Classic dynamics clips at `SPEED_LIMIT` (20 m/s) instead of `MAX_SPEED` (100 m/s)
- Jerk dynamics uses `SPEED_LIMIT` constant instead of hardcoded `20.0f`
- Remove overspeed reward penalty — speed is now physically clamped so agents can't overspeed. The penalty was ~1.0/step without dt scaling, dwarfing all other per-step rewards (~0.001-0.01).
- Remove stopped agents from the metrics
- Move advantage computation out of the loop