### PR TITLE
Fix: set expert agent velocities from log data

### DIFF
--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -2924,6 +2924,8 @@ void move_expert(Drive *env, float *actions, int agent_idx) {
     agent->sim_heading = agent->log_heading[t];
     agent->heading_x = cosf(agent->sim_heading);
     agent->heading_y = sinf(agent->sim_heading);
+    agent->sim_vx = agent->log_velocity_x[t];
+    agent->sim_vy = agent->log_velocity_y[t];
 }
 
 void move_dynamics(Drive *env, int action_idx, int agent_idx) {


### PR DESCRIPTION
## Summary
- `move_expert` set position and heading from log data but never updated `sim_vx`/`sim_vy`, leaving velocities stale
- This affected speed-based metrics, collision penalties that scale with speed, distance accumulation, and partner velocity observations

## Test plan
- [ ] Verify expert agents have correct velocities in log replay mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)