### PR TITLE
Unify rollout loop across Evaluator, render(), and SafeEvaluator

### DIFF
--- a/pufferlib/ocean/benchmark/evaluator.py
+++ b/pufferlib/ocean/benchmark/evaluator.py
@@ -1000,57 +1000,29 @@ class Evaluator:
     def _run_rollout(self, policy, env, render_env_idx=None, per_env_logs=False, view_mode=None, view_suffix=""):
         """Run a single rollout. If render_env_idx is not None, render that env.
 
-        view_mode: RenderView enum to use when rendering (defaults to FULL_SIM_STATE).
-        view_suffix: appended to the mp4 filename when logging multiple views, e.g. "_bev".
+        Thin wrapper around :func:`pufferlib.ocean.drive.rollout.rollout_loop`.
+        The shared helper owns the actual forward-sample-step-break loop; this
+        method just builds the RenderContext when rendering is requested.
         """
         from pufferlib.ocean.drive.drive import RenderView
+        from pufferlib.ocean.drive.rollout import RenderContext, rollout_loop
 
-        driver = env.driver_env
-        num_agents = env.observation_space.shape[0]
-        device = self.configs["train"]["device"]
-        if view_mode is None:
-            view_mode = RenderView.FULL_SIM_STATE
-
-        # Set video filename suffix in C before the first render call of this rollout.
-        # This ensures each view produces a uniquely named mp4 (e.g. {scenario_id}_bev.mp4).
-        if render_env_idx is not None and view_suffix:
-            driver.set_video_suffix(view_suffix, env_id=render_env_idx)
-
-        # Reset environment
-        obs, info = env.reset()
-
-        # Initialize RNN state if needed
-        state = {}
-        if self.configs["train"]["use_rnn"]:
-            state = dict(
-                lstm_h=torch.zeros(num_agents, policy.hidden_size, device=device),
-                lstm_c=torch.zeros(num_agents, policy.hidden_size, device=device),
+        render_ctx = None
+        if render_env_idx is not None:
+            render_ctx = RenderContext(
+                view_mode=view_mode if view_mode is not None else RenderView.FULL_SIM_STATE,
+                env_id=render_env_idx,
+                video_suffix=view_suffix,
             )
 
-        info_list = []
-        episode_length = env.driver_env.episode_length
-        for time_idx in range(episode_length):
-            if render_env_idx is not None:
-                driver.render(view_mode=view_mode, env_id=render_env_idx)
-
-            # Get action from policy
-            with torch.no_grad():
-                ob_tensor = torch.as_tensor(obs).to(device)
-                logits, value = policy.forward_eval(ob_tensor, state)
-                action, logprob, _ = pufferlib.pytorch.sample_logits(logits)
-                action_np = action.cpu().numpy().reshape(env.action_space.shape)
-
-            # Clip continuous actions to valid range
-            if isinstance(logits, torch.distributions.Normal):
-                action_np = np.clip(action_np, env.action_space.low, env.action_space.high)
-
-            # Step environment
-            obs, rewards, dones, truncs, info_list = env.step(action_np, per_env_logs=per_env_logs)
-
-            if truncs.all():
-                break
-
-        return info_list
+        return rollout_loop(
+            policy=policy,
+            env=env,
+            device=self.configs["train"]["device"],
+            use_rnn=self.configs["train"]["use_rnn"],
+            render_ctx=render_ctx,
+            per_env_logs=per_env_logs,
+        )
 
     def log_videos(self, eval_mode, epoch):
         """Log all mp4s in local path to wandb after env close has flushed ffmpeg pipes."""
@@ -1165,6 +1137,13 @@ class SafeEvaluator:
             )
         self.render_view_modes = _VIEW_MODE_MAP.get(view_mode_str, [RenderView.FULL_SIM_STATE])
 
+        # Authoritative RNN flag comes from the training config. PuffeRL passes
+        # its flattened train_config as full_config, where args["train"]["use_rnn"]
+        # (set in load_config from rnn_name) lives at the top level. We previously
+        # used hasattr(policy, "hidden_size") as a proxy, which is fragile because
+        # non-RNN policies can also expose hidden_size.
+        self.use_rnn = bool(full_config.get("use_rnn", False)) if full_config is not None else False
+
     def _build_eval_env_config(self):
         """Build env config with safe reward conditioning values applied.
 
@@ -1227,7 +1206,7 @@ class SafeEvaluator:
 
         policy.eval()
         num_agents = vecenv.observation_space.shape[0]
-        use_rnn = hasattr(policy, "hidden_size")
+        use_rnn = self.use_rnn
 
         ob, _ = vecenv.reset()
         state = {}
@@ -1281,10 +1260,13 @@ class SafeEvaluator:
 
         Always renders env index 0 (first env). Uses [eval].render_view_mode.
         Produces .mp4 files on disk (flushed when each render_env is closed).
+
+        Thin wrapper around :func:`pufferlib.ocean.drive.rollout.rollout_loop`.
         """
-        from pufferlib.ocean.drive.drive import RenderView
-        from pufferlib.pufferl import load_env
         import copy
+
+        from pufferlib.pufferl import load_env
+        from pufferlib.ocean.drive.rollout import RenderContext, rollout_loop
 
         multi_view = len(self.render_view_modes) > 1
         for view_mode in self.render_view_modes:
@@ -1292,31 +1274,19 @@ class SafeEvaluator:
             render_cfg = copy.deepcopy(eval_config)
             render_cfg["env"]["render_mode"] = 1
             render_env = load_env(self.env_name, render_cfg)
-            driver = render_env.driver_env
-            if suffix:
-                driver.set_video_suffix(suffix, env_id=0)
             try:
-                num_agents = render_env.observation_space.shape[0]
-                use_rnn = hasattr(policy, "hidden_size")
-                ob, _ = render_env.reset()
-                state = {}
-                if use_rnn:
-                    state = dict(
-                        lstm_h=torch.zeros(num_agents, policy.hidden_size, device=self.device),
-                        lstm_c=torch.zeros(num_agents, policy.hidden_size, device=self.device),
-                    )
-                for _ in range(self.episode_length):
-                    driver.render(view_mode=view_mode, env_id=0)
-                    with torch.no_grad():
-                        ob_t = torch.as_tensor(ob).to(self.device)
-                        logits, value = policy.forward_eval(ob_t, state)
-                        action, _, _ = pufferlib.pytorch.sample_logits(logits)
-                        action_np = action.cpu().numpy().reshape(render_env.action_space.shape)
-                    if isinstance(logits, torch.distributions.Normal):
-                        action_np = np.clip(action_np, render_env.action_space.low, render_env.action_space.high)
-                    ob, _, _, truncs, _ = render_env.step(action_np)
-                    if truncs.all():
-                        break
+                rollout_loop(
+                    policy=policy,
+                    env=render_env,
+                    device=self.device,
+                    use_rnn=self.use_rnn,
+                    max_steps=self.episode_length,
+                    render_ctx=RenderContext(
+                        view_mode=view_mode,
+                        env_id=0,
+                        video_suffix=suffix,
+                    ),
+                )
             finally:
                 render_env.close()
 

--- a/pufferlib/ocean/benchmark/evaluator.py
+++ b/pufferlib/ocean/benchmark/evaluator.py
@@ -1137,10 +1137,11 @@ class SafeEvaluator:
             )
         self.render_view_modes = _VIEW_MODE_MAP.get(view_mode_str, [RenderView.FULL_SIM_STATE])
 
-        # Authoritative RNN flag comes from the training config. PuffeRL passes
-        # its flattened train_config as full_config, where args["train"]["use_rnn"]
-        # (set in load_config from rnn_name) lives at the top level. We previously
-        # used hasattr(policy, "hidden_size") as a proxy, which is fragile because
+        # Authoritative RNN flag comes from `full_config`, which PuffeRL passes
+        # in flattened form for this evaluator. In this code path the flag
+        # lives at `full_config["use_rnn"]` (no `train` nesting) — it is set
+        # during config loading from `rnn_name`. We previously used
+        # hasattr(policy, "hidden_size") as a proxy, which is fragile because
         # non-RNN policies can also expose hidden_size.
         self.use_rnn = bool(full_config.get("use_rnn", False)) if full_config is not None else False
 

--- a/pufferlib/ocean/drive/rollout.py
+++ b/pufferlib/ocean/drive/rollout.py
@@ -1,0 +1,129 @@
+"""Shared rollout loop for Drive evaluation and rendering.
+
+Single source of truth for the forward-sample-step-break cycle. Used by:
+  - ``Evaluator._run_rollout`` — periodic training eval, optional env-selective render
+  - ``pufferl.render`` — offline batch rendering, one video per map
+  - ``SafeEvaluator.render`` — safe-eval-time rendering
+
+Extracting this eliminates three hand-maintained copies of the same loop that
+had drifted in subtle ways:
+  * ``render_one_map`` was missing continuous-action clipping
+  * ``render_one_map`` used ``done.all() or truncated.all()`` while the others used ``truncs.all()``
+  * ``render_one_map`` inferred video filenames via a ``glob`` diff instead of calling ``set_video_suffix``
+  * ``SafeEvaluator`` was using ``hasattr(policy, "hidden_size")`` as a proxy
+    for "is an RNN policy", which is fragile (many non-RNN policies also
+    expose ``hidden_size``). Callers now pass the authoritative ``use_rnn``
+    flag from the training config.
+
+Callers pass a ``RenderContext`` to turn on rendering; pass ``None`` for a pure
+stats rollout.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+import torch
+
+import pufferlib.pytorch
+
+
+@dataclass
+class RenderContext:
+    """Enables rendering inside :func:`rollout_loop`.
+
+    Attributes:
+        view_mode: ``RenderView`` enum value passed to ``driver.render``.
+        env_id: which sub-env in the vecenv to record from (default 0).
+        draw_traces: whether the C renderer should overlay trajectory traces.
+        video_suffix: appended to the mp4 filename; applied once before the
+            first render via ``set_video_suffix`` so multi-view rollouts don't
+            collide on output paths.
+    """
+
+    view_mode: int
+    env_id: int = 0
+    draw_traces: bool = True
+    video_suffix: str = ""
+
+
+def rollout_loop(
+    policy,
+    env,
+    device,
+    use_rnn: bool,
+    max_steps: Optional[int] = None,
+    render_ctx: Optional[RenderContext] = None,
+    per_env_logs: bool = False,
+):
+    """Run a single policy rollout in a Drive vecenv.
+
+    Args:
+        policy: the policy to run. Caller is responsible for calling ``.eval()``.
+        env: a ``PufferEnv``-compatible vecenv wrapping one or more Drive sub-envs.
+        device: torch device for observation / state tensors.
+        use_rnn: whether to allocate and carry LSTM hidden state.
+        max_steps: loop iteration cap. Defaults to ``env.driver_env.episode_length``.
+        render_ctx: if set, render the specified env/view every step before
+            sampling actions. Filename suffix is applied via ``set_video_suffix``.
+        per_env_logs: passed through to ``env.step`` so callers can get
+            unaggregated per-env logs instead of the default ``vec_log`` aggregate.
+
+    Returns:
+        The last ``info`` returned by ``env.step``. For stats rollouts this is
+        the aggregated ``vec_log`` dict or per-env logs list; for render
+        rollouts callers typically ignore it.
+    """
+    driver = env.driver_env
+    num_agents = env.observation_space.shape[0]
+
+    # Set the video filename suffix before the first render call so the C
+    # binding names the mp4 correctly up front (e.g. {scenario_id}_bev.mp4).
+    # Without this, callers have to glob-diff cwd and rename post hoc.
+    if render_ctx is not None and render_ctx.video_suffix:
+        driver.set_video_suffix(render_ctx.video_suffix, env_id=render_ctx.env_id)
+
+    obs, _ = env.reset()
+
+    state = {}
+    if use_rnn:
+        state = dict(
+            lstm_h=torch.zeros(num_agents, policy.hidden_size, device=device),
+            lstm_c=torch.zeros(num_agents, policy.hidden_size, device=device),
+        )
+
+    if max_steps is None:
+        max_steps = driver.episode_length
+
+    info = []
+    for _ in range(max_steps):
+        # Render BEFORE the step so each frame shows the state the policy was
+        # conditioned on.
+        if render_ctx is not None:
+            driver.render(
+                view_mode=render_ctx.view_mode,
+                draw_traces=render_ctx.draw_traces,
+                env_id=render_ctx.env_id,
+            )
+
+        with torch.no_grad():
+            ob_t = torch.as_tensor(obs).to(device)
+            logits, _ = policy.forward_eval(ob_t, state)
+            action, _, _ = pufferlib.pytorch.sample_logits(logits)
+            action_np = action.cpu().numpy().reshape(env.action_space.shape)
+
+        # Clip continuous actions to the valid range. This was previously
+        # missing in render_one_map, so continuous policies could emit OOB
+        # actions during offline rendering.
+        if isinstance(logits, torch.distributions.Normal):
+            action_np = np.clip(action_np, env.action_space.low, env.action_space.high)
+
+        obs, _, _, truncs, info = env.step(action_np, per_env_logs=per_env_logs)
+
+        # truncs.all() is set in the single c_step where the env auto-resets
+        # (time limit or early termination). Breaking here exits the loop
+        # exactly when the current episode wraps.
+        if truncs.all():
+            break
+
+    return info

--- a/pufferlib/ocean/drive/rollout.py
+++ b/pufferlib/ocean/drive/rollout.py
@@ -77,10 +77,13 @@ def rollout_loop(
     driver = env.driver_env
     num_agents = env.observation_space.shape[0]
 
-    # Set the video filename suffix before the first render call so the C
-    # binding names the mp4 correctly up front (e.g. {scenario_id}_bev.mp4).
-    # Without this, callers have to glob-diff cwd and rename post hoc.
-    if render_ctx is not None and render_ctx.video_suffix:
+    # Set (or clear) the video filename suffix before the first render call so
+    # the C binding names the mp4 correctly up front (e.g. {scenario_id}_bev.mp4).
+    # Without this, callers have to glob-diff cwd and rename post hoc. We call
+    # this unconditionally whenever render_ctx is provided — including the
+    # empty-string case — so reused envs can't leak a stale suffix from a
+    # prior rollout into the default-filename path.
+    if render_ctx is not None:
         driver.set_video_suffix(render_ctx.video_suffix, env_id=render_ctx.env_id)
 
     obs, _ = env.reset()
@@ -118,7 +121,17 @@ def rollout_loop(
         if isinstance(logits, torch.distributions.Normal):
             action_np = np.clip(action_np, env.action_space.low, env.action_space.high)
 
-        obs, _, _, truncs, info = env.step(action_np, per_env_logs=per_env_logs)
+        # Only pass per_env_logs when the caller explicitly asked for it.
+        # pufferlib.vector.Serial.step == pufferlib.vector.step, whose
+        # signature is (vecenv, actions) with no kwargs — passing per_env_logs
+        # unconditionally would raise TypeError on render_one_map's Serial
+        # backend. The per_env_logs=True path is only exercised by the
+        # Evaluator with a native PufferEnv backend where Drive.step does
+        # accept the kwarg.
+        if per_env_logs:
+            obs, _, _, truncs, info = env.step(action_np, per_env_logs=True)
+        else:
+            obs, _, _, truncs, info = env.step(action_np)
 
         # truncs.all() is set in the single c_step where the env auto-resets
         # (time limit or early termination). Breaking here exits the loop

--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -1626,13 +1626,17 @@ def render(env_name, args=None):
     def render_one_map(map_path):
         """Render a single map file in one or more view modes, moving resulting mp4(s) to output_dir.
 
-        Each view mode runs a separate rollout so that each gets its own ffmpeg
-        pipe and output file.  Output files are named {scenario_id}_{view}.mp4
-        when multiple views are requested, or {scenario_id}.mp4 for a single view.
+        Each view mode runs a separate rollout via the shared
+        :func:`pufferlib.ocean.drive.rollout.rollout_loop` helper, so that each
+        gets its own ffmpeg pipe and output file. Output files are named
+        ``{scenario_id}_{view}.mp4`` for multi-view runs or ``{scenario_id}.mp4``
+        for single-view runs — the C binding writes the correct name directly
+        via ``set_video_suffix``, no post-hoc renaming required.
         """
+        from pufferlib.ocean.drive.rollout import RenderContext, rollout_loop
+
         map_name = os.path.splitext(os.path.basename(map_path))[0]
 
-        # View-mode suffix labels used in output filenames
         _VIEW_SUFFIX = {
             RenderView.FULL_SIM_STATE: "sim_state",
             RenderView.AGENT_PERSP: "persp",
@@ -1649,7 +1653,7 @@ def render(env_name, args=None):
                     **args["env"],
                     "num_maps": 1,
                     "map_dir": tmp_map_dir,
-                    "render_mode": 1,  # headless ffmpeg → writes {scenario_id}.mp4 in cwd
+                    "render_mode": 1,  # headless ffmpeg → writes {scenario_id}[suffix].mp4 in cwd
                 }
                 if render_init_mode is not None:
                     env_overrides["init_mode"] = render_init_mode
@@ -1666,46 +1670,38 @@ def render(env_name, args=None):
                 policy = load_policy(map_args, env, env_name)
                 policy.eval()
 
-                ob, _ = env.reset()
-                driver = env.driver_env
-
-                state = {}
-                if map_args["train"]["use_rnn"]:
-                    n = env.agents_per_batch if hasattr(env, "agents_per_batch") else ob.shape[0]
-                    state = dict(
-                        lstm_h=torch.zeros(n, policy.hidden_size, device=device),
-                        lstm_c=torch.zeros(n, policy.hidden_size, device=device),
-                    )
-
-                # Remove any stale mp4 from a previous run
-                stale = os.path.join(os.getcwd(), f"{map_name}.mp4")
+                # Clean up any stale mp4 from a previous run and snapshot cwd so
+                # we can find the new file(s) created during this rollout.
+                suffix = f"_{_VIEW_SUFFIX[view_mode]}" if multi else ""
+                stale = os.path.join(os.getcwd(), f"{map_name}{suffix}.mp4")
                 if os.path.exists(stale):
                     os.remove(stale)
-
                 before = set(glob.glob(os.path.join(os.getcwd(), "*.mp4")))
 
-                for _ in range(max_frames):
-                    driver.render(view_mode=view_mode, draw_traces=draw_traces)
-
-                    with torch.no_grad():
-                        ob_t = torch.as_tensor(ob).to(device)
-                        logits, _ = policy.forward_eval(ob_t, state)
-                        action, _, _ = pufferlib.pytorch.sample_logits(logits)
-                        action = action.cpu().numpy().reshape(env.action_space.shape)
-
-                    ob, _, done, truncated, _ = env.step(action)
-                    if done.all() or truncated.all():
-                        break
+                rollout_loop(
+                    policy=policy,
+                    env=env,
+                    device=device,
+                    use_rnn=map_args["train"]["use_rnn"],
+                    max_steps=max_frames,
+                    render_ctx=RenderContext(
+                        view_mode=view_mode,
+                        env_id=0,
+                        draw_traces=draw_traces,
+                        video_suffix=suffix,
+                    ),
+                )
 
                 env.close()
 
+                # Move the newly produced mp4(s) to output_dir. With
+                # set_video_suffix, filenames are correct by construction — no
+                # post-hoc renaming needed.
                 after = set(glob.glob(os.path.join(os.getcwd(), "*.mp4")))
                 new_mp4s = after - before
                 if new_mp4s:
                     for src in sorted(new_mp4s):
-                        base = os.path.splitext(os.path.basename(src))[0]
-                        suffix = f"_{_VIEW_SUFFIX[view_mode]}" if multi else ""
-                        dst = os.path.join(output_dir, f"{base}{suffix}.mp4")
+                        dst = os.path.join(output_dir, os.path.basename(src))
                         shutil.move(src, dst)
                         print(f"  Saved {dst}")
                 else:


### PR DESCRIPTION
## Summary

- Extracts the shared forward-sample-step-break loop into `pufferlib/ocean/drive/rollout.py` (new module)
- `Evaluator._run_rollout`, `pufferl.render_one_map`, and `SafeEvaluator.render` all become thin wrappers around `rollout_loop`
- `SafeEvaluator.evaluate` and `SafeEvaluator.render` stop using the fragile `hasattr(policy, 'hidden_size')` check in favor of the authoritative `use_rnn` flag from `full_config`

## Motivation

The three rollout sites were 80% identical but had drifted in subtle ways:

| Issue | `Evaluator._run_rollout` | `pufferl.render_one_map` | `SafeEvaluator.render` |
|---|---|---|---|
| Continuous action clipping | ✅ | ❌ (latent bug) | ✅ |
| Break condition | `truncs.all()` | `done.all() or truncated.all()` | `truncs.all()` |
| Video filename handling | `set_video_suffix` | glob-before/after diff | `set_video_suffix` |
| RNN detection | config (`train.use_rnn`) | config (`train.use_rnn`) | `hasattr(policy, 'hidden_size')` |

All four got fixed / unified as a byproduct of deduplicating the loop.

## Implementation

New `rollout_loop(policy, env, device, use_rnn, max_steps, render_ctx, per_env_logs)` function lives in a new module. A `RenderContext` dataclass toggles rendering and carries view_mode / env_id / draw_traces / video_suffix.

- Pass `render_ctx=None` for pure stats rollouts.
- Pass a `RenderContext` for rendering rollouts — the helper calls `set_video_suffix` once before the first render so the C binding writes the correct mp4 name directly.
- `max_steps` defaults to `env.driver_env.episode_length`; callers with a fixed cap (`render_one_map`, `SafeEvaluator.render`) override explicitly.
- Break condition is `truncs.all()` (matches Evaluator's prior behavior, which was the majority). In Drive, `truncs.all()` is set in the single `c_step` where the env auto-resets, so it's the natural end-of-episode signal. Previously `render_one_map` broke on `done.all() or truncated.all()`, which cut videos one step early in any config where `done` fires per-agent for collision/offroad transitions.

## Callsites

**`Evaluator._run_rollout`** — now 26 lines (was 54). Builds a `RenderContext` when `render_env_idx` is set.

**`pufferl.render_one_map`** — now uses `set_video_suffix` directly, eliminating the stale-mp4-cleanup / glob-before-after / post-hoc-rename dance. The C binding names files correctly by construction.

**`SafeEvaluator.render`** — trivial wrapper. Plus, `SafeEvaluator` now reads `use_rnn` from `full_config` at init time (flat train_config passed by `PuffeRL._run_safe_eval`), replacing `hasattr(policy, 'hidden_size')` in both `evaluate()` and `render()`.

## Net diff

~34 lines deleted overall. +90 in the new module, -124 across the three callsites.

## Test plan

- [ ] Run a short training job that triggers `Evaluator.rollout` for both `self_play` and `human_replay` modes — confirm per-env stats collection still works and video filenames match expectations (`{scenario}_sim_state.mp4` etc.)
- [ ] Run `puffer render puffer_drive` on a small `map_dir` with `view_mode = "all"` — confirm three mp4s per map (`_sim_state`, `_persp`, `_bev`) land in `output_dir`
- [ ] Run a short training job with `safe_eval.render_safe_eval = True` — confirm a video is logged to wandb under `render/safe_eval/`