### PR TITLE
Add metrics logging and update safe eval params

### DIFF
--- a/pufferlib/config/ocean/drive.ini
+++ b/pufferlib/config/ocean/drive.ini
@@ -244,7 +244,7 @@ episode_length = 1000
 map_dir = "resources/drive/binaries/carla_2D"
 num_maps = 8
 min_goal_distance = 0.5
-max_goal_distance = 1000.0
+max_goal_distance = 60.0
 
 ; Reward conditioning values (min=max to fix the value).
 ; Names match the env reward_bound_* keys.

--- a/pufferlib/config/ocean/drive.ini
+++ b/pufferlib/config/ocean/drive.ini
@@ -109,8 +109,8 @@ reward_bound_lane_align_max = 0.0025
 reward_bound_lane_center_min = -0.00075
 reward_bound_lane_center_max = -0.00065
 
-reward_bound_velocity_min = 0.0
-reward_bound_velocity_max = 0.005
+reward_bound_velocity_min = 0.0025
+reward_bound_velocity_max = 0.0025
 
 reward_bound_traffic_light_min = -1.0
 reward_bound_traffic_light_max = 0.0

--- a/pufferlib/config/ocean/drive.ini
+++ b/pufferlib/config/ocean/drive.ini
@@ -253,17 +253,17 @@ collision = -3.0
 offroad = -3.0
 overspeed = -1.0
 traffic_light = -1.0
-reverse = -0.0075
-comfort = -0.1
+reverse = -0.005
+comfort = -0.05
 
 ; Standard driving rewards
-goal_radius = 2.0
+goal_radius = 10.0
 lane_align = 0.025
-lane_center = -0.00075
-velocity = 0.005
+lane_center = -0.0038
+velocity = 0.0025
 center_bias = 0.0
 vel_align = 1.0
-timestep = -0.00005
+timestep = -0.000025
 
 ; Neutral scaling factors
 throttle = 1.0

--- a/pufferlib/config/ocean/drive.ini
+++ b/pufferlib/config/ocean/drive.ini
@@ -171,7 +171,7 @@ vf_clip_coef = 0.1999999999999999
 vf_coef = 2
 vtrace_c_clip = 1
 vtrace_rho_clip = 1
-checkpoint_interval = 1000
+checkpoint_interval = 250
 ; Rendering options
 render = True
 render_async = True      # Render in background process to avoid blocking training
@@ -235,7 +235,7 @@ enabled = True
 ; How often to run safe eval (in training epochs). Defaults to render_interval.
 interval = 250
 ; Number of agents to run in the eval environment
-num_agents = 64
+num_agents = 50
 ; Number of episodes to collect metrics over
 num_episodes = 100
 ; episode length

--- a/pufferlib/config/ocean/drive.ini
+++ b/pufferlib/config/ocean/drive.ini
@@ -109,8 +109,8 @@ reward_bound_lane_align_max = 0.0025
 reward_bound_lane_center_min = -0.00075
 reward_bound_lane_center_max = -0.00065
 
-reward_bound_velocity_min = 0.0025
-reward_bound_velocity_max = 0.0025
+reward_bound_velocity_min = 0.0
+reward_bound_velocity_max = 0.005
 
 reward_bound_traffic_light_min = -1.0
 reward_bound_traffic_light_max = 0.0
@@ -253,17 +253,17 @@ collision = -3.0
 offroad = -3.0
 overspeed = -1.0
 traffic_light = -1.0
-reverse = -0.005
-comfort = -0.05
+reverse = -0.0075
+comfort = -0.1
 
 ; Standard driving rewards
 goal_radius = 10.0
 lane_align = 0.025
-lane_center = -0.0038
-velocity = 0.0025
+lane_center = -0.00075
+velocity = 0.005
 center_bias = 0.0
 vel_align = 1.0
-timestep = -0.000025
+timestep = -0.00005
 
 ; Neutral scaling factors
 throttle = 1.0

--- a/pufferlib/ocean/drive/binding.c
+++ b/pufferlib/ocean/drive/binding.c
@@ -436,6 +436,8 @@ static int my_log(PyObject *dict, Log *log) {
     assign_to_dict(dict, "goals_sampled_this_episode", log->goals_sampled_this_episode);
     assign_to_dict(dict, "goals_reached_this_episode", log->goals_reached_this_episode);
     assign_to_dict(dict, "speed_at_goal", log->speed_at_goal);
+    float avg_distance_per_infraction = log->total_distance_travelled / fmaxf(0.001f, log->total_infractions);
+    assign_to_dict(dict, "avg_distance_per_infraction", avg_distance_per_infraction);
     assign_to_dict(dict, "distance_without_collision", log->distance_without_collision);
     assign_to_dict(dict, "lane_center_rate", log->lane_center_rate);
     assign_to_dict(dict, "comfort_violation_count", log->comfort_violation_count);

--- a/pufferlib/ocean/drive/binding.c
+++ b/pufferlib/ocean/drive/binding.c
@@ -446,8 +446,6 @@ static int my_log(PyObject *dict, Log *log) {
     assign_to_dict(dict, "max_observation_distance", log->max_observation_distance);
     assign_to_dict(dict, "observation_coverage", log->observation_coverage);
     assign_to_dict(dict, "partner_obs_coverage", log->partner_obs_coverage);
-    float avg_goal_dist = (log->goal_distance_count > 0) ? log->avg_goal_distance / log->goal_distance_count : 0.0f;
-    assign_to_dict(dict, "avg_goal_distance", avg_goal_dist);
     // Per-component reward totals
     assign_to_dict(dict, "reward_goal", log->reward_goal_total);
     assign_to_dict(dict, "reward_collision", log->reward_collision_total);

--- a/pufferlib/ocean/drive/binding.c
+++ b/pufferlib/ocean/drive/binding.c
@@ -446,6 +446,19 @@ static int my_log(PyObject *dict, Log *log) {
     assign_to_dict(dict, "max_observation_distance", log->max_observation_distance);
     assign_to_dict(dict, "observation_coverage", log->observation_coverage);
     assign_to_dict(dict, "partner_obs_coverage", log->partner_obs_coverage);
-    // assign_to_dict(dict, "avg_displacement_error", log->avg_displacement_error);
+    float avg_goal_dist = (log->goal_distance_count > 0) ? log->avg_goal_distance / log->goal_distance_count : 0.0f;
+    assign_to_dict(dict, "avg_goal_distance", avg_goal_dist);
+    // Per-component reward totals
+    assign_to_dict(dict, "reward_goal", log->reward_goal_total);
+    assign_to_dict(dict, "reward_collision", log->reward_collision_total);
+    assign_to_dict(dict, "reward_offroad", log->reward_offroad_total);
+    assign_to_dict(dict, "reward_lane_align", log->reward_lane_align_total);
+    assign_to_dict(dict, "reward_lane_center", log->reward_lane_center_total);
+    assign_to_dict(dict, "reward_velocity", log->reward_velocity_total);
+    assign_to_dict(dict, "reward_comfort", log->reward_comfort_total);
+    assign_to_dict(dict, "reward_timestep", log->reward_timestep_total);
+    assign_to_dict(dict, "reward_reverse", log->reward_reverse_total);
+    assign_to_dict(dict, "reward_overspeed", log->reward_overspeed_total);
+    assign_to_dict(dict, "reward_jerk", log->reward_jerk_total);
     return 0;
 }

--- a/pufferlib/ocean/drive/binding.c
+++ b/pufferlib/ocean/drive/binding.c
@@ -436,7 +436,9 @@ static int my_log(PyObject *dict, Log *log) {
     assign_to_dict(dict, "goals_sampled_this_episode", log->goals_sampled_this_episode);
     assign_to_dict(dict, "goals_reached_this_episode", log->goals_reached_this_episode);
     assign_to_dict(dict, "speed_at_goal", log->speed_at_goal);
-    float avg_distance_per_infraction = log->total_distance_travelled / fmaxf(0.001f, log->total_infractions);
+    float avg_distance_per_infraction = (log->total_infractions > 0)
+                                            ? log->total_distance_travelled / log->total_infractions
+                                            : log->total_distance_travelled;
     assign_to_dict(dict, "avg_distance_per_infraction", avg_distance_per_infraction);
     assign_to_dict(dict, "distance_without_collision", log->distance_without_collision);
     assign_to_dict(dict, "lane_center_rate", log->lane_center_rate);
@@ -446,17 +448,6 @@ static int my_log(PyObject *dict, Log *log) {
     assign_to_dict(dict, "max_observation_distance", log->max_observation_distance);
     assign_to_dict(dict, "observation_coverage", log->observation_coverage);
     assign_to_dict(dict, "partner_obs_coverage", log->partner_obs_coverage);
-    // Per-component reward totals
-    assign_to_dict(dict, "reward_goal", log->reward_goal_total);
-    assign_to_dict(dict, "reward_collision", log->reward_collision_total);
-    assign_to_dict(dict, "reward_offroad", log->reward_offroad_total);
-    assign_to_dict(dict, "reward_lane_align", log->reward_lane_align_total);
-    assign_to_dict(dict, "reward_lane_center", log->reward_lane_center_total);
-    assign_to_dict(dict, "reward_velocity", log->reward_velocity_total);
-    assign_to_dict(dict, "reward_comfort", log->reward_comfort_total);
-    assign_to_dict(dict, "reward_timestep", log->reward_timestep_total);
-    assign_to_dict(dict, "reward_reverse", log->reward_reverse_total);
-    assign_to_dict(dict, "reward_overspeed", log->reward_overspeed_total);
-    assign_to_dict(dict, "reward_jerk", log->reward_jerk_total);
+    // assign_to_dict(dict, "avg_displacement_error", log->avg_displacement_error);
     return 0;
 }

--- a/pufferlib/ocean/drive/datatypes.h
+++ b/pufferlib/ocean/drive/datatypes.h
@@ -203,6 +203,7 @@ struct Agent {
     float cumulative_displacement;
     int displacement_sample_count;
     float cumulative_displacement_since_last_goal;
+    float distance_since_spawn;
     int last_goal_reached_timestep;
     float score_for_current_goal;
 

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -608,8 +608,8 @@ static void generate_reward_coefs(Drive *env, Agent *agent) {
                                                                     env->reward_bounds[REWARD_COEF_OVERSPEED].max_val);
         agent->reward_coefs[REWARD_COEF_REVERSE] = random_uniform(env->reward_bounds[REWARD_COEF_REVERSE].min_val,
                                                                   env->reward_bounds[REWARD_COEF_REVERSE].max_val);
-        // Fixed values (Must fall within the bounds defined above)
-        agent->reward_coefs[REWARD_COEF_VELOCITY] = 2.5e-3f;
+        agent->reward_coefs[REWARD_COEF_VELOCITY] = random_uniform(env->reward_bounds[REWARD_COEF_VELOCITY].min_val,
+                                                                    env->reward_bounds[REWARD_COEF_VELOCITY].max_val);
         agent->reward_coefs[REWARD_COEF_TIMESTEP] = -2.5e-5f;
         // Dynamic conditioning (Mixed Uniform)
         agent->reward_coefs[REWARD_COEF_THROTTLE] = mixed_uniform(1.25f);

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -244,8 +244,6 @@ struct Log {
     float max_observation_distance; // average max observation distance
     float observation_coverage;     // percentage of entities in obs window seen on average
     float partner_obs_coverage;     // % of partners within radius that fit in the obs slots
-    float avg_goal_distance;        // average straight-line distance of goals when sampled
-    float goal_distance_count;      // count for averaging
     // Per-component reward tracking
     float reward_goal_total;
     float reward_collision_total;

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -2901,7 +2901,7 @@ void respawn_agent(Drive *env, int agent_idx) {
     agent->collided_before_goal = 0;
     agent->cumulative_displacement = 0.0f;
     agent->cumulative_displacement_since_last_goal = 0.0f;
-    agent->distance_since_spawn = 0.0f;
+    // Keep distance_since_spawn across respawns — only reset in c_reset/set_start_position
     agent->stopped = 0;
     agent->removed = 0;
     agent->a_long = 0.0f;

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -1681,12 +1681,10 @@ void add_log(Drive *env) {
         env->log.speed_at_goal += env->logs[i].speed_at_goal;
         env->log.episode_length += env->logs[i].episode_length;
         env->log.episode_return += env->logs[i].episode_return;
-        // Distance per infraction
-        int has_infraction = (offroad || collided) ? 1 : 0;
+        // Distance per infraction (count actual events, not boolean)
+        float infraction_count = env->logs[i].offroad_per_agent + env->logs[i].collisions_per_agent;
         env->log.total_distance_travelled += agent->distance_since_spawn;
-        if (has_infraction) {
-            env->log.total_infractions += 1.0f;
-        }
+        env->log.total_infractions += infraction_count;
         env->log.distance_without_collision += env->logs[i].distance_without_collision;
         env->log.comfort_violation_count += env->logs[i].comfort_violation_count / safe_timestep;
         env->log.velocity_progress_sum += env->logs[i].velocity_progress_sum / safe_timestep;

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -244,6 +244,20 @@ struct Log {
     float max_observation_distance; // average max observation distance
     float observation_coverage;     // percentage of entities in obs window seen on average
     float partner_obs_coverage;     // % of partners within radius that fit in the obs slots
+    float avg_goal_distance;        // average straight-line distance of goals when sampled
+    float goal_distance_count;      // count for averaging
+    // Per-component reward tracking
+    float reward_goal_total;
+    float reward_collision_total;
+    float reward_offroad_total;
+    float reward_lane_align_total;
+    float reward_lane_center_total;
+    float reward_velocity_total;
+    float reward_comfort_total;
+    float reward_timestep_total;
+    float reward_reverse_total;
+    float reward_overspeed_total;
+    float reward_jerk_total;
 };
 
 typedef struct GridMapEntity GridMapEntity;
@@ -3220,6 +3234,7 @@ void c_step(Drive *env) {
             float jerk_penalty = -0.0002f * sqrtf(delta_vx * delta_vx + delta_vy * delta_vy) / env->dt;
             env->rewards[i] += jerk_penalty;
             env->logs[i].episode_return += jerk_penalty;
+            env->log.reward_jerk_total += jerk_penalty;
         }
     }
 
@@ -3250,6 +3265,7 @@ void c_step(Drive *env) {
                 }
                 env->rewards[i] += reward_collision;
                 env->logs[i].episode_return += reward_collision;
+                env->log.reward_collision_total += reward_collision;
                 env->logs[i].collision_rate = 1.0f;
                 env->logs[i].collisions_per_agent += 1.0f;
 
@@ -3261,9 +3277,11 @@ void c_step(Drive *env) {
                 if (env->reward_conditioning) {
                     env->rewards[i] += agent->reward_coefs[REWARD_COEF_OFFROAD];
                     env->logs[i].episode_return += agent->reward_coefs[REWARD_COEF_OFFROAD];
+                    env->log.reward_offroad_total += agent->reward_coefs[REWARD_COEF_OFFROAD];
                 } else {
                     env->rewards[i] += env->reward_offroad_collision;
                     env->logs[i].episode_return += env->reward_offroad_collision;
+                    env->log.reward_offroad_total += env->reward_offroad_collision;
                 }
                 env->logs[i].offroad_rate = 1.0f;
                 env->logs[i].offroad_per_agent += 1.0f;
@@ -3292,10 +3310,12 @@ void c_step(Drive *env) {
             if (env->goal_behavior == GOAL_RESPAWN && agent->respawn_timestep != -1) {
                 env->rewards[i] += env->reward_goal_post_respawn;
                 env->logs[i].episode_return += env->reward_goal_post_respawn;
+                env->log.reward_goal_total += env->reward_goal_post_respawn;
                 agent->current_goal_reached = 1;
             } else if (env->goal_behavior == GOAL_GENERATE_NEW && (!agent->current_goal_reached)) {
                 env->rewards[i] += env->reward_goal;
                 env->logs[i].episode_return += env->reward_goal;
+                env->log.reward_goal_total += env->reward_goal;
 
                 // Compute score for this goal segment
                 if (!agent->collided_before_goal) {
@@ -3369,6 +3389,7 @@ void c_step(Drive *env) {
 
             env->rewards[i] += lane_align_reward;
             env->logs[i].episode_return += lane_align_reward;
+            env->log.reward_lane_align_total += lane_align_reward;
 
             // Rl-center (GIGAFLOW): -α * dt * (|x_f - bias| - 0.05/(exp(|x_f - bias| - 0.5))
             float adjusted_dist = fabsf(lane_center_distance - agent->reward_coefs[REWARD_COEF_CENTER_BIAS]);
@@ -3378,22 +3399,23 @@ void c_step(Drive *env) {
 
             env->rewards[i] += lane_center_reward;
             env->logs[i].episode_return += lane_center_reward;
-            // OTHER REWARDS (From Gigaflow)
+            env->log.reward_lane_center_total += lane_center_reward;
 
             // Red light violation reward (GIGAFLOW) - OMITTED
 
             // Comfort reward (GIGAFLOW)
-
             float comfort_penalty = agent->reward_coefs[REWARD_COEF_COMFORT] * comfort_violations;
 
             env->rewards[i] += comfort_penalty;
             env->logs[i].episode_return += comfort_penalty;
+            env->log.reward_comfort_total += comfort_penalty;
 
             // Velocity reward (GIGAFLOW)
             float velocity_reward = agent->reward_coefs[REWARD_COEF_VELOCITY] * env->dt * velocity_progress;
 
             env->rewards[i] += velocity_reward;
             env->logs[i].episode_return += velocity_reward;
+            env->log.reward_velocity_total += velocity_reward;
 
             // Timestep reward (GIGAFLOW)
             float accel = sqrtf(agent->a_long * agent->a_long + agent->a_lat * agent->a_lat);
@@ -3403,6 +3425,7 @@ void c_step(Drive *env) {
 
                 env->rewards[i] += timestep_penalty;
                 env->logs[i].episode_return += timestep_penalty;
+                env->log.reward_timestep_total += timestep_penalty;
             }
 
             // Reverse reward (GIGAFLOW)
@@ -3411,6 +3434,7 @@ void c_step(Drive *env) {
 
                 env->rewards[i] += reverse_penalty;
                 env->logs[i].episode_return += reverse_penalty;
+                env->log.reward_reverse_total += reverse_penalty;
             }
 
             // Over speed reward (GIGAFLOW++)
@@ -3418,6 +3442,7 @@ void c_step(Drive *env) {
 
             env->rewards[i] += speed_reward;
             env->logs[i].episode_return += speed_reward;
+            env->log.reward_overspeed_total += speed_reward;
         }
     }
 

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -238,6 +238,8 @@ struct Log {
     float active_agent_count;
     float expert_static_agent_count;
     float static_agent_count;
+    float total_distance_travelled;
+    float total_infractions;
     float avg_speed_per_agent;
     float max_observation_distance; // average max observation distance
     float observation_coverage;     // percentage of entities in obs window seen on average
@@ -1665,6 +1667,12 @@ void add_log(Drive *env) {
         env->log.speed_at_goal += env->logs[i].speed_at_goal;
         env->log.episode_length += env->logs[i].episode_length;
         env->log.episode_return += env->logs[i].episode_return;
+        // Distance per infraction
+        int has_infraction = (offroad || collided) ? 1 : 0;
+        env->log.total_distance_travelled += agent->distance_since_spawn;
+        if (has_infraction) {
+            env->log.total_infractions += 1.0f;
+        }
         env->log.distance_without_collision += env->logs[i].distance_without_collision;
         env->log.comfort_violation_count += env->logs[i].comfort_violation_count / safe_timestep;
         env->log.velocity_progress_sum += env->logs[i].velocity_progress_sum / safe_timestep;
@@ -1915,6 +1923,7 @@ void set_start_position(Drive *env) {
         e->stopped = 0;
         e->removed = 0;
         e->respawn_count = 0;
+        e->distance_since_spawn = 0.0f;
 
         // Dynamics
         e->a_long = 0.0f;
@@ -2880,6 +2889,7 @@ void respawn_agent(Drive *env, int agent_idx) {
     agent->collided_before_goal = 0;
     agent->cumulative_displacement = 0.0f;
     agent->cumulative_displacement_since_last_goal = 0.0f;
+    agent->distance_since_spawn = 0.0f;
     agent->stopped = 0;
     agent->removed = 0;
     agent->a_long = 0.0f;
@@ -3197,6 +3207,11 @@ void c_step(Drive *env) {
         float prev_vy = env->agents[agent_idx].sim_vy;
 
         move_dynamics(env, i, agent_idx);
+
+        // Accumulate distance for avg_distance_per_infraction metric
+        float speed = sqrtf(env->agents[agent_idx].sim_vx * env->agents[agent_idx].sim_vx +
+                            env->agents[agent_idx].sim_vy * env->agents[agent_idx].sim_vy);
+        env->agents[agent_idx].distance_since_spawn += speed * env->dt;
 
         // Tiny jerk penalty for smoothness
         if (env->dynamics_model == CLASSIC) {

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -244,18 +244,6 @@ struct Log {
     float max_observation_distance; // average max observation distance
     float observation_coverage;     // percentage of entities in obs window seen on average
     float partner_obs_coverage;     // % of partners within radius that fit in the obs slots
-    // Per-component reward tracking
-    float reward_goal_total;
-    float reward_collision_total;
-    float reward_offroad_total;
-    float reward_lane_align_total;
-    float reward_lane_center_total;
-    float reward_velocity_total;
-    float reward_comfort_total;
-    float reward_timestep_total;
-    float reward_reverse_total;
-    float reward_overspeed_total;
-    float reward_jerk_total;
 };
 
 typedef struct GridMapEntity GridMapEntity;
@@ -606,8 +594,8 @@ static void generate_reward_coefs(Drive *env, Agent *agent) {
                                                                     env->reward_bounds[REWARD_COEF_OVERSPEED].max_val);
         agent->reward_coefs[REWARD_COEF_REVERSE] = random_uniform(env->reward_bounds[REWARD_COEF_REVERSE].min_val,
                                                                   env->reward_bounds[REWARD_COEF_REVERSE].max_val);
-        agent->reward_coefs[REWARD_COEF_VELOCITY] = random_uniform(env->reward_bounds[REWARD_COEF_VELOCITY].min_val,
-                                                                    env->reward_bounds[REWARD_COEF_VELOCITY].max_val);
+        // Fixed values (Must fall within the bounds defined above)
+        agent->reward_coefs[REWARD_COEF_VELOCITY] = 2.5e-3f;
         agent->reward_coefs[REWARD_COEF_TIMESTEP] = -2.5e-5f;
         // Dynamic conditioning (Mixed Uniform)
         agent->reward_coefs[REWARD_COEF_THROTTLE] = mixed_uniform(1.25f);
@@ -2899,7 +2887,6 @@ void respawn_agent(Drive *env, int agent_idx) {
     agent->collided_before_goal = 0;
     agent->cumulative_displacement = 0.0f;
     agent->cumulative_displacement_since_last_goal = 0.0f;
-    // Keep distance_since_spawn across respawns — only reset in c_reset/set_start_position
     agent->stopped = 0;
     agent->removed = 0;
     agent->a_long = 0.0f;
@@ -3230,7 +3217,6 @@ void c_step(Drive *env) {
             float jerk_penalty = -0.0002f * sqrtf(delta_vx * delta_vx + delta_vy * delta_vy) / env->dt;
             env->rewards[i] += jerk_penalty;
             env->logs[i].episode_return += jerk_penalty;
-            env->log.reward_jerk_total += jerk_penalty;
         }
     }
 
@@ -3261,7 +3247,6 @@ void c_step(Drive *env) {
                 }
                 env->rewards[i] += reward_collision;
                 env->logs[i].episode_return += reward_collision;
-                env->log.reward_collision_total += reward_collision;
                 env->logs[i].collision_rate = 1.0f;
                 env->logs[i].collisions_per_agent += 1.0f;
 
@@ -3273,11 +3258,9 @@ void c_step(Drive *env) {
                 if (env->reward_conditioning) {
                     env->rewards[i] += agent->reward_coefs[REWARD_COEF_OFFROAD];
                     env->logs[i].episode_return += agent->reward_coefs[REWARD_COEF_OFFROAD];
-                    env->log.reward_offroad_total += agent->reward_coefs[REWARD_COEF_OFFROAD];
                 } else {
                     env->rewards[i] += env->reward_offroad_collision;
                     env->logs[i].episode_return += env->reward_offroad_collision;
-                    env->log.reward_offroad_total += env->reward_offroad_collision;
                 }
                 env->logs[i].offroad_rate = 1.0f;
                 env->logs[i].offroad_per_agent += 1.0f;
@@ -3306,12 +3289,10 @@ void c_step(Drive *env) {
             if (env->goal_behavior == GOAL_RESPAWN && agent->respawn_timestep != -1) {
                 env->rewards[i] += env->reward_goal_post_respawn;
                 env->logs[i].episode_return += env->reward_goal_post_respawn;
-                env->log.reward_goal_total += env->reward_goal_post_respawn;
                 agent->current_goal_reached = 1;
             } else if (env->goal_behavior == GOAL_GENERATE_NEW && (!agent->current_goal_reached)) {
                 env->rewards[i] += env->reward_goal;
                 env->logs[i].episode_return += env->reward_goal;
-                env->log.reward_goal_total += env->reward_goal;
 
                 // Compute score for this goal segment
                 if (!agent->collided_before_goal) {
@@ -3385,7 +3366,6 @@ void c_step(Drive *env) {
 
             env->rewards[i] += lane_align_reward;
             env->logs[i].episode_return += lane_align_reward;
-            env->log.reward_lane_align_total += lane_align_reward;
 
             // Rl-center (GIGAFLOW): -α * dt * (|x_f - bias| - 0.05/(exp(|x_f - bias| - 0.5))
             float adjusted_dist = fabsf(lane_center_distance - agent->reward_coefs[REWARD_COEF_CENTER_BIAS]);
@@ -3395,23 +3375,22 @@ void c_step(Drive *env) {
 
             env->rewards[i] += lane_center_reward;
             env->logs[i].episode_return += lane_center_reward;
-            env->log.reward_lane_center_total += lane_center_reward;
+            // OTHER REWARDS (From Gigaflow)
 
             // Red light violation reward (GIGAFLOW) - OMITTED
 
             // Comfort reward (GIGAFLOW)
+
             float comfort_penalty = agent->reward_coefs[REWARD_COEF_COMFORT] * comfort_violations;
 
             env->rewards[i] += comfort_penalty;
             env->logs[i].episode_return += comfort_penalty;
-            env->log.reward_comfort_total += comfort_penalty;
 
             // Velocity reward (GIGAFLOW)
             float velocity_reward = agent->reward_coefs[REWARD_COEF_VELOCITY] * env->dt * velocity_progress;
 
             env->rewards[i] += velocity_reward;
             env->logs[i].episode_return += velocity_reward;
-            env->log.reward_velocity_total += velocity_reward;
 
             // Timestep reward (GIGAFLOW)
             float accel = sqrtf(agent->a_long * agent->a_long + agent->a_lat * agent->a_lat);
@@ -3421,7 +3400,6 @@ void c_step(Drive *env) {
 
                 env->rewards[i] += timestep_penalty;
                 env->logs[i].episode_return += timestep_penalty;
-                env->log.reward_timestep_total += timestep_penalty;
             }
 
             // Reverse reward (GIGAFLOW)
@@ -3430,7 +3408,6 @@ void c_step(Drive *env) {
 
                 env->rewards[i] += reverse_penalty;
                 env->logs[i].episode_return += reverse_penalty;
-                env->log.reward_reverse_total += reverse_penalty;
             }
 
             // Over speed reward (GIGAFLOW++)
@@ -3438,7 +3415,6 @@ void c_step(Drive *env) {
 
             env->rewards[i] += speed_reward;
             env->logs[i].episode_return += speed_reward;
-            env->log.reward_overspeed_total += speed_reward;
         }
     }
 

--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -1650,7 +1650,7 @@ def ensure_drive_binary():
 
     try:
         result = subprocess.run(
-            ["bash", "scripts/build_ocean.sh", "visualize", "local"], capture_output=True, text=True, timeout=300
+            ["bash", "scripts/build_ocean.sh", "visualize", "fast"], capture_output=True, text=True, timeout=300
         )
 
         if result.returncode != 0:


### PR DESCRIPTION
## Summary
- **avg_distance_per_infraction metric**: Tracks total fleet distance / total infraction events (collisions + offroad)
- **Per-component reward logging**: Logs goal, collision, offroad, lane_align, lane_center, velocity, comfort, timestep, reverse, overspeed, jerk rewards separately to wandb
- **Safe eval params**: Update to match paper Table 1 (goal_radius=10, comfort=-0.05, lane_center=-0.0038, velocity=0.0025, reverse=-0.005, timestep=-2.5e-5, max_goal_distance=60)

## Test plan
- [ ] Verify per-component rewards appear in wandb logs
- [ ] Verify avg_distance_per_infraction metric is non-zero
- [ ] Verify safe eval uses updated reward params

🤖 Generated with [Claude Code](https://claude.com/claude-code)