### PR TITLE
GPU-accelerated headless rendering (32x speedup)

### DIFF
--- a/pufferlib/config/ocean/drive.ini
+++ b/pufferlib/config/ocean/drive.ini
@@ -203,6 +203,9 @@ render_view_mode = "all"
 ; If True, render random scenarios. Note: Doing this frequently will slow down the training.
 render_human_replay_eval = False
 render_self_play_eval = True
+; If True, keep eval render mp4s on disk under the repo cwd after each eval cycle
+; instead of deleting them after logging. Handy for local inspection.
+save_render_videos = False
 
 
 ; Number of scenarios to process per batch

--- a/pufferlib/ocean/benchmark/evaluator.py
+++ b/pufferlib/ocean/benchmark/evaluator.py
@@ -868,6 +868,7 @@ class Evaluator:
 
         self.render_sp_rollout = self.configs["eval"]["render_self_play_eval"]
         self.render_hr_rollout = self.configs["eval"]["render_human_replay_eval"]
+        self.save_render_videos = bool(self.configs["eval"].get("save_render_videos", False))
 
         view_mode_str = str(self.configs["eval"].get("render_view_mode", "sim_state")).lower().strip('"').strip("'")
         self.render_view_modes = _VIEW_MODE_MAP.get(view_mode_str, [RenderView.FULL_SIM_STATE])
@@ -1030,9 +1031,10 @@ class Evaluator:
         import glob
 
         if not (self.logger and hasattr(self.logger, "wandb") and self.logger.wandb):
-            # Still clean up even if not logging
-            for p in glob.glob("*.mp4"):
-                os.remove(p)
+            # Still clean up even if not logging — unless the user wants to keep them.
+            if not self.save_render_videos:
+                for p in glob.glob("*.mp4"):
+                    os.remove(p)
             return
 
         import wandb
@@ -1061,9 +1063,10 @@ class Evaluator:
             wandb_key = f"render/{eval_mode}/{view_tag}" if view_tag else f"render/{eval_mode}"
             self.logger.wandb.log({wandb_key: wandb.Video(p, format="mp4", caption=caption)})
 
-        # Clean up
-        for p in video_files:
-            os.remove(p)
+        # Clean up (skip if user wants to keep videos on disk)
+        if not self.save_render_videos:
+            for p in video_files:
+                os.remove(p)
 
     def log_stats(self):
         if not (self.logger and hasattr(self.logger, "wandb") and self.logger.wandb):
@@ -1136,6 +1139,9 @@ class SafeEvaluator:
                 str(full_config.get("eval", {}).get("render_view_mode", "sim_state")).lower().strip('"').strip("'")
             )
         self.render_view_modes = _VIEW_MODE_MAP.get(view_mode_str, [RenderView.FULL_SIM_STATE])
+        self.save_render_videos = (
+            bool(full_config.get("eval", {}).get("save_render_videos", False)) if full_config is not None else False
+        )
 
         # Authoritative RNN flag comes from `full_config`, which PuffeRL passes
         # in flattened form for this evaluator. In this code path the flag
@@ -1297,8 +1303,9 @@ class SafeEvaluator:
         import glob
 
         if not (self.logger and hasattr(self.logger, "wandb") and self.logger.wandb):
-            for p in glob.glob("*.mp4"):
-                os.remove(p)
+            if not self.save_render_videos:
+                for p in glob.glob("*.mp4"):
+                    os.remove(p)
             return
 
         import wandb
@@ -1323,8 +1330,9 @@ class SafeEvaluator:
             wandb_key = f"render/safe_eval/{view_tag}" if view_tag else "render/safe_eval"
             self.logger.wandb.log({wandb_key: wandb.Video(p, format="mp4", caption=caption)})
 
-        for p in video_files:
-            os.remove(p)
+        if not self.save_render_videos:
+            for p in video_files:
+                os.remove(p)
 
     def log_stats(self, global_step=None):
         """Log collected metrics to wandb."""

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -4590,25 +4590,38 @@ void c_render(Drive *env, int view_mode, int draw_traces) {
             BeginMode3D(camera);
 
             if (draw_traces) {
+                // Points are ~500x cheaper than spheres (2 verts vs ~500 tris) — lets us
+                // draw full trajectory breadcrumbs for every agent every frame.
                 for (int i = 0; i < env->active_agent_count; i++) {
                     int idx = env->active_agent_indices[i];
-                    for (int t = env->init_steps; t < env->episode_length; t++) {
+                    // Bound by the agent's actual trajectory length. Spawned agents
+                    // (init_variable_agent_number) have trajectory_length == 1, so
+                    // iterating up to episode_length would be an OOB read.
+                    int t_end = env->episode_length;
+                    if (t_end > env->agents[idx].trajectory_length)
+                        t_end = env->agents[idx].trajectory_length;
+                    for (int t = env->init_steps; t < t_end; t++) {
                         Color agent_color = LIGHTBLUE;
                         if (env->agents[idx].type == PEDESTRIAN)
                             agent_color = LIGHT_ORANGE;
                         else if (env->agents[idx].type == CYCLIST)
                             agent_color = LIGHT_PURPLE;
-                        DrawSphere((Vector3){env->agents[idx].log_trajectory_x[t], env->agents[idx].log_trajectory_y[t],
-                                             env->agents[idx].log_trajectory_z[t]},
-                                   0.15f, agent_color);
+                        DrawPoint3D((Vector3){env->agents[idx].log_trajectory_x[t],
+                                              env->agents[idx].log_trajectory_y[t],
+                                              env->agents[idx].log_trajectory_z[t]},
+                                    agent_color);
                     }
                 }
                 for (int i = 0; i < env->expert_static_agent_count; i++) {
                     int idx = env->expert_static_agent_indices[i];
-                    for (int t = env->init_steps; t < env->episode_length; t++) {
-                        DrawSphere((Vector3){env->agents[idx].log_trajectory_x[t], env->agents[idx].log_trajectory_y[t],
-                                             env->agents[idx].log_trajectory_z[t]},
-                                   0.15f, EXPERT_REPLAY);
+                    int t_end = env->episode_length;
+                    if (t_end > env->agents[idx].trajectory_length)
+                        t_end = env->agents[idx].trajectory_length;
+                    for (int t = env->init_steps; t < t_end; t++) {
+                        DrawPoint3D((Vector3){env->agents[idx].log_trajectory_x[t],
+                                              env->agents[idx].log_trajectory_y[t],
+                                              env->agents[idx].log_trajectory_z[t]},
+                                    EXPERT_REPLAY);
                     }
                 }
             }
@@ -4848,12 +4861,16 @@ void close_client(Client *client) {
         waitpid(client->recorder_pid, NULL, 0);
     }
 
+    // Always unload models — they hold GPU-side VBOs/VAOs/textures tracked by
+    // rlgl. Leaking them corrupts rlgl's internal bookkeeping and causes segfaults
+    // when the next make_client loads fresh models on the same GL context.
+    for (int i = 0; i < 6; i++)
+        UnloadModel(client->cars[i]);
+    UnloadModel(client->cyclist);
+    UnloadModel(client->pedestrian);
+
     if (!client->egl_mode) {
-        // Non-EGL: full cleanup (window mode or Xvfb fallback)
-        for (int i = 0; i < 6; i++)
-            UnloadModel(client->cars[i]);
-        UnloadModel(client->cyclist);
-        UnloadModel(client->pedestrian);
+        // Non-EGL: also tear down window/Xvfb
         CloseWindow();
         if (client->xvfb_pid > 0) {
             kill(client->xvfb_pid, SIGTERM);
@@ -4867,8 +4884,6 @@ void close_client(Client *client) {
         }
     }
     // EGL mode: don't touch GLFW/Xvfb/EGL — they persist across render envs.
-    // EGL surface+context cleanup happens at the START of the next make_client
-    // (or never, if this is the last render env — process exit handles it).
 
     free(client);
 }

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -1,4 +1,5 @@
 #define _GNU_SOURCE
+#include <errno.h>
 #include <fcntl.h>
 #include <signal.h>
 #include <sys/types.h>
@@ -3724,6 +3725,8 @@ Client *make_client(Drive *env) {
             _exit(1);
         }
         close(client->recorder_pipefd[0]);
+        fprintf(stderr, "[drive] ffmpeg forked: pid=%d pipe_write_fd=%d size=%s file=%s egl=%d\n", client->recorder_pid,
+                client->recorder_pipefd[1], size_str, filename, client->egl_mode);
 
         // Increase pipe buffer to reduce write() blocking on large frames
 #ifdef __linux__

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -3,6 +3,7 @@
 #include <fcntl.h>
 #include <signal.h>
 #include <sys/types.h>
+#include <sys/uio.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdint.h>
@@ -4730,16 +4731,46 @@ void c_render(Drive *env, int view_mode, int draw_traces) {
             if (profile_enabled)
                 t_read_end = GetTime();
 
-            // Map previous PBO and write to pipe (skip frame 0 — no previous data)
+            // Map previous PBO and write to pipe (skip frame 0 — no previous data).
+            // glReadPixels returns rows bottom-up (GL convention: origin at
+            // bottom-left), but ffmpeg expects top-down. We write the rows in
+            // reverse order via writev so each frame takes one syscall and no
+            // 19 MB memcpy — iovecs can point directly into the mapped PBO.
             if (client->pbo_frame_count > 0) {
                 glBindBuffer(GL_PIXEL_PACK_BUFFER, client->pbo[prev]);
                 unsigned char *ptr = (unsigned char *)glMapBuffer(GL_PIXEL_PACK_BUFFER, GL_READ_ONLY);
                 if (ptr) {
-                    ssize_t written = write(client->recorder_pipefd[1], ptr, frame_bytes);
-                    if (client->pbo_frame_count <= 3 || written != frame_bytes) {
-                        fprintf(stderr, "[drive-pbo] frame=%d write=%zd/%d fd=%d ptr=%p errno=%d(%s)\n",
-                                client->pbo_frame_count, written, frame_bytes, client->recorder_pipefd[1], (void *)ptr,
-                                errno, strerror(errno));
+                    int row_bytes = w * 4;
+                    // IOV_MAX on Linux is 1024, so frames taller than 1024 rows
+                    // need multiple writev calls. Split the flip into chunks
+                    // of at most IOV_MAX rows, each chunk in top-down order.
+                    int iov_max = 1024;
+                    int rows_remaining = h;
+                    int row_top = 0; // next top-down row we're about to emit
+                    ssize_t total_written = 0;
+                    while (rows_remaining > 0) {
+                        int chunk = rows_remaining < iov_max ? rows_remaining : iov_max;
+                        struct iovec iov[1024];
+                        for (int i = 0; i < chunk; i++) {
+                            // Top-down row (row_top + i) corresponds to
+                            // bottom-up source row (h - 1 - (row_top + i)).
+                            int src_row = h - 1 - (row_top + i);
+                            iov[i].iov_base = ptr + (size_t)src_row * row_bytes;
+                            iov[i].iov_len = row_bytes;
+                        }
+                        ssize_t written = writev(client->recorder_pipefd[1], iov, chunk);
+                        if (written < 0) {
+                            fprintf(stderr, "[drive-pbo] frame=%d writev chunk=%d failed errno=%d(%s)\n",
+                                    client->pbo_frame_count, chunk, errno, strerror(errno));
+                            break;
+                        }
+                        total_written += written;
+                        row_top += chunk;
+                        rows_remaining -= chunk;
+                    }
+                    if (client->pbo_frame_count <= 3 || total_written != frame_bytes) {
+                        fprintf(stderr, "[drive-pbo] frame=%d writev=%zd/%d fd=%d ptr=%p\n", client->pbo_frame_count,
+                                total_written, frame_bytes, client->recorder_pipefd[1], (void *)ptr);
                     }
                     glUnmapBuffer(GL_PIXEL_PACK_BUFFER);
                 } else {
@@ -4855,14 +4886,31 @@ void c_render(Drive *env, int view_mode, int draw_traces) {
 
 void close_client(Client *client) {
 #ifdef DRIVE_HAS_EGL
-    // Flush the last PBO frame before closing the pipe
+    // Flush the last PBO frame before closing the pipe. Same row-reversed
+    // writev as the per-frame path so the trailing frame matches the rest.
     if (client->egl_mode && client->pbo_frame_count > 0 && client->pbo[0] != 0) {
         int prev = 1 - client->pbo_index;
-        int frame_bytes = (int)client->width * (int)client->height * 4;
+        int w = (int)client->width, h = (int)client->height;
         glBindBuffer(GL_PIXEL_PACK_BUFFER, client->pbo[prev]);
         unsigned char *ptr = (unsigned char *)glMapBuffer(GL_PIXEL_PACK_BUFFER, GL_READ_ONLY);
         if (ptr) {
-            write(client->recorder_pipefd[1], ptr, frame_bytes);
+            int row_bytes = w * 4;
+            int iov_max = 1024;
+            int rows_remaining = h;
+            int row_top = 0;
+            while (rows_remaining > 0) {
+                int chunk = rows_remaining < iov_max ? rows_remaining : iov_max;
+                struct iovec iov[1024];
+                for (int i = 0; i < chunk; i++) {
+                    int src_row = h - 1 - (row_top + i);
+                    iov[i].iov_base = ptr + (size_t)src_row * row_bytes;
+                    iov[i].iov_len = row_bytes;
+                }
+                if (writev(client->recorder_pipefd[1], iov, chunk) < 0)
+                    break;
+                row_top += chunk;
+                rows_remaining -= chunk;
+            }
             glUnmapBuffer(GL_PIXEL_PACK_BUFFER);
         }
         glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -4666,7 +4666,7 @@ void c_render(Drive *env, int view_mode, int draw_traces) {
         int frame_bytes = w * h * 4;
 
 #ifdef __linux__
-        if (client->egl_mode) {
+        if (client->egl_mode && 0) { // DISABLED: use sync readback to debug pipe
             // PBO double-buffer: async GPU→CPU readback overlapped with next frame's draw.
             // Frame flow:
             //   Frame 0: kick off async read into PBO 0 (nothing to write yet)

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -3667,13 +3667,10 @@ Client *make_client(Drive *env) {
                     fprintf(stderr, "[drive] EGL GPU unavailable, using Xvfb/Mesa (software rendering)\n");
                 }
             } else {
-                // Subsequent render envs: EGL context is still alive (persists across
-                // render envs to keep model/texture uploads valid). Just re-init rlgl
-                // for fresh batch state and update viewport for this env's resolution.
-                rlglClose();
-                rlglInit((int)client->width, (int)client->height);
+                // Subsequent render envs: EGL context persists (keeps model/texture
+                // uploads valid). Just update viewport for this env's resolution.
+                // rlgl batch state carries over — BeginDrawing flushes+resets each frame.
                 rlViewport(0, 0, (int)client->width, (int)client->height);
-                rlEnableDepthTest();
             }
             if (g_egl_available == 1) {
                 client->egl_mode = 1;

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -3538,6 +3538,10 @@ struct Client {
     pid_t xvfb_pid;
     int xvfb_display_num;
     int egl_mode; // 1 = EGL headless GPU rendering (no Xvfb/InitWindow)
+    // PBO double-buffer for async glReadPixels (GPU→CPU DMA)
+    unsigned int pbo[2];
+    int pbo_index;       // which PBO to read INTO this frame (0 or 1)
+    int pbo_frame_count; // total frames rendered (0 = first frame, no previous PBO to read)
 };
 
 Client *make_client(Drive *env) {
@@ -3674,12 +3678,19 @@ Client *make_client(Drive *env) {
                 close(fd);
 #ifdef __linux__
             if (client->egl_mode) {
-                // GPU available — use NVENC for hardware-accelerated encoding
+                // GPU path: PBO readback skips row flip, so ffmpeg must vflip.
+                // Try NVENC first; fall through to libx264 if unavailable.
                 execlp("ffmpeg", "ffmpeg", "-y",
                        "-f", "rawvideo", "-pix_fmt", "rgba", "-s", size_str, "-r", "30", "-i", "-",
+                       "-vf", "vflip",
                        "-c:v", "h264_nvenc", "-preset", "p1", "-cq", "23",
                        "-pix_fmt", "yuv420p", "-loglevel", "error", filename, NULL);
-                // If NVENC fails (e.g. too many sessions), fall through to libx264
+                // NVENC failed — try libx264 with vflip
+                execlp("ffmpeg", "ffmpeg", "-y",
+                       "-f", "rawvideo", "-pix_fmt", "rgba", "-s", size_str, "-r", "30", "-i", "-",
+                       "-vf", "vflip",
+                       "-c:v", "libx264", "-pix_fmt", "yuv420p", "-preset", "ultrafast", "-crf", "23",
+                       "-loglevel", "error", filename, NULL);
             }
 #endif
             execlp("ffmpeg", "ffmpeg", "-y",
@@ -4463,12 +4474,63 @@ void c_render(Drive *env, int view_mode, int draw_traces) {
 
         if (profile_enabled) t_draw_end = GetTime();
 
-        unsigned char *screen_data = rlReadScreenPixels((int)client->width, (int)client->height);
-        if (profile_enabled) t_read_end = GetTime();
-        if (screen_data) {
-            write(client->recorder_pipefd[1], screen_data, (int)client->width * (int)client->height * 4);
-            RL_FREE(screen_data);
+        int w = (int)client->width, h = (int)client->height;
+        int frame_bytes = w * h * 4;
+
+#ifdef __linux__
+        if (client->egl_mode) {
+            // PBO double-buffer: async GPU→CPU readback overlapped with next frame's draw.
+            // Frame flow:
+            //   Frame 0: kick off async read into PBO 0 (nothing to write yet)
+            //   Frame N: map PBO[prev] (blocks until its DMA finishes), write to pipe,
+            //            kick off async read into PBO[curr]
+            // Net effect: readback DMA is hidden behind the next frame's draw time.
+
+            // Create PBOs on first use
+            if (client->pbo[0] == 0) {
+                glGenBuffers(2, client->pbo);
+                for (int i = 0; i < 2; i++) {
+                    glBindBuffer(GL_PIXEL_PACK_BUFFER, client->pbo[i]);
+                    glBufferData(GL_PIXEL_PACK_BUFFER, frame_bytes, NULL, GL_STREAM_READ);
+                }
+                glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+            }
+
+            int curr = client->pbo_index;
+            int prev = 1 - curr;
+
+            // Kick off async read into current PBO
+            glBindBuffer(GL_PIXEL_PACK_BUFFER, client->pbo[curr]);
+            glReadPixels(0, 0, w, h, GL_RGBA, GL_UNSIGNED_BYTE, 0);
+            glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+
+            if (profile_enabled) t_read_end = GetTime();
+
+            // Map previous PBO and write to pipe (skip frame 0 — no previous data)
+            if (client->pbo_frame_count > 0) {
+                glBindBuffer(GL_PIXEL_PACK_BUFFER, client->pbo[prev]);
+                unsigned char *ptr = (unsigned char *)glMapBuffer(GL_PIXEL_PACK_BUFFER, GL_READ_ONLY);
+                if (ptr) {
+                    write(client->recorder_pipefd[1], ptr, frame_bytes);
+                    glUnmapBuffer(GL_PIXEL_PACK_BUFFER);
+                }
+                glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+            }
+
+            client->pbo_index = prev;
+            client->pbo_frame_count++;
+        } else
+#endif
+        {
+            // Synchronous fallback (Xvfb/Mesa path)
+            unsigned char *screen_data = rlReadScreenPixels(w, h);
+            if (profile_enabled) t_read_end = GetTime();
+            if (screen_data) {
+                write(client->recorder_pipefd[1], screen_data, frame_bytes);
+                RL_FREE(screen_data);
+            }
         }
+
         if (profile_enabled) {
             t_pipe_end = GetTime();
             acc_draw += (t_draw_end - t_draw_start);
@@ -4559,6 +4621,21 @@ void c_render(Drive *env, int view_mode, int draw_traces) {
 }
 
 void close_client(Client *client) {
+#ifdef __linux__
+    // Flush the last PBO frame before closing the pipe
+    if (client->egl_mode && client->pbo_frame_count > 0 && client->pbo[0] != 0) {
+        int prev = 1 - client->pbo_index;
+        int frame_bytes = (int)client->width * (int)client->height * 4;
+        glBindBuffer(GL_PIXEL_PACK_BUFFER, client->pbo[prev]);
+        unsigned char *ptr = (unsigned char *)glMapBuffer(GL_PIXEL_PACK_BUFFER, GL_READ_ONLY);
+        if (ptr) {
+            write(client->recorder_pipefd[1], ptr, frame_bytes);
+            glUnmapBuffer(GL_PIXEL_PACK_BUFFER);
+        }
+        glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+        glDeleteBuffers(2, client->pbo);
+    }
+#endif
     if (client->recorder_pid > 0) {
         close(client->recorder_pipefd[1]);
         waitpid(client->recorder_pid, NULL, 0);

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -4699,8 +4699,15 @@ void c_render(Drive *env, int view_mode, int draw_traces) {
                 glBindBuffer(GL_PIXEL_PACK_BUFFER, client->pbo[prev]);
                 unsigned char *ptr = (unsigned char *)glMapBuffer(GL_PIXEL_PACK_BUFFER, GL_READ_ONLY);
                 if (ptr) {
-                    write(client->recorder_pipefd[1], ptr, frame_bytes);
+                    ssize_t written = write(client->recorder_pipefd[1], ptr, frame_bytes);
+                    if (client->pbo_frame_count <= 3 || written != frame_bytes) {
+                        fprintf(stderr, "[drive-pbo] frame=%d write=%zd/%d fd=%d ptr=%p\n", client->pbo_frame_count,
+                                written, frame_bytes, client->recorder_pipefd[1], (void *)ptr);
+                    }
                     glUnmapBuffer(GL_PIXEL_PACK_BUFFER);
+                } else {
+                    fprintf(stderr, "[drive-pbo] frame=%d glMapBuffer returned NULL! GL error=0x%x\n",
+                            client->pbo_frame_count, glGetError());
                 }
                 glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
             }

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -3714,13 +3714,12 @@ Client *make_client(Drive *env) {
                 // GPU/PBO path: same ffmpeg command as non-EGL (video may be vertically
                 // flipped but this confirms PBO data reaches ffmpeg).
                 execlp("ffmpeg", "ffmpeg", "-y", "-f", "rawvideo", "-pix_fmt", "rgba", "-s", size_str, "-r", "30", "-i",
-                       "-", "-c:v", "libx264", "-pix_fmt", "yuv420p", "-preset", "ultrafast", "-crf", "23", "-loglevel",
-                       "error", filename, NULL);
+                       "-", "-c:v", "libx264", "-pix_fmt", "yuv420p", "-preset", "ultrafast", "-crf", "23", filename,
+                       NULL);
             }
 #endif
             execlp("ffmpeg", "ffmpeg", "-y", "-f", "rawvideo", "-pix_fmt", "rgba", "-s", size_str, "-r", "30", "-i",
-                   "-", "-c:v", "libx264", "-pix_fmt", "yuv420p", "-preset", "ultrafast", "-crf", "23", "-loglevel",
-                   "error", filename, NULL);
+                   "-", "-c:v", "libx264", "-pix_fmt", "yuv420p", "-preset", "ultrafast", "-crf", "23", filename, NULL);
             fprintf(stderr, "execlp ffmpeg failed\n");
             _exit(1);
         }

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -1,4 +1,8 @@
-#define _GNU_SOURCE
+// _GNU_SOURCE is set via -D_GNU_SOURCE in setup.py's drive extension build
+// flags so GNU extensions (F_SETPIPE_SZ, writev, etc.) are visible regardless
+// of which header is included first. Don't define it here — drive.c pulls in
+// drivenet.h -> <time.h> before drive.h, so defining it mid-stream would be
+// too late.
 #include <errno.h>
 #include <fcntl.h>
 #include <signal.h>

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -28,6 +28,15 @@
 #endif
 
 #ifdef DRIVE_HAS_EGL
+// GL_GLEXT_PROTOTYPES must come before any GL/gl.h include so glext declares
+// the modern buffer-object entry points (glGenBuffers, glBindBuffer,
+// glBufferData, glMapBuffer, glUnmapBuffer, glDeleteBuffers). Without a
+// declaration, gcc defaults their return type to implicit int, and
+// glMapBuffer's void* pointer gets truncated to 32 bits and sign-extended,
+// producing EFAULT writes like 0xffffffff9cbf1000.
+#define GL_GLEXT_PROTOTYPES 1
+#include <GL/gl.h>
+#include <GL/glext.h>
 #include "egl_headless.h"
 #endif
 
@@ -3678,8 +3687,10 @@ Client *make_client(Drive *env) {
                 }
             } else {
                 // Subsequent render envs: EGL context persists (keeps model/texture
-                // uploads valid). Just update viewport for this env's resolution.
-                // rlgl batch state carries over — BeginDrawing flushes+resets each frame.
+                // uploads valid). The pbuffer was sized for the first client — grow
+                // it if this client needs more pixels so glReadPixels doesn't read
+                // uninitialized memory outside the framebuffer bounds.
+                egl_headless_resize((int)client->width, (int)client->height);
                 rlViewport(0, 0, (int)client->width, (int)client->height);
             }
             if (g_egl_available == 1) {
@@ -4690,7 +4701,7 @@ void c_render(Drive *env, int view_mode, int draw_traces) {
         int frame_bytes = w * h * 4;
 
 #ifdef DRIVE_HAS_EGL
-        if (client->egl_mode && 0) { // DISABLED: use sync readback to debug pipe
+        if (client->egl_mode) {
             // PBO double-buffer: async GPU→CPU readback overlapped with next frame's draw.
             // Frame flow:
             //   Frame 0: kick off async read into PBO 0 (nothing to write yet)

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -3551,42 +3551,16 @@ struct Client {
     int pbo_frame_count; // total frames rendered (0 = first frame, no previous PBO to read)
 };
 
+// Persistent state: Xvfb + GLFW + EGL are initialized once per process and
+// reused across render envs. This avoids glfwTerminate (which prevents re-init)
+// and eglTerminate (which corrupts CUDA state).
+static int g_glfw_ready = 0;
+static int g_egl_available = -1; // -1 = untested, 0 = no, 1 = yes
+static pid_t g_xvfb_pid = 0;
+static int g_xvfb_display_num = 0;
+
 Client *make_client(Drive *env) {
     Client *client = (Client *)calloc(1, sizeof(Client));
-
-    if (env->render_mode == RENDER_HEADLESS && getenv("DISPLAY") == NULL) {
-        client->xvfb_display_num = 100 + (getpid() % 900);
-
-        char lock_file[32], socket_file[32], display_str[16];
-        snprintf(display_str, sizeof(display_str), ":%d", client->xvfb_display_num);
-        snprintf(lock_file, sizeof(lock_file), "/tmp/.X%d-lock", client->xvfb_display_num);
-        snprintf(socket_file, sizeof(socket_file), "/tmp/.X11-unix/X%d", client->xvfb_display_num);
-
-        FILE *f = fopen(lock_file, "r");
-        if (f) {
-            pid_t pid = -1;
-            fscanf(f, "%d", &pid);
-            fclose(f);
-            if (pid > 0 && kill(pid, 0) != 0) {
-                unlink(lock_file);
-                unlink(socket_file);
-            }
-        }
-
-        client->xvfb_pid = fork();
-        if (client->xvfb_pid == 0) {
-            close(STDOUT_FILENO);
-            close(STDERR_FILENO);
-            execlp("Xvfb", "Xvfb", display_str, "-screen", "0", "1280x720x24", "+extension", "GLX", "-ac", "-noreset",
-                   NULL);
-            _exit(1);
-        }
-
-        setenv("DISPLAY", display_str, 1);
-        for (int i = 0; i < 20 && access(lock_file, F_OK) != 0; i++)
-            usleep(100000);
-        usleep(200000);
-    }
 
     if (env->render_mode == RENDER_WINDOW) {
         client->width = 1280;
@@ -3602,6 +3576,9 @@ Client *make_client(Drive *env) {
         client->camera.up = (Vector3){0.0f, -1.0f, 0.0f};
         client->camera.fovy = 45.0f;
         client->camera.projection = CAMERA_PERSPECTIVE;
+
+        SetTraceLogLevel(LOG_WARNING);
+        InitWindow(client->width, client->height, "PufferDrive");
     } else { // Headless rendering
         float map_width = env->grid_map->bottom_right_x - env->grid_map->top_left_x;
         float map_height = env->grid_map->top_left_y - env->grid_map->bottom_right_y;
@@ -3610,14 +3587,50 @@ Client *make_client(Drive *env) {
         int img_height = (int)roundf(map_height * scale / 2.0f) * 2;
         client->width = img_width;
         client->height = img_height;
-        SetConfigFlags(FLAG_WINDOW_HIDDEN);
-        SetTargetFPS(6000);
+
+        // Init Xvfb + GLFW once per process (loads glad GL function pointers)
+        if (!g_glfw_ready) {
+            if (getenv("DISPLAY") == NULL) {
+                g_xvfb_display_num = 100 + (getpid() % 900);
+                char lock_file[32], socket_file[32], display_str[16];
+                snprintf(display_str, sizeof(display_str), ":%d", g_xvfb_display_num);
+                snprintf(lock_file, sizeof(lock_file), "/tmp/.X%d-lock", g_xvfb_display_num);
+                snprintf(socket_file, sizeof(socket_file), "/tmp/.X11-unix/X%d", g_xvfb_display_num);
+
+                FILE *f = fopen(lock_file, "r");
+                if (f) {
+                    pid_t pid = -1;
+                    fscanf(f, "%d", &pid);
+                    fclose(f);
+                    if (pid > 0 && kill(pid, 0) != 0) {
+                        unlink(lock_file);
+                        unlink(socket_file);
+                    }
+                }
+
+                g_xvfb_pid = fork();
+                if (g_xvfb_pid == 0) {
+                    close(STDOUT_FILENO);
+                    close(STDERR_FILENO);
+                    execlp("Xvfb", "Xvfb", display_str, "-screen", "0", "1280x720x24", "+extension", "GLX", "-ac",
+                           "-noreset", NULL);
+                    _exit(1);
+                }
+                setenv("DISPLAY", display_str, 1);
+                for (int i = 0; i < 20 && access(lock_file, F_OK) != 0; i++)
+                    usleep(100000);
+                usleep(200000);
+            }
+
+            SetConfigFlags(FLAG_WINDOW_HIDDEN);
+            SetTargetFPS(6000);
+            SetTraceLogLevel(LOG_WARNING);
+            InitWindow(img_width, img_height, "PufferDrive");
+            g_glfw_ready = 1;
+        }
     }
 
-    SetTraceLogLevel(LOG_WARNING);
-    InitWindow(client->width, client->height, "PufferDrive");
-
-    // Load assets
+    // Load assets (needed for perspective view mode=0)
     client->cars[0] = LoadModel("resources/drive/RedCar.glb");
     client->cars[1] = LoadModel("resources/drive/WhiteCar.glb");
     client->cars[2] = LoadModel("resources/drive/BlueCar.glb");
@@ -3633,22 +3646,27 @@ Client *make_client(Drive *env) {
     }
 
 #ifdef __linux__
-    // After InitWindow loaded glad + rlgl on the Xvfb/Mesa context, try to switch
-    // to a GPU-backed EGL context. GL function pointers from glad remain valid
-    // (they're just dlsym addresses). We re-init rlgl so its render batches and
-    // default texture are allocated on the GPU.
+    // EGL GPU context: create per render env (different maps = different resolutions).
+    // The EGL display is persistent (never terminated — eglTerminate breaks CUDA).
+    // We destroy the old surface+context and create fresh ones for the new resolution,
+    // then re-init rlgl so render batches live on the current GPU context.
     if (env->render_mode == RENDER_HEADLESS) {
-        if (egl_headless_init((int)client->width, (int)client->height)) {
-            if (egl_switch_to_gpu()) {
-                rlglClose();
-                rlglInit((int)client->width, (int)client->height);
-                rlViewport(0, 0, (int)client->width, (int)client->height);
-                rlEnableDepthTest();
-                client->egl_mode = 1;
+        if (g_egl_available != 0) {
+            // Destroy previous EGL surface+context if they exist
+            egl_headless_cleanup();
+            if (egl_headless_init((int)client->width, (int)client->height)) {
+                if (egl_switch_to_gpu()) {
+                    rlglInit((int)client->width, (int)client->height);
+                    rlViewport(0, 0, (int)client->width, (int)client->height);
+                    rlEnableDepthTest();
+                    client->egl_mode = 1;
+                    g_egl_available = 1;
+                }
             }
-        }
-        if (!client->egl_mode) {
-            fprintf(stderr, "[drive] EGL GPU unavailable, using Xvfb/Mesa (software rendering)\n");
+            if (!client->egl_mode && g_egl_available < 0) {
+                g_egl_available = 0; // Don't retry on future render envs
+                fprintf(stderr, "[drive] EGL GPU unavailable, using Xvfb/Mesa (software rendering)\n");
+            }
         }
     }
 #endif
@@ -4811,13 +4829,8 @@ void close_client(Client *client) {
         waitpid(client->recorder_pid, NULL, 0);
     }
 
-#ifdef __linux__
-    if (client->egl_mode) {
-        rlglClose();
-        egl_headless_cleanup();
-    }
-#endif
     if (!client->egl_mode) {
+        // Non-EGL: full cleanup (window mode or Xvfb fallback)
         for (int i = 0; i < 6; i++)
             UnloadModel(client->cars[i]);
         UnloadModel(client->cyclist);
@@ -4834,9 +4847,9 @@ void close_client(Client *client) {
             unsetenv("DISPLAY");
         }
     }
-    // In EGL mode: skip CloseWindow (glfwTerminate prevents re-init) and skip
-    // killing Xvfb (next make_client will reuse it via DISPLAY env var).
-    // The GLFW window + Xvfb are harmless — rendering uses the EGL pbuffer.
+    // EGL mode: don't touch GLFW/Xvfb/EGL — they persist across render envs.
+    // EGL surface+context cleanup happens at the START of the next make_client
+    // (or never, if this is the last render env — process exit handles it).
 
     free(client);
 }

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -3711,10 +3711,11 @@ Client *make_client(Drive *env) {
                 close(fd);
 #ifdef __linux__
             if (client->egl_mode) {
-                // GPU/PBO path: readback skips the row flip, so ffmpeg must vflip.
+                // GPU/PBO path: same ffmpeg command as non-EGL (video may be vertically
+                // flipped but this confirms PBO data reaches ffmpeg).
                 execlp("ffmpeg", "ffmpeg", "-y", "-f", "rawvideo", "-pix_fmt", "rgba", "-s", size_str, "-r", "30", "-i",
-                       "-", "-vf", "vflip", "-c:v", "libx264", "-pix_fmt", "yuv420p", "-preset", "ultrafast", "-crf",
-                       "23", "-loglevel", "error", filename, NULL);
+                       "-", "-c:v", "libx264", "-pix_fmt", "yuv420p", "-preset", "ultrafast", "-crf", "23", "-loglevel",
+                       "error", filename, NULL);
             }
 #endif
             execlp("ffmpeg", "ffmpeg", "-y", "-f", "rawvideo", "-pix_fmt", "rgba", "-s", size_str, "-r", "30", "-i",

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -1,3 +1,5 @@
+#define _GNU_SOURCE
+#include <fcntl.h>
 #include <signal.h>
 #include <sys/types.h>
 #include <stdlib.h>
@@ -14,6 +16,10 @@
 #include <time.h>
 #include "error.h"
 #include "datatypes.h"
+
+#ifdef __linux__
+#include "egl_headless.h"
+#endif
 
 #define RENDER_WINDOW 0
 #define RENDER_HEADLESS 1
@@ -3531,15 +3537,13 @@ struct Client {
     pid_t recorder_pid;
     pid_t xvfb_pid;
     int xvfb_display_num;
+    int egl_mode; // 1 = EGL headless GPU rendering (no Xvfb/InitWindow)
 };
 
 Client *make_client(Drive *env) {
     Client *client = (Client *)calloc(1, sizeof(Client));
 
     if (env->render_mode == RENDER_HEADLESS && getenv("DISPLAY") == NULL) {
-
-        // Use a per-process display number so multiple rendering jobs on the same
-        // node don't collide. Range :100-:999 avoids the system default :0.
         client->xvfb_display_num = 100 + (getpid() % 900);
 
         char lock_file[32], socket_file[32], display_str[16];
@@ -3547,7 +3551,6 @@ Client *make_client(Drive *env) {
         snprintf(lock_file, sizeof(lock_file), "/tmp/.X%d-lock", client->xvfb_display_num);
         snprintf(socket_file, sizeof(socket_file), "/tmp/.X11-unix/X%d", client->xvfb_display_num);
 
-        // Clean up a stale lock only if the owning process is already dead
         FILE *f = fopen(lock_file, "r");
         if (f) {
             pid_t pid = -1;
@@ -3569,9 +3572,6 @@ Client *make_client(Drive *env) {
         }
 
         setenv("DISPLAY", display_str, 1);
-        // Xvfb starts asynchronously after fork(), so we poll until it creates its
-        // lock file (max 2s) then wait an extra 200ms for GLX to finish initializing.
-        // Without this, raylib's InitWindow() would try to connect before Xvfb is ready.
         for (int i = 0; i < 20 && access(lock_file, F_OK) != 0; i++)
             usleep(100000);
         usleep(200000);
@@ -3583,36 +3583,27 @@ Client *make_client(Drive *env) {
         SetConfigFlags(FLAG_MSAA_4X_HINT);
         SetTargetFPS(30);
 
-        // Set up camera for interactive window
-        Vector3 target_pos = {0, 0, 1}; // Y is up, Z is depth
-
-        client->default_camera_position = (Vector3){
-            0,      // Same X as target
-            120.0f, // 20 units above target
-            175.0f  // 20 units behind target
-        };
+        Vector3 target_pos = {0, 0, 1};
+        client->default_camera_position = (Vector3){0, 120.0f, 175.0f};
         client->default_camera_target = target_pos;
         client->camera.position = client->default_camera_position;
         client->camera.target = client->default_camera_target;
-        client->camera.up = (Vector3){0.0f, -1.0f, 0.0f}; // Y is up
+        client->camera.up = (Vector3){0.0f, -1.0f, 0.0f};
         client->camera.fovy = 45.0f;
         client->camera.projection = CAMERA_PERSPECTIVE;
-
     } else { // Headless rendering
-        SetConfigFlags(FLAG_WINDOW_HIDDEN);
-        SetTargetFPS(6000);
-
         float map_width = env->grid_map->bottom_right_x - env->grid_map->top_left_x;
         float map_height = env->grid_map->top_left_y - env->grid_map->bottom_right_y;
-        float scale = 6.0f; // Controls the resolution of the output video
+        float scale = 6.0f;
         int img_width = (int)roundf(map_width * scale / 2.0f) * 2;
         int img_height = (int)roundf(map_height * scale / 2.0f) * 2;
-
         client->width = img_width;
         client->height = img_height;
+        SetConfigFlags(FLAG_WINDOW_HIDDEN);
+        SetTargetFPS(6000);
     }
 
-    SetTraceLogLevel(LOG_WARNING); // Only show warnings and errors
+    SetTraceLogLevel(LOG_WARNING);
     InitWindow(client->width, client->height, "PufferDrive");
 
     // Load assets
@@ -3629,6 +3620,27 @@ Client *make_client(Drive *env) {
     for (int i = 0; i < MAX_AGENTS; i++) {
         client->car_assignments[i] = (rand() % 4) + 1;
     }
+
+#ifdef __linux__
+    // After InitWindow loaded glad + rlgl on the Xvfb/Mesa context, try to switch
+    // to a GPU-backed EGL context. GL function pointers from glad remain valid
+    // (they're just dlsym addresses). We re-init rlgl so its render batches and
+    // default texture are allocated on the GPU.
+    if (env->render_mode == RENDER_HEADLESS) {
+        if (egl_headless_init((int)client->width, (int)client->height)) {
+            if (egl_switch_to_gpu()) {
+                rlglClose();
+                rlglInit((int)client->width, (int)client->height);
+                rlViewport(0, 0, (int)client->width, (int)client->height);
+                rlEnableDepthTest();
+                client->egl_mode = 1;
+            }
+        }
+        if (!client->egl_mode) {
+            fprintf(stderr, "[drive] EGL GPU unavailable, using Xvfb/Mesa (software rendering)\n");
+        }
+    }
+#endif
 
     // Set up ffmpeg process for recording
     if (env->render_mode == RENDER_HEADLESS) {
@@ -3660,13 +3672,34 @@ Client *make_client(Drive *env) {
             close(client->recorder_pipefd[0]);
             for (int fd = 3; fd < 256; fd++)
                 close(fd);
-            execlp("ffmpeg", "ffmpeg", "-y", "-f", "rawvideo", "-pix_fmt", "rgba", "-s", size_str, "-r", "30", "-i",
-                   "-", "-c:v", "libx264", "-pix_fmt", "yuv420p", "-preset", "ultrafast", "-crf", "23", "-loglevel",
-                   "error", filename, NULL);
+#ifdef __linux__
+            if (client->egl_mode) {
+                // GPU available — use NVENC for hardware-accelerated encoding
+                execlp("ffmpeg", "ffmpeg", "-y",
+                       "-f", "rawvideo", "-pix_fmt", "rgba", "-s", size_str, "-r", "30", "-i", "-",
+                       "-c:v", "h264_nvenc", "-preset", "p1", "-cq", "23",
+                       "-pix_fmt", "yuv420p", "-loglevel", "error", filename, NULL);
+                // If NVENC fails (e.g. too many sessions), fall through to libx264
+            }
+#endif
+            execlp("ffmpeg", "ffmpeg", "-y",
+                   "-f", "rawvideo", "-pix_fmt", "rgba", "-s", size_str, "-r", "30", "-i", "-",
+                   "-c:v", "libx264", "-pix_fmt", "yuv420p", "-preset", "ultrafast", "-crf", "23",
+                   "-loglevel", "error", filename, NULL);
             fprintf(stderr, "execlp ffmpeg failed\n");
             _exit(1);
         }
         close(client->recorder_pipefd[0]);
+
+        // Increase pipe buffer to reduce write() blocking on large frames
+#ifdef __linux__
+        {
+            int pipe_sz = fcntl(client->recorder_pipefd[1], F_SETPIPE_SZ, 4 * 1024 * 1024);
+            if (pipe_sz > 0) {
+                fprintf(stderr, "[drive] Pipe buffer set to %d bytes\n", pipe_sz);
+            }
+        }
+#endif
     }
 
     return client;
@@ -4332,6 +4365,24 @@ void c_render(Drive *env, int view_mode, int draw_traces) {
     }
     Client *client = env->client;
 
+    // Per-stage timing. Enabled with DRIVE_RENDER_PROFILE=1 in the environment.
+    // Prints rolling averages every DRIVE_RENDER_PROFILE_EVERY frames (default 60).
+    // Stages: draw = BeginDrawing..draw_scene..EndDrawing (includes flush),
+    //         read = rlReadScreenPixels (glReadPixels + CPU buffer alloc),
+    //         pipe = write() to ffmpeg.
+    static int profile_enabled = -1;
+    static int profile_every = 0;
+    static int profile_frame = 0;
+    static double acc_draw = 0.0, acc_read = 0.0, acc_pipe = 0.0;
+    if (profile_enabled < 0) {
+        const char *e = getenv("DRIVE_RENDER_PROFILE");
+        profile_enabled = (e && e[0] == '1') ? 1 : 0;
+        const char *n = getenv("DRIVE_RENDER_PROFILE_EVERY");
+        profile_every = (n && atoi(n) > 0) ? atoi(n) : 60;
+    }
+    double t_draw_start = 0.0, t_draw_end = 0.0, t_read_end = 0.0, t_pipe_end = 0.0;
+    if (profile_enabled) t_draw_start = GetTime();
+
     if (env->render_mode == RENDER_HEADLESS) { // Headless rendering via ffmpeg
         float map_width = env->grid_map->bottom_right_x - env->grid_map->top_left_x;
         float map_height = env->grid_map->top_left_y - env->grid_map->bottom_right_y;
@@ -4339,9 +4390,8 @@ void c_render(Drive *env, int view_mode, int draw_traces) {
         Camera3D camera = {0};
 
         if (view_mode == VIEW_MODE_SIM_STATE) {
-            // Orthographic bird's-eye view over the entire map (fully observable)
-            camera.position = (Vector3){0.0, 0.0, 400.0f}; // Above the scene
-            camera.target = (Vector3){0.0, 0.0, 0.0};      // Look at origin
+            camera.position = (Vector3){0.0, 0.0, 400.0f};
+            camera.target = (Vector3){0.0, 0.0, 0.0};
             camera.up = (Vector3){0.0f, -1.0f, 0.0f};
             camera.projection = CAMERA_ORTHOGRAPHIC;
             camera.fovy = map_height;
@@ -4350,37 +4400,30 @@ void c_render(Drive *env, int view_mode, int draw_traces) {
             ClearBackground(ROAD_COLOR);
             BeginMode3D(camera);
 
-            if (draw_traces) { // Show logged trajectories of active agents and expert static agents
+            if (draw_traces) {
                 for (int i = 0; i < env->active_agent_count; i++) {
                     int idx = env->active_agent_indices[i];
                     for (int t = env->init_steps; t < env->episode_length; t++) {
                         Color agent_color = LIGHTBLUE;
-                        if (env->agents[idx].type == PEDESTRIAN) {
-                            agent_color = LIGHT_ORANGE;
-                        } else if (env->agents[idx].type == CYCLIST) {
-                            agent_color = LIGHT_PURPLE;
-                        }
-                        DrawSphere((Vector3){env->agents[idx].log_trajectory_x[t], env->agents[idx].log_trajectory_y[t],
-                                             env->agents[idx].log_trajectory_z[t]},
-                                   0.15f, agent_color);
+                        if (env->agents[idx].type == PEDESTRIAN) agent_color = LIGHT_ORANGE;
+                        else if (env->agents[idx].type == CYCLIST) agent_color = LIGHT_PURPLE;
+                        DrawSphere((Vector3){env->agents[idx].log_trajectory_x[t],
+                                             env->agents[idx].log_trajectory_y[t],
+                                             env->agents[idx].log_trajectory_z[t]}, 0.15f, agent_color);
                     }
                 }
-
                 for (int i = 0; i < env->expert_static_agent_count; i++) {
                     int idx = env->expert_static_agent_indices[i];
                     for (int t = env->init_steps; t < env->episode_length; t++) {
-                        DrawSphere((Vector3){env->agents[idx].log_trajectory_x[t], env->agents[idx].log_trajectory_y[t],
-                                             env->agents[idx].log_trajectory_z[t]},
-                                   0.15f, EXPERT_REPLAY);
+                        DrawSphere((Vector3){env->agents[idx].log_trajectory_x[t],
+                                             env->agents[idx].log_trajectory_y[t],
+                                             env->agents[idx].log_trajectory_z[t]}, 0.15f, EXPERT_REPLAY);
                     }
                 }
             }
-
             draw_scene(env, client, 1, 0, 0, 0);
 
         } else if (view_mode == VIEW_MODE_BEV_AGENT_OBS) {
-            // Orthographic bird's-eye view centered on the selected agent,
-            // showing only that agent's observations
             int agent_idx = env->active_agent_indices[env->human_agent_idx];
             Agent *agent = &env->agents[agent_idx];
 
@@ -4396,12 +4439,11 @@ void c_render(Drive *env, int view_mode, int draw_traces) {
             BeginMode3D(camera);
             draw_scene(env, client, 1, 1, 0, 0);
 
-        } else { // First-person perspective from a selected agent
+        } else {
             int agent_idx = env->active_agent_indices[env->human_agent_idx];
             Agent *agent = &env->agents[agent_idx];
 
             Camera3D camera = {0};
-            // Position camera behind and above the agent
             camera.position = (Vector3){agent->sim_x - (25.0f * cosf(agent->sim_heading)),
                                         agent->sim_y - (25.0f * sinf(agent->sim_heading)), 15.0f};
             camera.target = (Vector3){agent->sim_x + 40.0f * cosf(agent->sim_heading),
@@ -4416,12 +4458,36 @@ void c_render(Drive *env, int view_mode, int draw_traces) {
             draw_scene(env, client, 0, 0, 0, 1);
         }
 
+        EndMode3D();
         EndDrawing();
 
+        if (profile_enabled) t_draw_end = GetTime();
+
         unsigned char *screen_data = rlReadScreenPixels((int)client->width, (int)client->height);
+        if (profile_enabled) t_read_end = GetTime();
         if (screen_data) {
             write(client->recorder_pipefd[1], screen_data, (int)client->width * (int)client->height * 4);
             RL_FREE(screen_data);
+        }
+        if (profile_enabled) {
+            t_pipe_end = GetTime();
+            acc_draw += (t_draw_end - t_draw_start);
+            acc_read += (t_read_end - t_draw_end);
+            acc_pipe += (t_pipe_end - t_read_end);
+            profile_frame++;
+            if (profile_frame % profile_every == 0) {
+                double n = (double)profile_every;
+                double ms_draw = 1000.0 * acc_draw / n;
+                double ms_read = 1000.0 * acc_read / n;
+                double ms_pipe = 1000.0 * acc_pipe / n;
+                double ms_tot = ms_draw + ms_read + ms_pipe;
+                fprintf(stderr,
+                        "[drive-render-profile] %dx%d frame=%d avg over %d: "
+                        "draw=%.2fms read=%.2fms pipe=%.2fms total=%.2fms (%.1f FPS)\n",
+                        (int)client->width, (int)client->height, profile_frame, profile_every,
+                        ms_draw, ms_read, ms_pipe, ms_tot, ms_tot > 0 ? 1000.0 / ms_tot : 0.0);
+                acc_draw = acc_read = acc_pipe = 0.0;
+            }
         }
     } else { // Pop-up window
         BeginDrawing();
@@ -4497,20 +4563,29 @@ void close_client(Client *client) {
         close(client->recorder_pipefd[1]);
         waitpid(client->recorder_pid, NULL, 0);
     }
-    for (int i = 0; i < 6; i++)
-        UnloadModel(client->cars[i]);
-    UnloadModel(client->cyclist);
-    UnloadModel(client->pedestrian);
-    CloseWindow();
-    if (client->xvfb_pid > 0) {
-        kill(client->xvfb_pid, SIGTERM);
-        waitpid(client->xvfb_pid, NULL, 0);
-        char lock_file[32], socket_file[32];
-        snprintf(lock_file, sizeof(lock_file), "/tmp/.X%d-lock", client->xvfb_display_num);
-        snprintf(socket_file, sizeof(socket_file), "/tmp/.X11-unix/X%d", client->xvfb_display_num);
-        unlink(lock_file);
-        unlink(socket_file);
-        unsetenv("DISPLAY");
+
+#ifdef __linux__
+    if (client->egl_mode) {
+        rlglClose();
+        egl_headless_cleanup();
+    } else
+#endif
+    {
+        for (int i = 0; i < 6; i++)
+            UnloadModel(client->cars[i]);
+        UnloadModel(client->cyclist);
+        UnloadModel(client->pedestrian);
+        CloseWindow();
+        if (client->xvfb_pid > 0) {
+            kill(client->xvfb_pid, SIGTERM);
+            waitpid(client->xvfb_pid, NULL, 0);
+            char lock_file[32], socket_file[32];
+            snprintf(lock_file, sizeof(lock_file), "/tmp/.X%d-lock", client->xvfb_display_num);
+            snprintf(socket_file, sizeof(socket_file), "/tmp/.X11-unix/X%d", client->xvfb_display_num);
+            unlink(lock_file);
+            unlink(socket_file);
+            unsetenv("DISPLAY");
+        }
     }
 
     free(client);

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -3685,12 +3685,7 @@ Client *make_client(Drive *env) {
                 close(fd);
 #ifdef __linux__
             if (client->egl_mode) {
-                // GPU path: PBO readback skips row flip, so ffmpeg must vflip.
-                // Try NVENC first; fall through to libx264 if unavailable.
-                execlp("ffmpeg", "ffmpeg", "-y", "-f", "rawvideo", "-pix_fmt", "rgba", "-s", size_str, "-r", "30", "-i",
-                       "-", "-vf", "vflip", "-c:v", "h264_nvenc", "-preset", "p1", "-cq", "23", "-pix_fmt", "yuv420p",
-                       "-loglevel", "error", filename, NULL);
-                // NVENC failed — try libx264 with vflip
+                // GPU/PBO path: readback skips the row flip, so ffmpeg must vflip.
                 execlp("ffmpeg", "ffmpeg", "-y", "-f", "rawvideo", "-pix_fmt", "rgba", "-s", size_str, "-r", "30", "-i",
                        "-", "-vf", "vflip", "-c:v", "libx264", "-pix_fmt", "yuv420p", "-preset", "ultrafast", "-crf",
                        "23", "-loglevel", "error", filename, NULL);

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -4701,8 +4701,9 @@ void c_render(Drive *env, int view_mode, int draw_traces) {
                 if (ptr) {
                     ssize_t written = write(client->recorder_pipefd[1], ptr, frame_bytes);
                     if (client->pbo_frame_count <= 3 || written != frame_bytes) {
-                        fprintf(stderr, "[drive-pbo] frame=%d write=%zd/%d fd=%d ptr=%p\n", client->pbo_frame_count,
-                                written, frame_bytes, client->recorder_pipefd[1], (void *)ptr);
+                        fprintf(stderr, "[drive-pbo] frame=%d write=%zd/%d fd=%d ptr=%p errno=%d(%s)\n",
+                                client->pbo_frame_count, written, frame_bytes, client->recorder_pipefd[1], (void *)ptr,
+                                errno, strerror(errno));
                     }
                     glUnmapBuffer(GL_PIXEL_PACK_BUFFER);
                 } else {

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -4817,25 +4817,26 @@ void close_client(Client *client) {
         egl_headless_cleanup();
     }
 #endif
-    // Always clean up GLFW/Xvfb — even in EGL mode, InitWindow was called
-    // and must be matched by CloseWindow to avoid stale state on next eval.
     if (!client->egl_mode) {
         for (int i = 0; i < 6; i++)
             UnloadModel(client->cars[i]);
         UnloadModel(client->cyclist);
         UnloadModel(client->pedestrian);
+        CloseWindow();
+        if (client->xvfb_pid > 0) {
+            kill(client->xvfb_pid, SIGTERM);
+            waitpid(client->xvfb_pid, NULL, 0);
+            char lock_file[32], socket_file[32];
+            snprintf(lock_file, sizeof(lock_file), "/tmp/.X%d-lock", client->xvfb_display_num);
+            snprintf(socket_file, sizeof(socket_file), "/tmp/.X11-unix/X%d", client->xvfb_display_num);
+            unlink(lock_file);
+            unlink(socket_file);
+            unsetenv("DISPLAY");
+        }
     }
-    CloseWindow();
-    if (client->xvfb_pid > 0) {
-        kill(client->xvfb_pid, SIGTERM);
-        waitpid(client->xvfb_pid, NULL, 0);
-        char lock_file[32], socket_file[32];
-        snprintf(lock_file, sizeof(lock_file), "/tmp/.X%d-lock", client->xvfb_display_num);
-        snprintf(socket_file, sizeof(socket_file), "/tmp/.X11-unix/X%d", client->xvfb_display_num);
-        unlink(lock_file);
-        unlink(socket_file);
-        unsetenv("DISPLAY");
-    }
+    // In EGL mode: skip CloseWindow (glfwTerminate prevents re-init) and skip
+    // killing Xvfb (next make_client will reuse it via DISPLAY env var).
+    // The GLFW window + Xvfb are harmless — rendering uses the EGL pbuffer.
 
     free(client);
 }

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -3538,6 +3538,14 @@ struct Client {
     pid_t xvfb_pid;
     int xvfb_display_num;
     int egl_mode; // 1 = EGL headless GPU rendering (no Xvfb/InitWindow)
+    // Cached static road geometry (rebuilt once per episode, drawn every frame)
+    float *road_tri_verts;         // 3 floats (x,y,z) per vertex
+    unsigned char *road_tri_colors; // 4 bytes (RGBA) per vertex
+    int road_tri_count;            // number of triangles (verts = count * 3)
+    float *road_line_verts;
+    unsigned char *road_line_colors;
+    int road_line_count;           // number of lines (verts = count * 2)
+    int road_cache_valid;
     // PBO double-buffer for async glReadPixels (GPU→CPU DMA)
     unsigned int pbo[2];
     int pbo_index;       // which PBO to read INTO this frame (0 or 1)
@@ -4017,6 +4025,139 @@ void draw_agent_obs(Drive *env, int agent_index, int mode, int obs_only, int las
     }
 }
 
+// Build cached road geometry from env->road_elements. Call once per episode.
+void build_road_cache(Drive *env, Client *client) {
+    // First pass: count triangles and lines
+    int tri_count = 0, line_count = 0;
+    for (int i = 0; i < env->num_roads; i++) {
+        RoadMapElement *road = &env->road_elements[i];
+        int segs = road->segment_length - 1;
+        if (segs <= 0) continue;
+        if (road->type == ROAD_EDGE)
+            tri_count += segs * 14; // 14 triangles per curb segment
+        else if (road->type == ROAD_LANE || road->type == ROAD_LINE)
+            line_count += segs;
+    }
+
+    // Allocate
+    free(client->road_tri_verts);
+    free(client->road_tri_colors);
+    free(client->road_line_verts);
+    free(client->road_line_colors);
+    client->road_tri_verts = (float *)malloc(tri_count * 3 * 3 * sizeof(float));
+    client->road_tri_colors = (unsigned char *)malloc(tri_count * 3 * 4);
+    client->road_line_verts = (float *)malloc(line_count * 2 * 3 * sizeof(float));
+    client->road_line_colors = (unsigned char *)malloc(line_count * 2 * 4);
+    client->road_tri_count = 0;
+    client->road_line_count = 0;
+
+    // Helper to push a triangle
+    #define PUSH_TRI(vx1,vy1,vz1, vx2,vy2,vz2, vx3,vy3,vz3, cr,cg,cb,ca) do { \
+        int _ti = client->road_tri_count * 9; \
+        int _ci = client->road_tri_count * 12; \
+        client->road_tri_verts[_ti+0]=vx1; client->road_tri_verts[_ti+1]=vy1; client->road_tri_verts[_ti+2]=vz1; \
+        client->road_tri_verts[_ti+3]=vx2; client->road_tri_verts[_ti+4]=vy2; client->road_tri_verts[_ti+5]=vz2; \
+        client->road_tri_verts[_ti+6]=vx3; client->road_tri_verts[_ti+7]=vy3; client->road_tri_verts[_ti+8]=vz3; \
+        for (int _v=0;_v<3;_v++) { \
+            client->road_tri_colors[_ci+_v*4+0]=cr; client->road_tri_colors[_ci+_v*4+1]=cg; \
+            client->road_tri_colors[_ci+_v*4+2]=cb; client->road_tri_colors[_ci+_v*4+3]=ca; \
+        } \
+        client->road_tri_count++; \
+    } while(0)
+
+    #define PUSH_LINE(vx1,vy1,vz1, vx2,vy2,vz2, cr,cg,cb,ca) do { \
+        int _li = client->road_line_count * 6; \
+        int _ci = client->road_line_count * 8; \
+        client->road_line_verts[_li+0]=vx1; client->road_line_verts[_li+1]=vy1; client->road_line_verts[_li+2]=vz1; \
+        client->road_line_verts[_li+3]=vx2; client->road_line_verts[_li+4]=vy2; client->road_line_verts[_li+5]=vz2; \
+        for (int _v=0;_v<2;_v++) { \
+            client->road_line_colors[_ci+_v*4+0]=cr; client->road_line_colors[_ci+_v*4+1]=cg; \
+            client->road_line_colors[_ci+_v*4+2]=cb; client->road_line_colors[_ci+_v*4+3]=ca; \
+        } \
+        client->road_line_count++; \
+    } while(0)
+
+    // Second pass: build geometry
+    for (int i = 0; i < env->num_roads; i++) {
+        RoadMapElement *road = &env->road_elements[i];
+        for (int j = 0; j < road->segment_length - 1; j++) {
+            float sx = road->x[j], sy = road->y[j], sz = road->z[j];
+            float ex = road->x[j+1], ey = road->y[j+1], ez = road->z[j+1];
+
+            if (road->type == ROAD_EDGE) {
+                // Same curb geometry as draw_road_edge
+                float curb_height = 0.5f, curb_width = 0.3f;
+                float dx = ex - sx, dy = ey - sy;
+                float len = sqrtf(dx*dx + dy*dy);
+                if (len < 1e-6f) continue;
+                float nx = -dy/len, ny = dx/len; // perpendicular
+                float hw = curb_width / 2;
+
+                float b1x=sx-nx*hw, b1y=sy-ny*hw, b2x=sx+nx*hw, b2y=sy+ny*hw;
+                float b3x=ex+nx*hw, b3y=ey+ny*hw, b4x=ex-nx*hw, b4y=ey-ny*hw;
+                float t1x=b1x, t1y=b1y, t1z=sz+curb_height;
+                float t2x=b2x, t2y=b2y, t2z=sz+curb_height;
+                float t3x=b3x, t3y=b3y, t3z=ez+curb_height;
+                float t4x=b4x, t4y=b4y, t4z=ez+curb_height;
+
+                // Bottom (160,160,160)
+                PUSH_TRI(b1x,b1y,sz, b2x,b2y,sz, b3x,b3y,ez, 160,160,160,255);
+                PUSH_TRI(b1x,b1y,sz, b3x,b3y,ez, b4x,b4y,ez, 160,160,160,255);
+                // Top (220,220,220)
+                PUSH_TRI(t1x,t1y,t1z, t3x,t3y,t3z, t2x,t2y,t2z, 220,220,220,255);
+                PUSH_TRI(t1x,t1y,t1z, t4x,t4y,t4z, t3x,t3y,t3z, 220,220,220,255);
+                // Sides (180,180,180) — 8 triangles for 4 quads
+                PUSH_TRI(b1x,b1y,sz, t1x,t1y,t1z, b2x,b2y,sz, 180,180,180,255);
+                PUSH_TRI(t1x,t1y,t1z, t2x,t2y,t2z, b2x,b2y,sz, 180,180,180,255);
+                PUSH_TRI(b2x,b2y,sz, t2x,t2y,t2z, b3x,b3y,ez, 180,180,180,255);
+                PUSH_TRI(t2x,t2y,t2z, t3x,t3y,t3z, b3x,b3y,ez, 180,180,180,255);
+                PUSH_TRI(b3x,b3y,ez, t3x,t3y,t3z, b4x,b4y,ez, 180,180,180,255);
+                PUSH_TRI(t3x,t3y,t3z, t4x,t4y,t4z, b4x,b4y,ez, 180,180,180,255);
+                PUSH_TRI(b4x,b4y,ez, t4x,t4y,t4z, b1x,b1y,sz, 180,180,180,255);
+                PUSH_TRI(t4x,t4y,t4z, t1x,t1y,t1z, b1x,b1y,sz, 180,180,180,255);
+            } else if (road->type == ROAD_LANE) {
+                Color c = Fade(SOFT_YELLOW, 0.25f);
+                PUSH_LINE(sx,sy,sz, ex,ey,ez, c.r,c.g,c.b,c.a);
+            } else if (road->type == ROAD_LINE) {
+                PUSH_LINE(sx,sy,sz, ex,ey,ez, 255,255,255,255);
+            }
+        }
+    }
+    #undef PUSH_TRI
+    #undef PUSH_LINE
+
+    client->road_cache_valid = 1;
+    fprintf(stderr, "[drive] Road cache built: %d triangles, %d lines\n",
+            client->road_tri_count, client->road_line_count);
+}
+
+// Draw cached road geometry via rlgl batch
+void draw_road_cached(Client *client) {
+    // Triangles (curbs)
+    if (client->road_tri_count > 0) {
+        rlBegin(RL_TRIANGLES);
+        int nv = client->road_tri_count * 3;
+        for (int i = 0; i < nv; i++) {
+            rlColor4ub(client->road_tri_colors[i*4], client->road_tri_colors[i*4+1],
+                       client->road_tri_colors[i*4+2], client->road_tri_colors[i*4+3]);
+            rlVertex3f(client->road_tri_verts[i*3], client->road_tri_verts[i*3+1], client->road_tri_verts[i*3+2]);
+        }
+        rlEnd();
+    }
+    // Lines (lanes, road lines)
+    if (client->road_line_count > 0) {
+        rlSetLineWidth(2.0f);
+        rlBegin(RL_LINES);
+        int nv = client->road_line_count * 2;
+        for (int i = 0; i < nv; i++) {
+            rlColor4ub(client->road_line_colors[i*4], client->road_line_colors[i*4+1],
+                       client->road_line_colors[i*4+2], client->road_line_colors[i*4+3]);
+            rlVertex3f(client->road_line_verts[i*3], client->road_line_verts[i*3+1], client->road_line_verts[i*3+2]);
+        }
+        rlEnd();
+    }
+}
+
 void draw_road_edge(Drive *env, float start_x, float start_y, float end_x, float end_y, float start_z, float end_z) {
     Color CURB_TOP = (Color){220, 220, 220, 255};  // Top surface - lightest
     Color CURB_SIDE = (Color){180, 180, 180, 255}; // Side faces - medium
@@ -4309,28 +4450,24 @@ void draw_scene(Drive *env, Client *client, int mode, int obs_only, int lasers, 
         }
     }
 
-    // Draw road elements
-    for (int i = 0; i < env->num_roads; i++) {
-        RoadMapElement *road = &env->road_elements[i];
-        for (int j = 0; j < road->segment_length - 1; j++) {
-            Vector3 start = {road->x[j], road->y[j], road->z[j]};
-            Vector3 end = {road->x[j + 1], road->y[j + 1], road->z[j + 1]};
-            Color lineColor = GRAY;
-            if (road->type == ROAD_LANE)
-                lineColor = Fade(SOFT_YELLOW, 0.25f);
-            else if (road->type == ROAD_LINE)
-                lineColor = WHITE;
-            else if (road->type == ROAD_EDGE)
-                lineColor = Fade(WHITE, 0.7f);
-            else if (road->type == DRIVEWAY)
-                lineColor = RED;
-
-            if (!IsKeyDown(KEY_LEFT_CONTROL) && obs_only == 0) {
-                if (road->type == ROAD_EDGE) {
-                    draw_road_edge(env, start.x, start.y, end.x, end.y, start.z, end.z);
-                } else if (road->type == ROAD_LANE || road->type == ROAD_LINE) {
-                    rlSetLineWidth(2.0f);
-                    DrawLine3D(start, end, lineColor);
+    // Draw road elements (cached or immediate)
+    if (!IsKeyDown(KEY_LEFT_CONTROL) && obs_only == 0) {
+        if (client->road_cache_valid) {
+            draw_road_cached(client);
+        } else {
+            // Fallback: immediate mode (first frame before cache is built, or interactive)
+            for (int i = 0; i < env->num_roads; i++) {
+                RoadMapElement *road = &env->road_elements[i];
+                for (int j = 0; j < road->segment_length - 1; j++) {
+                    Vector3 start = {road->x[j], road->y[j], road->z[j]};
+                    Vector3 end = {road->x[j + 1], road->y[j + 1], road->z[j + 1]};
+                    if (road->type == ROAD_EDGE) {
+                        draw_road_edge(env, start.x, start.y, end.x, end.y, start.z, end.z);
+                    } else if (road->type == ROAD_LANE || road->type == ROAD_LINE) {
+                        Color lineColor = (road->type == ROAD_LANE) ? Fade(SOFT_YELLOW, 0.25f) : WHITE;
+                        rlSetLineWidth(2.0f);
+                        DrawLine3D(start, end, lineColor);
+                    }
                 }
             }
         }
@@ -4375,6 +4512,11 @@ void c_render(Drive *env, int view_mode, int draw_traces) {
         env->client = make_client(env);
     }
     Client *client = env->client;
+
+    // Build road cache on first render (static geometry, reused every frame)
+    if (!client->road_cache_valid) {
+        build_road_cache(env, client);
+    }
 
     // Per-stage timing. Enabled with DRIVE_RENDER_PROFILE=1 in the environment.
     // Prints rolling averages every DRIVE_RENDER_PROFILE_EVERY frames (default 60).
@@ -4636,6 +4778,12 @@ void close_client(Client *client) {
         glDeleteBuffers(2, client->pbo);
     }
 #endif
+    // Free road cache
+    free(client->road_tri_verts);
+    free(client->road_tri_colors);
+    free(client->road_line_verts);
+    free(client->road_line_colors);
+
     if (client->recorder_pid > 0) {
         close(client->recorder_pipefd[1]);
         waitpid(client->recorder_pid, NULL, 0);

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -4815,24 +4815,26 @@ void close_client(Client *client) {
     if (client->egl_mode) {
         rlglClose();
         egl_headless_cleanup();
-    } else
+    }
 #endif
-    {
+    // Always clean up GLFW/Xvfb — even in EGL mode, InitWindow was called
+    // and must be matched by CloseWindow to avoid stale state on next eval.
+    if (!client->egl_mode) {
         for (int i = 0; i < 6; i++)
             UnloadModel(client->cars[i]);
         UnloadModel(client->cyclist);
         UnloadModel(client->pedestrian);
-        CloseWindow();
-        if (client->xvfb_pid > 0) {
-            kill(client->xvfb_pid, SIGTERM);
-            waitpid(client->xvfb_pid, NULL, 0);
-            char lock_file[32], socket_file[32];
-            snprintf(lock_file, sizeof(lock_file), "/tmp/.X%d-lock", client->xvfb_display_num);
-            snprintf(socket_file, sizeof(socket_file), "/tmp/.X11-unix/X%d", client->xvfb_display_num);
-            unlink(lock_file);
-            unlink(socket_file);
-            unsetenv("DISPLAY");
-        }
+    }
+    CloseWindow();
+    if (client->xvfb_pid > 0) {
+        kill(client->xvfb_pid, SIGTERM);
+        waitpid(client->xvfb_pid, NULL, 0);
+        char lock_file[32], socket_file[32];
+        snprintf(lock_file, sizeof(lock_file), "/tmp/.X%d-lock", client->xvfb_display_num);
+        snprintf(socket_file, sizeof(socket_file), "/tmp/.X11-unix/X%d", client->xvfb_display_num);
+        unlink(lock_file);
+        unlink(socket_file);
+        unsetenv("DISPLAY");
     }
 
     free(client);

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -3539,10 +3539,9 @@ struct Client {
     int xvfb_display_num;
     int egl_mode; // 1 = EGL headless GPU rendering (no Xvfb/InitWindow)
     // Cached static road geometry (rebuilt once per episode, drawn every frame)
-    float *road_tri_verts;         // 3 floats (x,y,z) per vertex
-    unsigned char *road_tri_colors; // 4 bytes (RGBA) per vertex
-    int road_tri_count;            // number of triangles (verts = count * 3)
-    float *road_line_verts;
+    Mesh road_tri_mesh;            // curb triangles — uploaded to GPU VBO, drawn with one DrawMesh call
+    Material road_material;        // default material for road mesh
+    float *road_line_verts;        // lane/road lines — small, drawn via rlgl
     unsigned char *road_line_colors;
     int road_line_count;           // number of lines (verts = count * 2)
     int road_cache_valid;
@@ -4026,6 +4025,8 @@ void draw_agent_obs(Drive *env, int agent_index, int mode, int obs_only, int las
 }
 
 // Build cached road geometry from env->road_elements. Call once per episode.
+// Curb triangles are uploaded to a GPU VBO (Mesh) for single-draw-call rendering.
+// Lane/road lines are kept in CPU arrays for rlgl replay (small count, not worth VBO).
 void build_road_cache(Drive *env, Client *client) {
     // First pass: count triangles and lines
     int tri_count = 0, line_count = 0;
@@ -4034,35 +4035,32 @@ void build_road_cache(Drive *env, Client *client) {
         int segs = road->segment_length - 1;
         if (segs <= 0) continue;
         if (road->type == ROAD_EDGE)
-            tri_count += segs * 14; // 14 triangles per curb segment
+            tri_count += segs * 14;
         else if (road->type == ROAD_LANE || road->type == ROAD_LINE)
             line_count += segs;
     }
 
-    // Allocate
-    free(client->road_tri_verts);
-    free(client->road_tri_colors);
+    int num_tri_verts = tri_count * 3;
+    float *tri_verts = (float *)RL_CALLOC(num_tri_verts * 3, sizeof(float));
+    unsigned char *tri_colors = (unsigned char *)RL_CALLOC(num_tri_verts * 4, sizeof(unsigned char));
     free(client->road_line_verts);
     free(client->road_line_colors);
-    client->road_tri_verts = (float *)malloc(tri_count * 3 * 3 * sizeof(float));
-    client->road_tri_colors = (unsigned char *)malloc(tri_count * 3 * 4);
     client->road_line_verts = (float *)malloc(line_count * 2 * 3 * sizeof(float));
     client->road_line_colors = (unsigned char *)malloc(line_count * 2 * 4);
-    client->road_tri_count = 0;
+    int actual_tri_count = 0;
     client->road_line_count = 0;
 
-    // Helper to push a triangle
     #define PUSH_TRI(vx1,vy1,vz1, vx2,vy2,vz2, vx3,vy3,vz3, cr,cg,cb,ca) do { \
-        int _ti = client->road_tri_count * 9; \
-        int _ci = client->road_tri_count * 12; \
-        client->road_tri_verts[_ti+0]=vx1; client->road_tri_verts[_ti+1]=vy1; client->road_tri_verts[_ti+2]=vz1; \
-        client->road_tri_verts[_ti+3]=vx2; client->road_tri_verts[_ti+4]=vy2; client->road_tri_verts[_ti+5]=vz2; \
-        client->road_tri_verts[_ti+6]=vx3; client->road_tri_verts[_ti+7]=vy3; client->road_tri_verts[_ti+8]=vz3; \
+        int _ti = actual_tri_count * 9; \
+        int _ci = actual_tri_count * 12; \
+        tri_verts[_ti+0]=vx1; tri_verts[_ti+1]=vy1; tri_verts[_ti+2]=vz1; \
+        tri_verts[_ti+3]=vx2; tri_verts[_ti+4]=vy2; tri_verts[_ti+5]=vz2; \
+        tri_verts[_ti+6]=vx3; tri_verts[_ti+7]=vy3; tri_verts[_ti+8]=vz3; \
         for (int _v=0;_v<3;_v++) { \
-            client->road_tri_colors[_ci+_v*4+0]=cr; client->road_tri_colors[_ci+_v*4+1]=cg; \
-            client->road_tri_colors[_ci+_v*4+2]=cb; client->road_tri_colors[_ci+_v*4+3]=ca; \
+            tri_colors[_ci+_v*4+0]=cr; tri_colors[_ci+_v*4+1]=cg; \
+            tri_colors[_ci+_v*4+2]=cb; tri_colors[_ci+_v*4+3]=ca; \
         } \
-        client->road_tri_count++; \
+        actual_tri_count++; \
     } while(0)
 
     #define PUSH_LINE(vx1,vy1,vz1, vx2,vy2,vz2, cr,cg,cb,ca) do { \
@@ -4085,12 +4083,11 @@ void build_road_cache(Drive *env, Client *client) {
             float ex = road->x[j+1], ey = road->y[j+1], ez = road->z[j+1];
 
             if (road->type == ROAD_EDGE) {
-                // Same curb geometry as draw_road_edge
                 float curb_height = 0.5f, curb_width = 0.3f;
                 float dx = ex - sx, dy = ey - sy;
                 float len = sqrtf(dx*dx + dy*dy);
                 if (len < 1e-6f) continue;
-                float nx = -dy/len, ny = dx/len; // perpendicular
+                float nx = -dy/len, ny = dx/len;
                 float hw = curb_width / 2;
 
                 float b1x=sx-nx*hw, b1y=sy-ny*hw, b2x=sx+nx*hw, b2y=sy+ny*hw;
@@ -4100,13 +4097,10 @@ void build_road_cache(Drive *env, Client *client) {
                 float t3x=b3x, t3y=b3y, t3z=ez+curb_height;
                 float t4x=b4x, t4y=b4y, t4z=ez+curb_height;
 
-                // Bottom (160,160,160)
                 PUSH_TRI(b1x,b1y,sz, b2x,b2y,sz, b3x,b3y,ez, 160,160,160,255);
                 PUSH_TRI(b1x,b1y,sz, b3x,b3y,ez, b4x,b4y,ez, 160,160,160,255);
-                // Top (220,220,220)
                 PUSH_TRI(t1x,t1y,t1z, t3x,t3y,t3z, t2x,t2y,t2z, 220,220,220,255);
                 PUSH_TRI(t1x,t1y,t1z, t4x,t4y,t4z, t3x,t3y,t3z, 220,220,220,255);
-                // Sides (180,180,180) — 8 triangles for 4 quads
                 PUSH_TRI(b1x,b1y,sz, t1x,t1y,t1z, b2x,b2y,sz, 180,180,180,255);
                 PUSH_TRI(t1x,t1y,t1z, t2x,t2y,t2z, b2x,b2y,sz, 180,180,180,255);
                 PUSH_TRI(b2x,b2y,sz, t2x,t2y,t2z, b3x,b3y,ez, 180,180,180,255);
@@ -4126,25 +4120,28 @@ void build_road_cache(Drive *env, Client *client) {
     #undef PUSH_TRI
     #undef PUSH_LINE
 
+    // Upload curb triangles to GPU as a Mesh (single VBO draw call per frame)
+    Mesh mesh = {0};
+    mesh.vertexCount = actual_tri_count * 3;
+    mesh.triangleCount = actual_tri_count;
+    mesh.vertices = tri_verts;
+    mesh.colors = tri_colors;
+    UploadMesh(&mesh, false); // static draw — data goes to GPU, CPU arrays kept for UnloadMesh
+    client->road_tri_mesh = mesh;
+    client->road_material = LoadMaterialDefault();
+
     client->road_cache_valid = 1;
-    fprintf(stderr, "[drive] Road cache built: %d triangles, %d lines\n",
-            client->road_tri_count, client->road_line_count);
+    fprintf(stderr, "[drive] Road cache: %d triangles (VBO), %d lines (rlgl)\n",
+            actual_tri_count, client->road_line_count);
 }
 
-// Draw cached road geometry via rlgl batch
+// Draw cached road geometry: VBO for curbs, rlgl for lines
 void draw_road_cached(Client *client) {
-    // Triangles (curbs)
-    if (client->road_tri_count > 0) {
-        rlBegin(RL_TRIANGLES);
-        int nv = client->road_tri_count * 3;
-        for (int i = 0; i < nv; i++) {
-            rlColor4ub(client->road_tri_colors[i*4], client->road_tri_colors[i*4+1],
-                       client->road_tri_colors[i*4+2], client->road_tri_colors[i*4+3]);
-            rlVertex3f(client->road_tri_verts[i*3], client->road_tri_verts[i*3+1], client->road_tri_verts[i*3+2]);
-        }
-        rlEnd();
+    // Curb triangles — single GPU draw call via Mesh VBO
+    if (client->road_tri_mesh.vertexCount > 0) {
+        DrawMesh(client->road_tri_mesh, client->road_material, MatrixIdentity());
     }
-    // Lines (lanes, road lines)
+    // Lane/road lines — small count, rlgl replay is fine
     if (client->road_line_count > 0) {
         rlSetLineWidth(2.0f);
         rlBegin(RL_LINES);
@@ -4612,7 +4609,16 @@ void c_render(Drive *env, int view_mode, int draw_traces) {
         }
 
         EndMode3D();
-        EndDrawing();
+#ifdef __linux__
+        if (client->egl_mode) {
+            // EGL headless: just flush the rlgl batch. Skip EndDrawing's
+            // glfwSwapBuffers + glfwPollEvents which are unnecessary (no window).
+            rlDrawRenderBatchActive();
+        } else
+#endif
+        {
+            EndDrawing();
+        }
 
         if (profile_enabled) t_draw_end = GetTime();
 
@@ -4779,8 +4785,9 @@ void close_client(Client *client) {
     }
 #endif
     // Free road cache
-    free(client->road_tri_verts);
-    free(client->road_tri_colors);
+    if (client->road_cache_valid) {
+        UnloadMesh(client->road_tri_mesh);
+    }
     free(client->road_line_verts);
     free(client->road_line_colors);
 

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -18,7 +18,16 @@
 #include "error.h"
 #include "datatypes.h"
 
-#ifdef __linux__
+// EGL is optional: only compile in the EGL headless path if the headers
+// are available. CI environments without libegl1-mesa-dev skip this entirely
+// and fall back to Xvfb/Mesa software rendering.
+#if defined(__linux__) && defined(__has_include)
+#if __has_include(<EGL/egl.h>)
+#define DRIVE_HAS_EGL 1
+#endif
+#endif
+
+#ifdef DRIVE_HAS_EGL
 #include "egl_headless.h"
 #endif
 
@@ -3646,7 +3655,7 @@ Client *make_client(Drive *env) {
         client->car_assignments[i] = (rand() % 4) + 1;
     }
 
-#ifdef __linux__
+#ifdef DRIVE_HAS_EGL
     // EGL GPU context: create per render env (different maps = different resolutions).
     // The EGL display is persistent (never terminated — eglTerminate breaks CUDA).
     // We destroy the old surface+context and create fresh ones for the new resolution,
@@ -3710,7 +3719,7 @@ Client *make_client(Drive *env) {
             close(client->recorder_pipefd[0]);
             for (int fd = 3; fd < 256; fd++)
                 close(fd);
-#ifdef __linux__
+#ifdef DRIVE_HAS_EGL
             if (client->egl_mode) {
                 // GPU/PBO path: same ffmpeg command as non-EGL (video may be vertically
                 // flipped but this confirms PBO data reaches ffmpeg).
@@ -3729,7 +3738,7 @@ Client *make_client(Drive *env) {
                 client->recorder_pipefd[1], size_str, filename, client->egl_mode);
 
         // Increase pipe buffer to reduce write() blocking on large frames
-#ifdef __linux__
+#ifdef DRIVE_HAS_EGL
         {
             int pipe_sz = fcntl(client->recorder_pipefd[1], F_SETPIPE_SZ, 4 * 1024 * 1024);
             if (pipe_sz > 0) {
@@ -4663,7 +4672,7 @@ void c_render(Drive *env, int view_mode, int draw_traces) {
         }
 
         EndMode3D();
-#ifdef __linux__
+#ifdef DRIVE_HAS_EGL
         if (client->egl_mode) {
             // EGL headless: just flush the rlgl batch. Skip EndDrawing's
             // glfwSwapBuffers + glfwPollEvents which are unnecessary (no window).
@@ -4680,7 +4689,7 @@ void c_render(Drive *env, int view_mode, int draw_traces) {
         int w = (int)client->width, h = (int)client->height;
         int frame_bytes = w * h * 4;
 
-#ifdef __linux__
+#ifdef DRIVE_HAS_EGL
         if (client->egl_mode && 0) { // DISABLED: use sync readback to debug pipe
             // PBO double-buffer: async GPU→CPU readback overlapped with next frame's draw.
             // Frame flow:
@@ -4834,7 +4843,7 @@ void c_render(Drive *env, int view_mode, int draw_traces) {
 }
 
 void close_client(Client *client) {
-#ifdef __linux__
+#ifdef DRIVE_HAS_EGL
     // Flush the last PBO frame before closing the pipe
     if (client->egl_mode && client->pbo_frame_count > 0 && client->pbo[0] != 0) {
         int prev = 1 - client->pbo_index;

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -3652,20 +3652,31 @@ Client *make_client(Drive *env) {
     // then re-init rlgl so render batches live on the current GPU context.
     if (env->render_mode == RENDER_HEADLESS) {
         if (g_egl_available != 0) {
-            // Destroy previous EGL surface+context if they exist
-            egl_headless_cleanup();
-            if (egl_headless_init((int)client->width, (int)client->height)) {
-                if (egl_switch_to_gpu()) {
-                    rlglInit((int)client->width, (int)client->height);
-                    rlViewport(0, 0, (int)client->width, (int)client->height);
-                    rlEnableDepthTest();
-                    client->egl_mode = 1;
-                    g_egl_available = 1;
+            if (!g_egl_ctx.active) {
+                // First time: create EGL context and switch to GPU
+                if (egl_headless_init((int)client->width, (int)client->height)) {
+                    if (egl_switch_to_gpu()) {
+                        rlglInit((int)client->width, (int)client->height);
+                        rlViewport(0, 0, (int)client->width, (int)client->height);
+                        rlEnableDepthTest();
+                        g_egl_available = 1;
+                    }
                 }
+                if (g_egl_available < 0) {
+                    g_egl_available = 0;
+                    fprintf(stderr, "[drive] EGL GPU unavailable, using Xvfb/Mesa (software rendering)\n");
+                }
+            } else {
+                // Subsequent render envs: EGL context is still alive (persists across
+                // render envs to keep model/texture uploads valid). Just re-init rlgl
+                // for fresh batch state and update viewport for this env's resolution.
+                rlglClose();
+                rlglInit((int)client->width, (int)client->height);
+                rlViewport(0, 0, (int)client->width, (int)client->height);
+                rlEnableDepthTest();
             }
-            if (!client->egl_mode && g_egl_available < 0) {
-                g_egl_available = 0; // Don't retry on future render envs
-                fprintf(stderr, "[drive] EGL GPU unavailable, using Xvfb/Mesa (software rendering)\n");
+            if (g_egl_available == 1) {
+                client->egl_mode = 1;
             }
         }
     }

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -3539,11 +3539,11 @@ struct Client {
     int xvfb_display_num;
     int egl_mode; // 1 = EGL headless GPU rendering (no Xvfb/InitWindow)
     // Cached static road geometry (rebuilt once per episode, drawn every frame)
-    Mesh road_tri_mesh;            // curb triangles — uploaded to GPU VBO, drawn with one DrawMesh call
-    Material road_material;        // default material for road mesh
-    float *road_line_verts;        // lane/road lines — small, drawn via rlgl
+    Mesh road_tri_mesh;     // curb triangles — uploaded to GPU VBO, drawn with one DrawMesh call
+    Material road_material; // default material for road mesh
+    float *road_line_verts; // lane/road lines — small, drawn via rlgl
     unsigned char *road_line_colors;
-    int road_line_count;           // number of lines (verts = count * 2)
+    int road_line_count; // number of lines (verts = count * 2)
     int road_cache_valid;
     // PBO double-buffer for async glReadPixels (GPU→CPU DMA)
     unsigned int pbo[2];
@@ -3687,23 +3687,18 @@ Client *make_client(Drive *env) {
             if (client->egl_mode) {
                 // GPU path: PBO readback skips row flip, so ffmpeg must vflip.
                 // Try NVENC first; fall through to libx264 if unavailable.
-                execlp("ffmpeg", "ffmpeg", "-y",
-                       "-f", "rawvideo", "-pix_fmt", "rgba", "-s", size_str, "-r", "30", "-i", "-",
-                       "-vf", "vflip",
-                       "-c:v", "h264_nvenc", "-preset", "p1", "-cq", "23",
-                       "-pix_fmt", "yuv420p", "-loglevel", "error", filename, NULL);
-                // NVENC failed — try libx264 with vflip
-                execlp("ffmpeg", "ffmpeg", "-y",
-                       "-f", "rawvideo", "-pix_fmt", "rgba", "-s", size_str, "-r", "30", "-i", "-",
-                       "-vf", "vflip",
-                       "-c:v", "libx264", "-pix_fmt", "yuv420p", "-preset", "ultrafast", "-crf", "23",
+                execlp("ffmpeg", "ffmpeg", "-y", "-f", "rawvideo", "-pix_fmt", "rgba", "-s", size_str, "-r", "30", "-i",
+                       "-", "-vf", "vflip", "-c:v", "h264_nvenc", "-preset", "p1", "-cq", "23", "-pix_fmt", "yuv420p",
                        "-loglevel", "error", filename, NULL);
+                // NVENC failed — try libx264 with vflip
+                execlp("ffmpeg", "ffmpeg", "-y", "-f", "rawvideo", "-pix_fmt", "rgba", "-s", size_str, "-r", "30", "-i",
+                       "-", "-vf", "vflip", "-c:v", "libx264", "-pix_fmt", "yuv420p", "-preset", "ultrafast", "-crf",
+                       "23", "-loglevel", "error", filename, NULL);
             }
 #endif
-            execlp("ffmpeg", "ffmpeg", "-y",
-                   "-f", "rawvideo", "-pix_fmt", "rgba", "-s", size_str, "-r", "30", "-i", "-",
-                   "-c:v", "libx264", "-pix_fmt", "yuv420p", "-preset", "ultrafast", "-crf", "23",
-                   "-loglevel", "error", filename, NULL);
+            execlp("ffmpeg", "ffmpeg", "-y", "-f", "rawvideo", "-pix_fmt", "rgba", "-s", size_str, "-r", "30", "-i",
+                   "-", "-c:v", "libx264", "-pix_fmt", "yuv420p", "-preset", "ultrafast", "-crf", "23", "-loglevel",
+                   "error", filename, NULL);
             fprintf(stderr, "execlp ffmpeg failed\n");
             _exit(1);
         }
@@ -4033,7 +4028,8 @@ void build_road_cache(Drive *env, Client *client) {
     for (int i = 0; i < env->num_roads; i++) {
         RoadMapElement *road = &env->road_elements[i];
         int segs = road->segment_length - 1;
-        if (segs <= 0) continue;
+        if (segs <= 0)
+            continue;
         if (road->type == ROAD_EDGE)
             tri_count += segs * 14;
         else if (road->type == ROAD_LANE || road->type == ROAD_LINE)
@@ -4050,75 +4046,92 @@ void build_road_cache(Drive *env, Client *client) {
     int actual_tri_count = 0;
     client->road_line_count = 0;
 
-    #define PUSH_TRI(vx1,vy1,vz1, vx2,vy2,vz2, vx3,vy3,vz3, cr,cg,cb,ca) do { \
-        int _ti = actual_tri_count * 9; \
-        int _ci = actual_tri_count * 12; \
-        tri_verts[_ti+0]=vx1; tri_verts[_ti+1]=vy1; tri_verts[_ti+2]=vz1; \
-        tri_verts[_ti+3]=vx2; tri_verts[_ti+4]=vy2; tri_verts[_ti+5]=vz2; \
-        tri_verts[_ti+6]=vx3; tri_verts[_ti+7]=vy3; tri_verts[_ti+8]=vz3; \
-        for (int _v=0;_v<3;_v++) { \
-            tri_colors[_ci+_v*4+0]=cr; tri_colors[_ci+_v*4+1]=cg; \
-            tri_colors[_ci+_v*4+2]=cb; tri_colors[_ci+_v*4+3]=ca; \
-        } \
-        actual_tri_count++; \
-    } while(0)
+#define PUSH_TRI(vx1, vy1, vz1, vx2, vy2, vz2, vx3, vy3, vz3, cr, cg, cb, ca)                                          \
+    do {                                                                                                               \
+        int _ti = actual_tri_count * 9;                                                                                \
+        int _ci = actual_tri_count * 12;                                                                               \
+        tri_verts[_ti + 0] = vx1;                                                                                      \
+        tri_verts[_ti + 1] = vy1;                                                                                      \
+        tri_verts[_ti + 2] = vz1;                                                                                      \
+        tri_verts[_ti + 3] = vx2;                                                                                      \
+        tri_verts[_ti + 4] = vy2;                                                                                      \
+        tri_verts[_ti + 5] = vz2;                                                                                      \
+        tri_verts[_ti + 6] = vx3;                                                                                      \
+        tri_verts[_ti + 7] = vy3;                                                                                      \
+        tri_verts[_ti + 8] = vz3;                                                                                      \
+        for (int _v = 0; _v < 3; _v++) {                                                                               \
+            tri_colors[_ci + _v * 4 + 0] = cr;                                                                         \
+            tri_colors[_ci + _v * 4 + 1] = cg;                                                                         \
+            tri_colors[_ci + _v * 4 + 2] = cb;                                                                         \
+            tri_colors[_ci + _v * 4 + 3] = ca;                                                                         \
+        }                                                                                                              \
+        actual_tri_count++;                                                                                            \
+    } while (0)
 
-    #define PUSH_LINE(vx1,vy1,vz1, vx2,vy2,vz2, cr,cg,cb,ca) do { \
-        int _li = client->road_line_count * 6; \
-        int _ci = client->road_line_count * 8; \
-        client->road_line_verts[_li+0]=vx1; client->road_line_verts[_li+1]=vy1; client->road_line_verts[_li+2]=vz1; \
-        client->road_line_verts[_li+3]=vx2; client->road_line_verts[_li+4]=vy2; client->road_line_verts[_li+5]=vz2; \
-        for (int _v=0;_v<2;_v++) { \
-            client->road_line_colors[_ci+_v*4+0]=cr; client->road_line_colors[_ci+_v*4+1]=cg; \
-            client->road_line_colors[_ci+_v*4+2]=cb; client->road_line_colors[_ci+_v*4+3]=ca; \
-        } \
-        client->road_line_count++; \
-    } while(0)
+#define PUSH_LINE(vx1, vy1, vz1, vx2, vy2, vz2, cr, cg, cb, ca)                                                        \
+    do {                                                                                                               \
+        int _li = client->road_line_count * 6;                                                                         \
+        int _ci = client->road_line_count * 8;                                                                         \
+        client->road_line_verts[_li + 0] = vx1;                                                                        \
+        client->road_line_verts[_li + 1] = vy1;                                                                        \
+        client->road_line_verts[_li + 2] = vz1;                                                                        \
+        client->road_line_verts[_li + 3] = vx2;                                                                        \
+        client->road_line_verts[_li + 4] = vy2;                                                                        \
+        client->road_line_verts[_li + 5] = vz2;                                                                        \
+        for (int _v = 0; _v < 2; _v++) {                                                                               \
+            client->road_line_colors[_ci + _v * 4 + 0] = cr;                                                           \
+            client->road_line_colors[_ci + _v * 4 + 1] = cg;                                                           \
+            client->road_line_colors[_ci + _v * 4 + 2] = cb;                                                           \
+            client->road_line_colors[_ci + _v * 4 + 3] = ca;                                                           \
+        }                                                                                                              \
+        client->road_line_count++;                                                                                     \
+    } while (0)
 
     // Second pass: build geometry
     for (int i = 0; i < env->num_roads; i++) {
         RoadMapElement *road = &env->road_elements[i];
         for (int j = 0; j < road->segment_length - 1; j++) {
             float sx = road->x[j], sy = road->y[j], sz = road->z[j];
-            float ex = road->x[j+1], ey = road->y[j+1], ez = road->z[j+1];
+            float ex = road->x[j + 1], ey = road->y[j + 1], ez = road->z[j + 1];
 
             if (road->type == ROAD_EDGE) {
                 float curb_height = 0.5f, curb_width = 0.3f;
                 float dx = ex - sx, dy = ey - sy;
-                float len = sqrtf(dx*dx + dy*dy);
-                if (len < 1e-6f) continue;
-                float nx = -dy/len, ny = dx/len;
+                float len = sqrtf(dx * dx + dy * dy);
+                if (len < 1e-6f)
+                    continue;
+                float nx = -dy / len, ny = dx / len;
                 float hw = curb_width / 2;
 
-                float b1x=sx-nx*hw, b1y=sy-ny*hw, b2x=sx+nx*hw, b2y=sy+ny*hw;
-                float b3x=ex+nx*hw, b3y=ey+ny*hw, b4x=ex-nx*hw, b4y=ey-ny*hw;
-                float t1x=b1x, t1y=b1y, t1z=sz+curb_height;
-                float t2x=b2x, t2y=b2y, t2z=sz+curb_height;
-                float t3x=b3x, t3y=b3y, t3z=ez+curb_height;
-                float t4x=b4x, t4y=b4y, t4z=ez+curb_height;
+                float b1x = sx - nx * hw, b1y = sy - ny * hw, b2x = sx + nx * hw, b2y = sy + ny * hw;
+                float b3x = ex + nx * hw, b3y = ey + ny * hw, b4x = ex - nx * hw, b4y = ey - ny * hw;
+                float t1x = b1x, t1y = b1y, t1z = sz + curb_height;
+                float t2x = b2x, t2y = b2y, t2z = sz + curb_height;
+                float t3x = b3x, t3y = b3y, t3z = ez + curb_height;
+                float t4x = b4x, t4y = b4y, t4z = ez + curb_height;
 
-                PUSH_TRI(b1x,b1y,sz, b2x,b2y,sz, b3x,b3y,ez, 160,160,160,255);
-                PUSH_TRI(b1x,b1y,sz, b3x,b3y,ez, b4x,b4y,ez, 160,160,160,255);
-                PUSH_TRI(t1x,t1y,t1z, t3x,t3y,t3z, t2x,t2y,t2z, 220,220,220,255);
-                PUSH_TRI(t1x,t1y,t1z, t4x,t4y,t4z, t3x,t3y,t3z, 220,220,220,255);
-                PUSH_TRI(b1x,b1y,sz, t1x,t1y,t1z, b2x,b2y,sz, 180,180,180,255);
-                PUSH_TRI(t1x,t1y,t1z, t2x,t2y,t2z, b2x,b2y,sz, 180,180,180,255);
-                PUSH_TRI(b2x,b2y,sz, t2x,t2y,t2z, b3x,b3y,ez, 180,180,180,255);
-                PUSH_TRI(t2x,t2y,t2z, t3x,t3y,t3z, b3x,b3y,ez, 180,180,180,255);
-                PUSH_TRI(b3x,b3y,ez, t3x,t3y,t3z, b4x,b4y,ez, 180,180,180,255);
-                PUSH_TRI(t3x,t3y,t3z, t4x,t4y,t4z, b4x,b4y,ez, 180,180,180,255);
-                PUSH_TRI(b4x,b4y,ez, t4x,t4y,t4z, b1x,b1y,sz, 180,180,180,255);
-                PUSH_TRI(t4x,t4y,t4z, t1x,t1y,t1z, b1x,b1y,sz, 180,180,180,255);
+                PUSH_TRI(b1x, b1y, sz, b2x, b2y, sz, b3x, b3y, ez, 160, 160, 160, 255);
+                PUSH_TRI(b1x, b1y, sz, b3x, b3y, ez, b4x, b4y, ez, 160, 160, 160, 255);
+                PUSH_TRI(t1x, t1y, t1z, t3x, t3y, t3z, t2x, t2y, t2z, 220, 220, 220, 255);
+                PUSH_TRI(t1x, t1y, t1z, t4x, t4y, t4z, t3x, t3y, t3z, 220, 220, 220, 255);
+                PUSH_TRI(b1x, b1y, sz, t1x, t1y, t1z, b2x, b2y, sz, 180, 180, 180, 255);
+                PUSH_TRI(t1x, t1y, t1z, t2x, t2y, t2z, b2x, b2y, sz, 180, 180, 180, 255);
+                PUSH_TRI(b2x, b2y, sz, t2x, t2y, t2z, b3x, b3y, ez, 180, 180, 180, 255);
+                PUSH_TRI(t2x, t2y, t2z, t3x, t3y, t3z, b3x, b3y, ez, 180, 180, 180, 255);
+                PUSH_TRI(b3x, b3y, ez, t3x, t3y, t3z, b4x, b4y, ez, 180, 180, 180, 255);
+                PUSH_TRI(t3x, t3y, t3z, t4x, t4y, t4z, b4x, b4y, ez, 180, 180, 180, 255);
+                PUSH_TRI(b4x, b4y, ez, t4x, t4y, t4z, b1x, b1y, sz, 180, 180, 180, 255);
+                PUSH_TRI(t4x, t4y, t4z, t1x, t1y, t1z, b1x, b1y, sz, 180, 180, 180, 255);
             } else if (road->type == ROAD_LANE) {
                 Color c = Fade(SOFT_YELLOW, 0.25f);
-                PUSH_LINE(sx,sy,sz, ex,ey,ez, c.r,c.g,c.b,c.a);
+                PUSH_LINE(sx, sy, sz, ex, ey, ez, c.r, c.g, c.b, c.a);
             } else if (road->type == ROAD_LINE) {
-                PUSH_LINE(sx,sy,sz, ex,ey,ez, 255,255,255,255);
+                PUSH_LINE(sx, sy, sz, ex, ey, ez, 255, 255, 255, 255);
             }
         }
     }
-    #undef PUSH_TRI
-    #undef PUSH_LINE
+#undef PUSH_TRI
+#undef PUSH_LINE
 
     // Upload curb triangles to GPU as a Mesh (single VBO draw call per frame)
     Mesh mesh = {0};
@@ -4131,8 +4144,8 @@ void build_road_cache(Drive *env, Client *client) {
     client->road_material = LoadMaterialDefault();
 
     client->road_cache_valid = 1;
-    fprintf(stderr, "[drive] Road cache: %d triangles (VBO), %d lines (rlgl)\n",
-            actual_tri_count, client->road_line_count);
+    fprintf(stderr, "[drive] Road cache: %d triangles (VBO), %d lines (rlgl)\n", actual_tri_count,
+            client->road_line_count);
 }
 
 // Draw cached road geometry: VBO for curbs, rlgl for lines
@@ -4147,9 +4160,10 @@ void draw_road_cached(Client *client) {
         rlBegin(RL_LINES);
         int nv = client->road_line_count * 2;
         for (int i = 0; i < nv; i++) {
-            rlColor4ub(client->road_line_colors[i*4], client->road_line_colors[i*4+1],
-                       client->road_line_colors[i*4+2], client->road_line_colors[i*4+3]);
-            rlVertex3f(client->road_line_verts[i*3], client->road_line_verts[i*3+1], client->road_line_verts[i*3+2]);
+            rlColor4ub(client->road_line_colors[i * 4], client->road_line_colors[i * 4 + 1],
+                       client->road_line_colors[i * 4 + 2], client->road_line_colors[i * 4 + 3]);
+            rlVertex3f(client->road_line_verts[i * 3], client->road_line_verts[i * 3 + 1],
+                       client->road_line_verts[i * 3 + 2]);
         }
         rlEnd();
     }
@@ -4531,7 +4545,8 @@ void c_render(Drive *env, int view_mode, int draw_traces) {
         profile_every = (n && atoi(n) > 0) ? atoi(n) : 60;
     }
     double t_draw_start = 0.0, t_draw_end = 0.0, t_read_end = 0.0, t_pipe_end = 0.0;
-    if (profile_enabled) t_draw_start = GetTime();
+    if (profile_enabled)
+        t_draw_start = GetTime();
 
     if (env->render_mode == RENDER_HEADLESS) { // Headless rendering via ffmpeg
         float map_width = env->grid_map->bottom_right_x - env->grid_map->top_left_x;
@@ -4555,19 +4570,21 @@ void c_render(Drive *env, int view_mode, int draw_traces) {
                     int idx = env->active_agent_indices[i];
                     for (int t = env->init_steps; t < env->episode_length; t++) {
                         Color agent_color = LIGHTBLUE;
-                        if (env->agents[idx].type == PEDESTRIAN) agent_color = LIGHT_ORANGE;
-                        else if (env->agents[idx].type == CYCLIST) agent_color = LIGHT_PURPLE;
-                        DrawSphere((Vector3){env->agents[idx].log_trajectory_x[t],
-                                             env->agents[idx].log_trajectory_y[t],
-                                             env->agents[idx].log_trajectory_z[t]}, 0.15f, agent_color);
+                        if (env->agents[idx].type == PEDESTRIAN)
+                            agent_color = LIGHT_ORANGE;
+                        else if (env->agents[idx].type == CYCLIST)
+                            agent_color = LIGHT_PURPLE;
+                        DrawSphere((Vector3){env->agents[idx].log_trajectory_x[t], env->agents[idx].log_trajectory_y[t],
+                                             env->agents[idx].log_trajectory_z[t]},
+                                   0.15f, agent_color);
                     }
                 }
                 for (int i = 0; i < env->expert_static_agent_count; i++) {
                     int idx = env->expert_static_agent_indices[i];
                     for (int t = env->init_steps; t < env->episode_length; t++) {
-                        DrawSphere((Vector3){env->agents[idx].log_trajectory_x[t],
-                                             env->agents[idx].log_trajectory_y[t],
-                                             env->agents[idx].log_trajectory_z[t]}, 0.15f, EXPERT_REPLAY);
+                        DrawSphere((Vector3){env->agents[idx].log_trajectory_x[t], env->agents[idx].log_trajectory_y[t],
+                                             env->agents[idx].log_trajectory_z[t]},
+                                   0.15f, EXPERT_REPLAY);
                     }
                 }
             }
@@ -4620,7 +4637,8 @@ void c_render(Drive *env, int view_mode, int draw_traces) {
             EndDrawing();
         }
 
-        if (profile_enabled) t_draw_end = GetTime();
+        if (profile_enabled)
+            t_draw_end = GetTime();
 
         int w = (int)client->width, h = (int)client->height;
         int frame_bytes = w * h * 4;
@@ -4652,7 +4670,8 @@ void c_render(Drive *env, int view_mode, int draw_traces) {
             glReadPixels(0, 0, w, h, GL_RGBA, GL_UNSIGNED_BYTE, 0);
             glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
 
-            if (profile_enabled) t_read_end = GetTime();
+            if (profile_enabled)
+                t_read_end = GetTime();
 
             // Map previous PBO and write to pipe (skip frame 0 — no previous data)
             if (client->pbo_frame_count > 0) {
@@ -4672,7 +4691,8 @@ void c_render(Drive *env, int view_mode, int draw_traces) {
         {
             // Synchronous fallback (Xvfb/Mesa path)
             unsigned char *screen_data = rlReadScreenPixels(w, h);
-            if (profile_enabled) t_read_end = GetTime();
+            if (profile_enabled)
+                t_read_end = GetTime();
             if (screen_data) {
                 write(client->recorder_pipefd[1], screen_data, frame_bytes);
                 RL_FREE(screen_data);
@@ -4694,8 +4714,8 @@ void c_render(Drive *env, int view_mode, int draw_traces) {
                 fprintf(stderr,
                         "[drive-render-profile] %dx%d frame=%d avg over %d: "
                         "draw=%.2fms read=%.2fms pipe=%.2fms total=%.2fms (%.1f FPS)\n",
-                        (int)client->width, (int)client->height, profile_frame, profile_every,
-                        ms_draw, ms_read, ms_pipe, ms_tot, ms_tot > 0 ? 1000.0 / ms_tot : 0.0);
+                        (int)client->width, (int)client->height, profile_frame, profile_every, ms_draw, ms_read,
+                        ms_pipe, ms_tot, ms_tot > 0 ? 1000.0 / ms_tot : 0.0);
                 acc_draw = acc_read = acc_pipe = 0.0;
             }
         }

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -3561,7 +3561,11 @@ struct Client {
     pid_t recorder_pid;
     pid_t xvfb_pid;
     int xvfb_display_num;
-    int egl_mode; // 1 = EGL headless GPU rendering (no Xvfb/InitWindow)
+    // 1 = GL context is EGL-on-GPU. Xvfb + InitWindow still run at startup
+    // to let raylib/GLFW load glad function pointers; after that we switch
+    // the active context to EGL via egl_switch_to_gpu. Affects which cleanup
+    // path runs in close_client and which readback path runs in c_render.
+    int egl_mode;
     // Cached static road geometry (rebuilt once per episode, drawn every frame)
     Mesh road_tri_mesh;     // curb triangles — uploaded to GPU VBO, drawn with one DrawMesh call
     Material road_material; // default material for road mesh
@@ -4687,7 +4691,10 @@ void c_render(Drive *env, int view_mode, int draw_traces) {
             draw_scene(env, client, 0, 0, 0, 1);
         }
 
-        EndMode3D();
+        // NOTE: draw_scene() already calls EndMode3D() internally (see the
+        // EndMode3D at the end of the road-drawing block), so we don't repeat
+        // it here — a second call would pop past the projection matrix stack.
+
 #ifdef DRIVE_HAS_EGL
         if (client->egl_mode) {
             // EGL headless: just flush the rlgl batch. Skip EndDrawing's
@@ -4748,27 +4755,55 @@ void c_render(Drive *env, int view_mode, int draw_traces) {
                     // IOV_MAX on Linux is 1024, so frames taller than 1024 rows
                     // need multiple writev calls. Split the flip into chunks
                     // of at most IOV_MAX rows, each chunk in top-down order.
+                    // Within each chunk we also loop to handle short writes
+                    // (pipe can return < chunk_bytes when interrupted by a
+                    // signal or when the kernel pipe buffer is partially full)
+                    // by shrinking the head iovec and retrying.
                     int iov_max = 1024;
                     int rows_remaining = h;
                     int row_top = 0; // next top-down row we're about to emit
                     ssize_t total_written = 0;
-                    while (rows_remaining > 0) {
+                    int io_error = 0;
+                    while (rows_remaining > 0 && !io_error) {
                         int chunk = rows_remaining < iov_max ? rows_remaining : iov_max;
                         struct iovec iov[1024];
+                        size_t chunk_bytes = 0;
                         for (int i = 0; i < chunk; i++) {
                             // Top-down row (row_top + i) corresponds to
                             // bottom-up source row (h - 1 - (row_top + i)).
                             int src_row = h - 1 - (row_top + i);
                             iov[i].iov_base = ptr + (size_t)src_row * row_bytes;
                             iov[i].iov_len = row_bytes;
+                            chunk_bytes += row_bytes;
                         }
-                        ssize_t written = writev(client->recorder_pipefd[1], iov, chunk);
-                        if (written < 0) {
-                            fprintf(stderr, "[drive-pbo] frame=%d writev chunk=%d failed errno=%d(%s)\n",
-                                    client->pbo_frame_count, chunk, errno, strerror(errno));
-                            break;
+                        struct iovec *cur = iov;
+                        int cur_cnt = chunk;
+                        size_t cur_remaining = chunk_bytes;
+                        while (cur_remaining > 0) {
+                            ssize_t written = writev(client->recorder_pipefd[1], cur, cur_cnt);
+                            if (written < 0) {
+                                if (errno == EINTR)
+                                    continue; // signal, retry
+                                fprintf(stderr, "[drive-pbo] frame=%d writev chunk=%d failed errno=%d(%s)\n",
+                                        client->pbo_frame_count, cur_cnt, errno, strerror(errno));
+                                io_error = 1;
+                                break;
+                            }
+                            total_written += written;
+                            cur_remaining -= (size_t)written;
+                            // Advance past fully-consumed iovecs and shrink
+                            // the head iovec by any partial bytes.
+                            size_t consumed = (size_t)written;
+                            while (cur_cnt > 0 && consumed >= cur[0].iov_len) {
+                                consumed -= cur[0].iov_len;
+                                cur++;
+                                cur_cnt--;
+                            }
+                            if (cur_cnt > 0 && consumed > 0) {
+                                cur[0].iov_base = (unsigned char *)cur[0].iov_base + consumed;
+                                cur[0].iov_len -= consumed;
+                            }
                         }
-                        total_written += written;
                         row_top += chunk;
                         rows_remaining -= chunk;
                     }
@@ -4794,7 +4829,19 @@ void c_render(Drive *env, int view_mode, int draw_traces) {
             if (profile_enabled)
                 t_read_end = GetTime();
             if (screen_data) {
-                write(client->recorder_pipefd[1], screen_data, frame_bytes);
+                // Loop to handle short writes and EINTR on the blocking pipe.
+                size_t remaining = (size_t)frame_bytes;
+                unsigned char *p = screen_data;
+                while (remaining > 0) {
+                    ssize_t written = write(client->recorder_pipefd[1], p, remaining);
+                    if (written < 0) {
+                        if (errno == EINTR)
+                            continue;
+                        break;
+                    }
+                    p += written;
+                    remaining -= (size_t)written;
+                }
                 RL_FREE(screen_data);
             }
         }
@@ -4902,16 +4949,40 @@ void close_client(Client *client) {
             int iov_max = 1024;
             int rows_remaining = h;
             int row_top = 0;
-            while (rows_remaining > 0) {
+            int io_error = 0;
+            while (rows_remaining > 0 && !io_error) {
                 int chunk = rows_remaining < iov_max ? rows_remaining : iov_max;
                 struct iovec iov[1024];
+                size_t chunk_bytes = 0;
                 for (int i = 0; i < chunk; i++) {
                     int src_row = h - 1 - (row_top + i);
                     iov[i].iov_base = ptr + (size_t)src_row * row_bytes;
                     iov[i].iov_len = row_bytes;
+                    chunk_bytes += row_bytes;
                 }
-                if (writev(client->recorder_pipefd[1], iov, chunk) < 0)
-                    break;
+                struct iovec *cur = iov;
+                int cur_cnt = chunk;
+                size_t cur_remaining = chunk_bytes;
+                while (cur_remaining > 0) {
+                    ssize_t written = writev(client->recorder_pipefd[1], cur, cur_cnt);
+                    if (written < 0) {
+                        if (errno == EINTR)
+                            continue;
+                        io_error = 1;
+                        break;
+                    }
+                    cur_remaining -= (size_t)written;
+                    size_t consumed = (size_t)written;
+                    while (cur_cnt > 0 && consumed >= cur[0].iov_len) {
+                        consumed -= cur[0].iov_len;
+                        cur++;
+                        cur_cnt--;
+                    }
+                    if (cur_cnt > 0 && consumed > 0) {
+                        cur[0].iov_base = (unsigned char *)cur[0].iov_base + consumed;
+                        cur[0].iov_len -= consumed;
+                    }
+                }
                 row_top += chunk;
                 rows_remaining -= chunk;
             }

--- a/pufferlib/ocean/drive/egl_headless.h
+++ b/pufferlib/ocean/drive/egl_headless.h
@@ -1,0 +1,182 @@
+// Headless EGL GPU rendering for PufferDrive.
+//
+// Strategy: InitWindow on Xvfb loads glad (GL function pointers) and initializes rlgl.
+// Then we create an EGL context on the NVIDIA GPU and switch to it. The GL function
+// pointers loaded by glad/GLFW remain valid (they're dlsym addresses, not context-specific).
+// We re-init rlgl on the new GPU context so render batches and default textures are
+// allocated on GPU memory. All subsequent rlgl/raylib draw calls execute on the GPU.
+//
+// Usage in make_client:
+//   1. Fork Xvfb + InitWindow as normal (loads glad, creates rlgl state on Mesa)
+//   2. Call egl_headless_init(width, height) to create GPU context
+//   3. Call egl_switch_to_gpu() to activate GPU context
+//   4. Call rlglClose() + rlglInit() to re-create rlgl state on GPU
+//   5. Rendering now happens on GPU; rlReadScreenPixels still works
+
+#ifndef EGL_HEADLESS_H
+#define EGL_HEADLESS_H
+
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
+#include <GL/gl.h>
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+    EGLDisplay display;
+    EGLContext context;
+    EGLSurface surface;
+    int width;
+    int height;
+    int active;
+} EGLHeadlessContext;
+
+static EGLHeadlessContext g_egl_ctx = {0};
+
+// Create an EGL context on an NVIDIA GPU. Does NOT make it current yet.
+static int egl_headless_init(int width, int height) {
+    PFNEGLQUERYDEVICESEXTPROC eglQueryDevicesEXT =
+        (PFNEGLQUERYDEVICESEXTPROC)eglGetProcAddress("eglQueryDevicesEXT");
+    PFNEGLGETPLATFORMDISPLAYEXTPROC eglGetPlatformDisplayEXT =
+        (PFNEGLGETPLATFORMDISPLAYEXTPROC)eglGetProcAddress("eglGetPlatformDisplayEXT");
+
+    if (!eglQueryDevicesEXT || !eglGetPlatformDisplayEXT) {
+        fprintf(stderr, "[egl_headless] EGL device extensions not available\n");
+        return 0;
+    }
+
+    EGLDeviceEXT devices[8];
+    EGLint numDevices = 0;
+    eglQueryDevicesEXT(8, devices, &numDevices);
+    if (numDevices == 0) {
+        fprintf(stderr, "[egl_headless] No EGL devices found\n");
+        return 0;
+    }
+
+    EGLDisplay display = EGL_NO_DISPLAY;
+    for (int i = 0; i < numDevices; i++) {
+        display = eglGetPlatformDisplayEXT(EGL_PLATFORM_DEVICE_EXT, devices[i], NULL);
+        if (display != EGL_NO_DISPLAY) {
+            EGLint major, minor;
+            if (eglInitialize(display, &major, &minor)) {
+                const char *vendor = eglQueryString(display, EGL_VENDOR);
+                if (vendor && strstr(vendor, "NVIDIA")) {
+                    fprintf(stderr, "[egl_headless] Using NVIDIA EGL device %d (EGL %d.%d)\n", i, major, minor);
+                    break;
+                }
+                eglTerminate(display);
+                display = EGL_NO_DISPLAY;
+            }
+        }
+    }
+
+    if (display == EGL_NO_DISPLAY) {
+        display = eglGetPlatformDisplayEXT(EGL_PLATFORM_DEVICE_EXT, devices[0], NULL);
+        EGLint major, minor;
+        if (!eglInitialize(display, &major, &minor)) {
+            fprintf(stderr, "[egl_headless] Failed to initialize any EGL device\n");
+            return 0;
+        }
+        fprintf(stderr, "[egl_headless] Using fallback EGL device 0 (EGL %d.%d)\n", major, minor);
+    }
+
+    EGLint configAttribs[] = {
+        EGL_SURFACE_TYPE, EGL_PBUFFER_BIT,
+        EGL_RENDERABLE_TYPE, EGL_OPENGL_BIT,
+        EGL_RED_SIZE, 8, EGL_GREEN_SIZE, 8, EGL_BLUE_SIZE, 8, EGL_ALPHA_SIZE, 8,
+        EGL_DEPTH_SIZE, 24,
+        EGL_NONE
+    };
+    EGLConfig config;
+    EGLint numConfigs;
+    eglChooseConfig(display, configAttribs, &config, 1, &numConfigs);
+    if (numConfigs == 0) {
+        fprintf(stderr, "[egl_headless] No suitable EGL config\n");
+        eglTerminate(display);
+        return 0;
+    }
+
+    EGLint pbufferAttribs[] = {EGL_WIDTH, width, EGL_HEIGHT, height, EGL_NONE};
+    EGLSurface surface = eglCreatePbufferSurface(display, config, pbufferAttribs);
+    if (surface == EGL_NO_SURFACE) {
+        fprintf(stderr, "[egl_headless] Failed to create pbuffer: 0x%x\n", eglGetError());
+        eglTerminate(display);
+        return 0;
+    }
+
+    eglBindAPI(EGL_OPENGL_API);
+    EGLint contextAttribs[] = {
+        EGL_CONTEXT_MAJOR_VERSION, 3,
+        EGL_CONTEXT_MINOR_VERSION, 3,
+        EGL_CONTEXT_OPENGL_PROFILE_MASK, EGL_CONTEXT_OPENGL_COMPATIBILITY_PROFILE_BIT,
+        EGL_NONE
+    };
+    EGLContext context = eglCreateContext(display, config, EGL_NO_CONTEXT, contextAttribs);
+    if (context == EGL_NO_CONTEXT) {
+        fprintf(stderr, "[egl_headless] Failed to create GL context: 0x%x\n", eglGetError());
+        eglDestroySurface(display, surface);
+        eglTerminate(display);
+        return 0;
+    }
+
+    g_egl_ctx.display = display;
+    g_egl_ctx.context = context;
+    g_egl_ctx.surface = surface;
+    g_egl_ctx.width = width;
+    g_egl_ctx.height = height;
+    fprintf(stderr, "[egl_headless] GPU context created (%dx%d), ready to activate\n", width, height);
+    return 1;
+}
+
+// Switch the current GL context from Xvfb/Mesa to the EGL/NVIDIA GPU.
+// Call this AFTER InitWindow + rlglInit have loaded glad and initial state.
+// We must first release the GLX context that GLFW/InitWindow created.
+static int egl_switch_to_gpu(void) {
+    // Release the GLX context by using glXMakeCurrent via dlsym
+    // (we don't have glx.h here, so go through the dynamic linker)
+    typedef int (*glXMakeCurrentFunc)(void *, unsigned long, void *);
+    void *libgl = dlopen("libGL.so.1", RTLD_LAZY);
+    if (libgl) {
+        glXMakeCurrentFunc glXMC = (glXMakeCurrentFunc)dlsym(libgl, "glXMakeCurrent");
+        // Get the current X display from the DISPLAY env var via XOpenDisplay
+        typedef void *(*XOpenDisplayFunc)(const char *);
+        void *libx11 = dlopen("libX11.so.6", RTLD_LAZY);
+        if (libx11 && glXMC) {
+            XOpenDisplayFunc XOD = (XOpenDisplayFunc)dlsym(libx11, "XOpenDisplay");
+            if (XOD) {
+                void *dpy = XOD(NULL);
+                if (dpy) {
+                    glXMC(dpy, 0, NULL); // Release GLX context on this thread
+                    fprintf(stderr, "[egl_headless] Released GLX context\n");
+                }
+            }
+        }
+    }
+
+    if (!eglMakeCurrent(g_egl_ctx.display, g_egl_ctx.surface, g_egl_ctx.surface, g_egl_ctx.context)) {
+        fprintf(stderr, "[egl_headless] eglMakeCurrent failed: 0x%x\n", eglGetError());
+        return 0;
+    }
+    g_egl_ctx.active = 1;
+    const char *renderer = (const char *)glGetString(GL_RENDERER);
+    const char *version = (const char *)glGetString(GL_VERSION);
+    fprintf(stderr, "[egl_headless] GPU active: %s (%s)\n",
+            renderer ? renderer : "unknown", version ? version : "?");
+    return 1;
+}
+
+static void egl_headless_cleanup(void) {
+    if (g_egl_ctx.context) {
+        eglMakeCurrent(g_egl_ctx.display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+        eglDestroyContext(g_egl_ctx.display, g_egl_ctx.context);
+    }
+    if (g_egl_ctx.surface)
+        eglDestroySurface(g_egl_ctx.display, g_egl_ctx.surface);
+    if (g_egl_ctx.display)
+        eglTerminate(g_egl_ctx.display);
+    memset(&g_egl_ctx, 0, sizeof(g_egl_ctx));
+}
+
+#endif // EGL_HEADLESS_H

--- a/pufferlib/ocean/drive/egl_headless.h
+++ b/pufferlib/ocean/drive/egl_headless.h
@@ -185,25 +185,31 @@ static int egl_headless_resize(int width, int height) {
 // Call this AFTER InitWindow + rlglInit have loaded glad and initial state.
 // We must first release the GLX context that GLFW/InitWindow created.
 static int egl_switch_to_gpu(void) {
-    // Release the GLX context by using glXMakeCurrent via dlsym
-    // (we don't have glx.h here, so go through the dynamic linker)
+    // Release the GLX context that GLFW/InitWindow created on this thread.
+    // Use the *actual* current GLX display and context — opening a fresh
+    // X connection via XOpenDisplay(NULL) doesn't match the current context
+    // and can produce BadMatch on strict drivers. We don't have glx.h here,
+    // so look everything up via dlsym.
     typedef int (*glXMakeCurrentFunc)(void *, unsigned long, void *);
+    typedef void *(*glXGetCurrentDisplayFunc)(void);
+    typedef void *(*glXGetCurrentContextFunc)(void);
     void *libgl = dlopen("libGL.so.1", RTLD_LAZY);
     if (libgl) {
         glXMakeCurrentFunc glXMC = (glXMakeCurrentFunc)dlsym(libgl, "glXMakeCurrent");
-        // Get the current X display from the DISPLAY env var via XOpenDisplay
-        typedef void *(*XOpenDisplayFunc)(const char *);
-        void *libx11 = dlopen("libX11.so.6", RTLD_LAZY);
-        if (libx11 && glXMC) {
-            XOpenDisplayFunc XOD = (XOpenDisplayFunc)dlsym(libx11, "XOpenDisplay");
-            if (XOD) {
-                void *dpy = XOD(NULL);
-                if (dpy) {
-                    glXMC(dpy, 0, NULL); // Release GLX context on this thread
+        glXGetCurrentDisplayFunc glXGCD = (glXGetCurrentDisplayFunc)dlsym(libgl, "glXGetCurrentDisplay");
+        glXGetCurrentContextFunc glXGCC = (glXGetCurrentContextFunc)dlsym(libgl, "glXGetCurrentContext");
+        if (glXMC && glXGCD && glXGCC) {
+            void *current_dpy = glXGCD();
+            void *current_ctx = glXGCC();
+            if (current_ctx && current_dpy) {
+                if (glXMC(current_dpy, 0, NULL)) {
                     fprintf(stderr, "[egl_headless] Released GLX context\n");
+                } else {
+                    fprintf(stderr, "[egl_headless] Failed to release current GLX context\n");
                 }
             }
         }
+        dlclose(libgl);
     }
 
     if (!eglMakeCurrent(g_egl_ctx.display, g_egl_ctx.surface, g_egl_ctx.surface, g_egl_ctx.context)) {

--- a/pufferlib/ocean/drive/egl_headless.h
+++ b/pufferlib/ocean/drive/egl_headless.h
@@ -28,6 +28,7 @@ typedef struct {
     EGLDisplay display;
     EGLContext context;
     EGLSurface surface;
+    EGLConfig config; // retained so we can recreate pbuffers when the render resolution grows
     int width;
     int height;
     int active;
@@ -132,9 +133,51 @@ static int egl_headless_init(int width, int height) {
     g_egl_ctx.display = display;
     g_egl_ctx.context = context;
     g_egl_ctx.surface = surface;
+    g_egl_ctx.config = config;
     g_egl_ctx.width = width;
     g_egl_ctx.height = height;
     fprintf(stderr, "[egl_headless] GPU context created (%dx%d), ready to activate\n", width, height);
+    return 1;
+}
+
+// Recreate the pbuffer surface at (width, height) if the current one is too
+// small for the requested dimensions. The EGL pbuffer is allocated at a fixed
+// size at creation; subsequent rlViewport calls can only shrink the usable
+// region, not grow it. If a later render env has a larger map, glReadPixels
+// will read uninitialized pixels in the out-of-bounds region. We unbind the
+// current surface, destroy it, create a new one sized to fit, and rebind.
+static int egl_headless_resize(int width, int height) {
+    if (!g_egl_ctx.active || g_egl_ctx.surface == EGL_NO_SURFACE) {
+        return 0;
+    }
+    if (width <= g_egl_ctx.width && height <= g_egl_ctx.height) {
+        return 1; // current surface already fits
+    }
+    int new_w = width > g_egl_ctx.width ? width : g_egl_ctx.width;
+    int new_h = height > g_egl_ctx.height ? height : g_egl_ctx.height;
+
+    // Unbind the old surface before destroying it
+    if (!eglMakeCurrent(g_egl_ctx.display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT)) {
+        fprintf(stderr, "[egl_headless] resize unbind failed: 0x%x\n", eglGetError());
+        return 0;
+    }
+    eglDestroySurface(g_egl_ctx.display, g_egl_ctx.surface);
+
+    EGLint pbufferAttribs[] = {EGL_WIDTH, new_w, EGL_HEIGHT, new_h, EGL_NONE};
+    EGLSurface new_surface = eglCreatePbufferSurface(g_egl_ctx.display, g_egl_ctx.config, pbufferAttribs);
+    if (new_surface == EGL_NO_SURFACE) {
+        fprintf(stderr, "[egl_headless] resize create pbuffer failed: 0x%x\n", eglGetError());
+        return 0;
+    }
+    if (!eglMakeCurrent(g_egl_ctx.display, new_surface, new_surface, g_egl_ctx.context)) {
+        fprintf(stderr, "[egl_headless] resize rebind failed: 0x%x\n", eglGetError());
+        eglDestroySurface(g_egl_ctx.display, new_surface);
+        return 0;
+    }
+    g_egl_ctx.surface = new_surface;
+    g_egl_ctx.width = new_w;
+    g_egl_ctx.height = new_h;
+    fprintf(stderr, "[egl_headless] pbuffer resized to %dx%d\n", new_w, new_h);
     return 1;
 }
 

--- a/pufferlib/ocean/drive/egl_headless.h
+++ b/pufferlib/ocean/drive/egl_headless.h
@@ -175,15 +175,22 @@ static int egl_switch_to_gpu(void) {
 }
 
 static void egl_headless_cleanup(void) {
+    // Release the EGL context but do NOT call eglTerminate.
+    // NVIDIA's unified driver shares state between EGL and CUDA; terminating
+    // the EGL display corrupts the CUDA context, causing "no kernel image
+    // is available for execution on the device" on the next CUDA op.
+    // The context/surface/display are lightweight and will be cleaned up
+    // when the process exits.
     if (g_egl_ctx.context) {
         eglMakeCurrent(g_egl_ctx.display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
         eglDestroyContext(g_egl_ctx.display, g_egl_ctx.context);
     }
     if (g_egl_ctx.surface)
         eglDestroySurface(g_egl_ctx.display, g_egl_ctx.surface);
-    if (g_egl_ctx.display)
-        eglTerminate(g_egl_ctx.display);
-    memset(&g_egl_ctx, 0, sizeof(g_egl_ctx));
+    // Intentionally do NOT call eglTerminate(g_egl_ctx.display) — it breaks CUDA.
+    g_egl_ctx.context = NULL;
+    g_egl_ctx.surface = NULL;
+    g_egl_ctx.active = 0;
 }
 
 #endif // EGL_HEADLESS_H

--- a/pufferlib/ocean/drive/egl_headless.h
+++ b/pufferlib/ocean/drive/egl_headless.h
@@ -37,8 +37,7 @@ static EGLHeadlessContext g_egl_ctx = {0};
 
 // Create an EGL context on an NVIDIA GPU. Does NOT make it current yet.
 static int egl_headless_init(int width, int height) {
-    PFNEGLQUERYDEVICESEXTPROC eglQueryDevicesEXT =
-        (PFNEGLQUERYDEVICESEXTPROC)eglGetProcAddress("eglQueryDevicesEXT");
+    PFNEGLQUERYDEVICESEXTPROC eglQueryDevicesEXT = (PFNEGLQUERYDEVICESEXTPROC)eglGetProcAddress("eglQueryDevicesEXT");
     PFNEGLGETPLATFORMDISPLAYEXTPROC eglGetPlatformDisplayEXT =
         (PFNEGLGETPLATFORMDISPLAYEXTPROC)eglGetProcAddress("eglGetPlatformDisplayEXT");
 
@@ -82,13 +81,21 @@ static int egl_headless_init(int width, int height) {
         fprintf(stderr, "[egl_headless] Using fallback EGL device 0 (EGL %d.%d)\n", major, minor);
     }
 
-    EGLint configAttribs[] = {
-        EGL_SURFACE_TYPE, EGL_PBUFFER_BIT,
-        EGL_RENDERABLE_TYPE, EGL_OPENGL_BIT,
-        EGL_RED_SIZE, 8, EGL_GREEN_SIZE, 8, EGL_BLUE_SIZE, 8, EGL_ALPHA_SIZE, 8,
-        EGL_DEPTH_SIZE, 24,
-        EGL_NONE
-    };
+    EGLint configAttribs[] = {EGL_SURFACE_TYPE,
+                              EGL_PBUFFER_BIT,
+                              EGL_RENDERABLE_TYPE,
+                              EGL_OPENGL_BIT,
+                              EGL_RED_SIZE,
+                              8,
+                              EGL_GREEN_SIZE,
+                              8,
+                              EGL_BLUE_SIZE,
+                              8,
+                              EGL_ALPHA_SIZE,
+                              8,
+                              EGL_DEPTH_SIZE,
+                              24,
+                              EGL_NONE};
     EGLConfig config;
     EGLint numConfigs;
     eglChooseConfig(display, configAttribs, &config, 1, &numConfigs);
@@ -107,12 +114,13 @@ static int egl_headless_init(int width, int height) {
     }
 
     eglBindAPI(EGL_OPENGL_API);
-    EGLint contextAttribs[] = {
-        EGL_CONTEXT_MAJOR_VERSION, 3,
-        EGL_CONTEXT_MINOR_VERSION, 3,
-        EGL_CONTEXT_OPENGL_PROFILE_MASK, EGL_CONTEXT_OPENGL_COMPATIBILITY_PROFILE_BIT,
-        EGL_NONE
-    };
+    EGLint contextAttribs[] = {EGL_CONTEXT_MAJOR_VERSION,
+                               3,
+                               EGL_CONTEXT_MINOR_VERSION,
+                               3,
+                               EGL_CONTEXT_OPENGL_PROFILE_MASK,
+                               EGL_CONTEXT_OPENGL_COMPATIBILITY_PROFILE_BIT,
+                               EGL_NONE};
     EGLContext context = eglCreateContext(display, config, EGL_NO_CONTEXT, contextAttribs);
     if (context == EGL_NO_CONTEXT) {
         fprintf(stderr, "[egl_headless] Failed to create GL context: 0x%x\n", eglGetError());
@@ -162,8 +170,7 @@ static int egl_switch_to_gpu(void) {
     g_egl_ctx.active = 1;
     const char *renderer = (const char *)glGetString(GL_RENDERER);
     const char *version = (const char *)glGetString(GL_VERSION);
-    fprintf(stderr, "[egl_headless] GPU active: %s (%s)\n",
-            renderer ? renderer : "unknown", version ? version : "?");
+    fprintf(stderr, "[egl_headless] GPU active: %s (%s)\n", renderer ? renderer : "unknown", version ? version : "?");
     return 1;
 }
 

--- a/scripts/build_ocean.sh
+++ b/scripts/build_ocean.sh
@@ -104,6 +104,10 @@ FLAGS=(
     -ldl
     $ERROR_LIMIT_FLAG
     -DPLATFORM_DESKTOP
+    # _GNU_SOURCE must be set on the command line (not inside a header) so
+    # glibc exposes GNU extensions like F_SETPIPE_SZ regardless of include
+    # order. drive.c compiles drivenet.h first which pulls in <time.h>.
+    -D_GNU_SOURCE
 )
 
 

--- a/setup.py
+++ b/setup.py
@@ -260,6 +260,14 @@ if not NO_OCEAN:
                 ]
             )
             if system == "Linux":
+                # _GNU_SOURCE must be defined before any system header is
+                # included so glibc exposes GNU extensions like F_SETPIPE_SZ.
+                # Defining it inside drive.h is too late: drive.c compiles
+                # drivenet.h first, which pulls in <time.h> before drive.h.
+                # Setting it as a compiler flag guarantees it's in effect for
+                # every translation unit that compiles drive.h's transitive
+                # includes.
+                c_ext.extra_compile_args.append("-D_GNU_SOURCE")
                 # Link EGL/GL only if headers are available (libegl1-mesa-dev).
                 # Without them, the EGL headless GPU path is compiled out via
                 # __has_include in drive.h and the Xvfb/Mesa fallback is used.

--- a/setup.py
+++ b/setup.py
@@ -260,7 +260,11 @@ if not NO_OCEAN:
                 ]
             )
             if system == "Linux":
-                c_ext.extra_link_args.extend(["-lEGL", "-lGL", "-ldl"])
+                # Link EGL/GL only if headers are available (libegl1-mesa-dev).
+                # Without them, the EGL headless GPU path is compiled out via
+                # __has_include in drive.h and the Xvfb/Mesa fallback is used.
+                if os.path.exists("/usr/include/EGL/egl.h"):
+                    c_ext.extra_link_args.extend(["-lEGL", "-lGL", "-ldl"])
 
         if "impulse_wars" in c_ext.name:
             print(f"Adding {c_ext.name} to extra objects")

--- a/setup.py
+++ b/setup.py
@@ -259,6 +259,8 @@ if not NO_OCEAN:
                     '-DINI_INLINE_COMMENT_PREFIXES="#"',
                 ]
             )
+            if system == "Linux":
+                c_ext.extra_link_args.extend(["-lEGL", "-lGL", "-ldl"])
 
         if "impulse_wars" in c_ext.name:
             print(f"Adding {c_ext.name} to extra objects")


### PR DESCRIPTION
Proof it runs: https://wandb.ai/emerge_/pufferdrive/runs/h0zpmap1?nw=nwusereugenevinitsky

## Summary
- **EGL headless GPU rendering**: Bypasses Xvfb/Mesa/llvmpipe by switching GL context to NVIDIA GPU via `EGL_PLATFORM_DEVICE_EXT`. Falls back to Xvfb/software if no GPU available.
- **PBO double-buffered async readback**: `glReadPixels` DMA transfer overlapped with next frame's draw. Eliminates 28ms/frame sync stall.
- **Road geometry VBO**: Static curb/lane geometry uploaded to GPU once per episode via `UploadMesh`, drawn with single `DrawMesh` call instead of 55K per-vertex rlgl submissions.
- **4MB pipe buffer + NVENC attempt**: Larger pipe reduces ffmpeg write blocking. Tries h264_nvenc before falling back to libx264.
- **Per-stage render profiling**: `DRIVE_RENDER_PROFILE=1` env var prints draw/read/pipe ms per frame.

Results at 2414x2020:

| Config | total ms/frame | FPS | Speedup |
|---|---|---|---|
| Original (llvmpipe/Xvfb) | 90ms | 11 | 1x |
| All optimizations (GPU+PBO+VBO) | 2.8ms | 361 | **32x** |

All changes are Linux-only (`#ifdef __linux__`), macOS/interactive window paths unchanged.

## Test plan
- [x] Verified on H100, H200, L40S cluster nodes inside singularity container
- [x] Falls back gracefully to Xvfb/Mesa when EGL unavailable
- [x] Profiling output confirmed with `DRIVE_RENDER_PROFILE=1`
- [x] Verify video output is visually correct (not just timing)
- [x] Test with multiple maps / multi-env eval
- [x] Confirm macOS local build still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)