### PR TITLE
Align reward randomization bounds with GIGAFLOW paper

### DIFF
--- a/pufferlib/config/ocean/drive.ini
+++ b/pufferlib/config/ocean/drive.ini
@@ -99,38 +99,51 @@ reward_conditioning = 1
 reward_bound_goal_radius_min = 2.0
 reward_bound_goal_radius_max = 12.0
 
+# GIGAFLOW reward ranges (Cusumano-Towner et al.).
+# Penalty terms are stored negative here because our C formulas don't prepend
+# a leading `-` to reward_coefs (unlike turbostream). Spec α values in U(0, X)
+# therefore map to our bounds U(-X, 0).
+
 reward_bound_collision_min = -3.0
-reward_bound_collision_max = -0.1
+reward_bound_collision_max = 0.0
 
 reward_bound_offroad_min = -3.0
-reward_bound_offroad_max = -0.1
+reward_bound_offroad_max = 0.0
 
 reward_bound_comfort_min = -0.1
 reward_bound_comfort_max = 0.0
 
-reward_bound_lane_align_min = 0.0020
-reward_bound_lane_align_max = 0.0025
+reward_bound_lane_align_min = 0.00025
+reward_bound_lane_align_max = 0.025
 
-reward_bound_lane_center_min = -0.00075
-reward_bound_lane_center_max = -0.00065
+reward_bound_lane_center_min = -0.0075
+reward_bound_lane_center_max = -0.00025
 
-reward_bound_velocity_min = 0.0
-reward_bound_velocity_max = 0.005
+# Velocity α is FIXED at 2.5e-3 in GIGAFLOW (not randomized). Pin min=max.
+# Note: generate_reward_coefs() also hardcodes this value regardless of bounds.
+reward_bound_velocity_min = 0.0025
+reward_bound_velocity_max = 0.0025
 
+# Stop-line penalty (GIGAFLOW calls this Rstop-line). Our code plumbs it as
+# traffic_light but does not actually fire the metric — bounds are present for
+# obs normalization only.
 reward_bound_traffic_light_min = -1.0
 reward_bound_traffic_light_max = 0.0
 
-reward_bound_center_bias_min = -0.1
-reward_bound_center_bias_max = 0.1
+reward_bound_center_bias_min = -0.5
+reward_bound_center_bias_max = 0.5
 
 reward_bound_vel_align_min = 0.0
 reward_bound_vel_align_max = 1.0
 
+# Overspeed is a custom "GIGAFLOW++" term not in the paper. Left untouched.
 reward_bound_overspeed_min = -1.0
 reward_bound_overspeed_max = -0.9
 
-reward_bound_timestep_min = -0.00005
-reward_bound_timestep_max = 0.0
+# Timestep α is FIXED at 2.5e-5 in GIGAFLOW (not randomized). Pin min=max.
+# Note: generate_reward_coefs() also hardcodes -2.5e-5 regardless of bounds.
+reward_bound_timestep_min = -0.000025
+reward_bound_timestep_max = -0.000025
 
 reward_bound_reverse_min = -0.0075
 reward_bound_reverse_max = -0.00025


### PR DESCRIPTION
## Summary

- Widens the reward randomization bounds in `drive.ini` to match the uniform ranges specified in GIGAFLOW (Cusumano-Towner et al.). Every randomized α was narrower than the spec on `3.0`.
- Pins the two coefficients GIGAFLOW specifies as fixed (`velocity` at `2.5e-3`, `timestep` at `2.5e-5`) so `min == max`.
- Leaves `overspeed` unchanged (`[-1.0, -0.9]`) — it's a custom "GIGAFLOW++" term not in the paper, and the current magnitude is intentional.
- No C/Python changes. Only `pufferlib/config/ocean/drive.ini`.

### Sign convention caveat

Our C reward formulas in `drive.h` don't prepend a leading `-` to penalty coefficients (unlike `vcha/turbostream`). So GIGAFLOW ranges of `U(0, X)` for penalty terms are stored here as `U(-X, 0)` — this preserves the spec's effective reward while matching our code's convention.

### Changed bounds

| Term | Before | After | Source in spec |
|------|--------|-------|----------------|
| `collision` | `[-3.0, -0.1]` | `[-3.0, 0.0]` | `αcollision ∼ U(0, 3)` |
| `offroad` | `[-3.0, -0.1]` | `[-3.0, 0.0]` | `αboundary ∼ U(0, 3)` |
| `lane_align` | `[0.002, 0.0025]` | `[2.5e-4, 2.5e-2]` | `αl-align ∼ U(2.5e-4, 2.5e-2)` |
| `lane_center` | `[-7.5e-4, -6.5e-4]` | `[-7.5e-3, -2.5e-4]` | `αl-center ∼ U(2.5e-4, 7.5e-3)` |
| `velocity` | `[0.0, 0.005]` | pinned `[2.5e-3, 2.5e-3]` | `αvelocity = 2.5e-3` (fixed) |
| `center_bias` | `[-0.1, 0.1]` | `[-0.5, 0.5]` | `αcenter-bias ∼ U(-0.5, 0.5)` |
| `timestep` | `[-5e-5, 0.0]` | pinned `[-2.5e-5, -2.5e-5]` | `αtimestep = 2.5e-5` (fixed) |

### Already-matching bounds (unchanged)

`goal_radius` (`U(2, 12)`), `comfort` (`U(0, 0.1)`), `traffic_light`/stop-line (`U(0, 1)`), `vel_align` (`U(0, 1)`), `reverse` (`U(2.5e-4, 7.5e-3)`).

### Not addressed (out of scope)

- `overspeed` bounds — left at `[-1.0, -0.9]` per request.
- `max_goal_speed = 10.0` vs GIGAFLOW's `v_goal = 3` — this is a structural difference (waypoint vs. every-goal semantics), not a numeric tweak to a bound.
- `velocity`/`timestep` are also hardcoded in `generate_reward_coefs()` at `drive.h:647-648` regardless of bounds; this PR just makes the bounds consistent with the hardcoded values for observation normalization purposes.
- Missing `R_stop-line` firing logic in C (the metric is never computed, so `traffic_light` bounds are currently decorative).

## Test plan

- [ ] Build the C extension locally: `python setup.py build_ext --inplace --force`
- [ ] Sanity-check `reward_coefs` landing in the observation are in the new ranges (e.g. `lane_align` coef in observations should now span much wider than before)
- [ ] Launch a short cluster run (e.g. 100M steps) and confirm training is stable with the widened reward ranges
- [ ] Compare reward-component logs (`lane_alignment_rate`, `lane_center_rate`, `velocity_progress_sum`, collision/offroad rates) against a run on plain `3.0` to verify per-component magnitudes move the expected direction