### PR TITLE
Fix: align C episode length with Python resample timing

### DIFF
--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -3401,7 +3401,7 @@ void c_step(Drive *env) {
             break;
         }
     }
-    int reached_time_limit = (env->timestep + 1) >= env->episode_length;
+    int reached_time_limit = env->timestep >= env->episode_length;
     int reached_early_termination = (!originals_remaining && env->termination_mode == 1);
     if (reached_time_limit || reached_early_termination) {
         for (int i = 0; i < env->active_agent_count; i++) {


### PR DESCRIPTION
## Summary
C checked `(env->timestep + 1) >= env->episode_length`, causing episodes to end after `episode_length - 1` steps. Python checked `tick % resample_frequency == 0` after `resample_frequency` steps. This off-by-one meant C reset one step before Python resampled.

Changed C to `env->timestep >= env->episode_length` so both fire on the same step. Episodes now run for exactly `episode_length` steps.