### PR TITLE
WIP: fix stopped-agent metric dilution (active_step_count divisor)

### DIFF
--- a/pufferlib/ocean/drive/binding.c
+++ b/pufferlib/ocean/drive/binding.c
@@ -472,6 +472,12 @@ static int my_log(PyObject *dict, Log *log) {
     assign_to_dict(dict, "max_observation_distance", log->max_observation_distance);
     assign_to_dict(dict, "observation_coverage", log->observation_coverage);
     assign_to_dict(dict, "partner_obs_coverage", log->partner_obs_coverage);
+    // Per-agent average of how many steps each agent was active (not stopped).
+    // Equals episode_length for fleets with no stops; drops toward 0 as the
+    // stopping rate rises. Useful for sanity-checking the new Option C
+    // normalization — sharp drops here should correlate with drops in
+    // collision_rate / offroad_rate.
+    assign_to_dict(dict, "active_step_count", log->active_step_count);
     // assign_to_dict(dict, "avg_displacement_error", log->avg_displacement_error);
     return 0;
 }

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -261,6 +261,16 @@ typedef struct TrafficControlElement TrafficControlElement;
 struct Log {
     float episode_return;
     float episode_length;
+    // active_step_count: number of steps on which this agent's reward-loop
+    // metric updates actually ran. Equals episode_length for agents that were
+    // never stopped. For agents that were stopped at step T_stop, it equals
+    // T_stop (the last step before stopped=1 took effect). Used as the
+    // per-agent divisor for reward-loop rate fields (velocity_progress_sum,
+    // avg_speed_per_agent, comfort_violation_count, lane_center_rate) so
+    // stopping doesn't dilute those averages. Not used for observation-loop
+    // rate fields (max_observation_distance, observation_coverage,
+    // partner_obs_coverage), which continue to be updated for stopped agents.
+    float active_step_count;
     float score;
     float goals_reached_this_episode;
     float goals_sampled_this_episode;
@@ -1688,6 +1698,24 @@ void add_log(Drive *env) {
         int agent_idx = env->active_agent_indices[i];
         Agent *agent = &env->agents[agent_idx];
 
+        // Per-agent divisor for REWARD-LOOP rate fields. These fields
+        // (avg_speed_per_agent, comfort_violation_count, velocity_progress_sum,
+        // lane_center_rate) are only updated while the agent is active — once
+        // agent->stopped is set, c_step's reward loop `continue`s and the
+        // fields freeze. Dividing their frozen sums by the FULL env->timestep
+        // would bias them downward by the ratio of active-to-total steps and,
+        // because that ratio varies episode-to-episode (especially with
+        // stopped_reset_threshold bimodal termination), produce large
+        // spurious swings in the reported averages. Instead, use the agent's
+        // own active_step_count so each agent reports its true per-active-step
+        // rate. The fallback to 1 prevents division-by-zero for agents that
+        // never had a non-stopped step (unlikely, but possible on step 0
+        // resets).
+        int active_ts = (int)env->logs[i].active_step_count;
+        if (active_ts < 1) {
+            active_ts = 1;
+        }
+
         env->log.goals_reached_this_episode += agent->goals_reached_this_episode;
         env->log.goals_sampled_this_episode += agent->goals_sampled_this_episode;
         env->log.goals_attempted_this_episode += agent->goals_attempted_this_episode;
@@ -1700,8 +1728,9 @@ void add_log(Drive *env) {
         env->log.offroad_per_agent += offroad_per_agent;
         float collisions_per_agent = env->logs[i].collisions_per_agent;
         env->log.collisions_per_agent += collisions_per_agent;
+        // CATEGORY A (reward-loop rate field): divide by per-agent active_ts.
         float avg_speed_per_agent = env->logs[i].avg_speed_per_agent;
-        env->log.avg_speed_per_agent += avg_speed_per_agent / safe_timestep;
+        env->log.avg_speed_per_agent += avg_speed_per_agent / active_ts;
         float frac_goal_reached = agent->goals_reached_this_episode / agent->goals_attempted_this_episode;
 
         // Score related computation
@@ -1729,16 +1758,25 @@ void add_log(Drive *env) {
         env->log.total_distance_travelled += agent->distance_since_spawn;
         env->log.total_infractions += infraction_count;
         env->log.distance_without_collision += env->logs[i].distance_without_collision;
-        env->log.comfort_violation_count += env->logs[i].comfort_violation_count / safe_timestep;
-        env->log.velocity_progress_sum += env->logs[i].velocity_progress_sum / safe_timestep;
+        // CATEGORY A (reward-loop rate fields): divide by per-agent active_ts.
+        env->log.comfort_violation_count += env->logs[i].comfort_violation_count / active_ts;
+        env->log.velocity_progress_sum += env->logs[i].velocity_progress_sum / active_ts;
         // Log composition counts per agent so vec_log averaging recovers the per-env value
         env->log.active_agent_count += env->active_agent_count;
         env->log.expert_static_agent_count += env->expert_static_agent_count;
         env->log.static_agent_count += env->static_agent_count;
-        env->log.lane_center_rate += env->logs[i].lane_center_rate / safe_timestep;
+        // CATEGORY A (reward-loop rate field): divide by per-agent active_ts.
+        env->log.lane_center_rate += env->logs[i].lane_center_rate / active_ts;
+        // CATEGORY B (observation-loop rate fields): these continue to be
+        // updated for stopped agents inside compute_observations (no stopped
+        // check there), so their per-step denominator is still the full env
+        // timestep count, not active_ts.
         env->log.max_observation_distance += env->logs[i].max_observation_distance / safe_timestep;
         env->log.observation_coverage += env->logs[i].observation_coverage / safe_timestep;
         env->log.partner_obs_coverage += env->logs[i].partner_obs_coverage / safe_timestep;
+        // Per-agent active step count itself, reported as a diagnostic
+        // (per-agent average active step count after vec_log divides by n).
+        env->log.active_step_count += env->logs[i].active_step_count;
         env->log.n += 1;
     }
 }
@@ -3302,6 +3340,14 @@ void c_step(Drive *env) {
             env->rewards[i] = 0.0f;
             continue;
         }
+        // This agent's reward-loop metrics are about to run. Count this step
+        // in active_step_count so add_log can divide reward-loop rate fields
+        // by the correct per-agent denominator (see Log struct comment).
+        // Note: on the step where the agent FIRST crashes, agent->stopped is
+        // still 0 at this point — compute_agent_metrics below may set it to 1
+        // after detecting the collision. That's correct: this step's metric
+        // updates do execute, so it counts toward active_step_count.
+        env->logs[i].active_step_count += 1.0f;
         compute_agent_metrics(env, agent_idx);
         int collision_state = agent->collision_state;
         if (collision_state == NO_COLLISION) {


### PR DESCRIPTION
## Status

**WIP — do not merge.** Needs code review + A/B verification run against a parallel job on plain \`ricky/stop_behavior_gradient_fix\` before landing.

## Why the metrics are spiky on \`ricky/stop_behavior_gradient_fix\`

Commit \`8d1a1bbd\` ("Skip metrics and rewards for stopped agents") added a \`continue\` in \`c_step\`'s reward loop at \`drive.h:3301\` that stops all per-agent metric updates once \`agent->stopped\` is set. But \`add_log\` — running at episode termination — still iterates over every active agent (including stopped ones) and divides their frozen per-agent sums by \`env->timestep\` (the full episode length). So every rate-style field (\`velocity_progress_sum\`, \`avg_speed_per_agent\`, \`comfort_violation_count\`, \`lane_center_rate\`) is biased downward by a factor of \`active_steps_i / env->timestep\` for each stopped agent.

On its own, that would just be a stable bias. The **spike amplifier** is \`stopped_reset_threshold = 0.5\` in \`drive.ini\`: at \`drive.h:3534-3539\`, the env resets as soon as half the agents are stopped, creating two episode-termination regimes:

- **Graceful**: \`env->timestep = 300\` (full \`episode_length\`)
- **Collapsed**: \`env->timestep ∈ (20, 200)\` depending on how fast the stopping cascaded

The dilution ratio varies per-episode, and the per-batch mix of graceful vs collapsed episodes varies per-report, so each wandb report divides by a different effective denominator and reports a different value for the same underlying per-step behavior.

## Why I'm not using a survivor-only divisor (Option B)

The tempting fix — "skip stopped agents in \`add_log\`, divide by \`active_n\` = count of non-stopped agents" — is wrong. It conditions the metric on \"agent did not get stopped,\" which biases the average toward survivors. Counter-example: a reckless policy that stops 50% of agents but has the survivors driving at 12 m/s reports **higher** \`velocity_progress_sum\` than a safe policy that keeps 90% of agents alive at 10 m/s. Option B can flip the sign of the training signal relative to actual policy quality. Not safe to use as a learning-curve indicator.

## What this PR does (Option C)

Per-agent \`active_step_count\` as a local divisor for *only* the fields that are gated by stopping.

### Changed in \`pufferlib/ocean/drive/drive.h\`

1. **\`Log\` struct**: new \`float active_step_count\` field (placed next to \`episode_length\` with an explanatory comment).

2. **\`c_step\` reward loop (\`drive.h:3350\`)**: after the existing \`if (agent->stopped) continue;\` skip, increment \`env->logs[i].active_step_count += 1.0f\`. On the first step an agent crashes, \`agent->stopped\` is still \`0\` at the skip check — \`compute_agent_metrics\` sets it to \`1\` afterward. This step DOES execute all its rate-field updates, so it correctly counts toward \`active_step_count\`. Every subsequent step, the skip fires before the increment, so \`active_step_count\` freezes at the right value.

3. **\`add_log\` loop (\`drive.h:1697\`)**: computes \`active_ts = max(env->logs[i].active_step_count, 1)\` per agent and divides the four Category A fields (\`avg_speed_per_agent\`, \`comfort_violation_count\`, \`velocity_progress_sum\`, \`lane_center_rate\`) by \`active_ts\` instead of \`safe_timestep\`. Each agent contributes its true per-active-step rate. Category B fields (\`max_observation_distance\`, \`observation_coverage\`, \`partner_obs_coverage\`) continue to divide by \`safe_timestep\` because \`compute_observations\` does NOT skip stopped agents — they keep accumulating those fields every step, so the correct denominator is still the full env timestep count. Fallback of \`1\` avoids divide-by-zero for agents that were stopped on step 0 (unlikely, but possible on reset).

4. **\`add_log\` aggregation**: \`env->log.active_step_count += env->logs[i].active_step_count\` so the per-agent mean active step count is reported as a wandb metric. Useful diagnostic: should equal \`episode_length\` when no stopping, drop proportionally as the stopping rate rises.

### Changed in \`pufferlib/ocean/drive/binding.c\`

Add \`assign_to_dict(dict, \"active_step_count\", log->active_step_count)\` in \`my_log\` so the new field shows up in wandb.

### Categories — why this split is correct

| Field | Category | Why |
|-------|----------|-----|
| \`avg_speed_per_agent\` | A | updated at \`drive.h:3422\`, AFTER the stopped-skip at \`drive.h:3301\` |
| \`comfort_violation_count\` | A | updated at \`drive.h:3415\`, same reason |
| \`velocity_progress_sum\` | A | updated at \`drive.h:3419\`, same reason |
| \`lane_center_rate\` | A | updated at \`drive.h:3411\`, same reason |
| \`max_observation_distance\` | B | updated at \`drive.h:2921\` inside \`compute_observations\`, which has no stopped check |
| \`observation_coverage\` | B | updated at \`drive.h:2922\`, same |
| \`partner_obs_coverage\` | B | updated at \`drive.h:2846\`, same |

Category B stopped agents still get their observation metrics updated every step (\`compute_observations\` iterates all active agents without a stopped check), so dividing their frozen-looking sums by \`active_step_count\` would actually *over*-report those fields. Category B stays as-is.

## Unchanged

- \`episode_return\`, \`episode_length\` — not rate fields; stopped agents' partial values are their legitimate contributions.
- \`collision_rate\`, \`offroad_rate\`, \`collisions_per_agent\`, \`offroad_per_agent\` — outcome flags/counts, correct as population-level averages over \`n\`.
- \`stopped_reset_threshold = 0.5\` — left at default (this PR doesn't touch the bimodal termination behavior, only fixes the aggregation that's sensitive to it).
- Python code — no changes.
- ini config — no changes.

## Test plan

- [ ] Read the diff and sanity-check the Category A / B split
- [ ] Rebuild C extension on cluster (\`rebuild_on_cluster.py --wait\`)
- [ ] Launch a 5B-step 10h run on this branch, compare against the 5B run already on plain \`ricky/stop_behavior_gradient_fix\` (job 6167426/27/28). Expected:
  - \`velocity_progress_sum\`, \`avg_speed_per_agent\`, \`comfort_violation_count\`, \`lane_center_rate\` should be much less spiky (same underlying policy behavior, more stable reports)
  - \`active_step_count\` should appear as a new metric, equal to ~300 when few agents are stopping and dropping below that as the stopping rate grows
  - \`collision_rate\`, \`offroad_rate\`, \`episode_return\` should be unchanged in magnitude (those paths weren't modified)
- [ ] Side-by-side the wandb plots to confirm spikes are reduced in magnitude, not shifted

## Known limitations / followups

- Doesn't fix the \`jerk_penalty\` leak at \`drive.h:3285-3286\` where stopped agents still accumulate jerk in their \`episode_return\` log even though the actual reward is zeroed at \`drive.h:3302\`. Small magnitude (\`-0.0002\` coef), minor consistency issue, not addressed here.
- The \`(cos_theta > 0.5)\` gate and \`exp_decay\` terms in the lane-center reward at \`drive.h:3449-3450\` are spec-faithful to GIGAFLOW but create separate issues around reward shaping. Out of scope for this PR.
- Doesn't rename or remove any existing wandb fields, so dashboards built against \`velocity_progress_sum\` etc. will continue to work — the numerical values will shift upward (closer to their true per-active-step rates), but the metric identity is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)