### PR TITLE
Cap libx264 thread pool to 4 in drive.h ffmpeg pipe

### DIFF
--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -3731,13 +3731,22 @@ Client *make_client(Drive *env) {
             if (client->egl_mode) {
                 // GPU/PBO path: same ffmpeg command as non-EGL (video may be vertically
                 // flipped but this confirms PBO data reaches ffmpeg).
+                // -threads 4: cap libx264's internal thread pool. x264's default
+                // autodetects from the physical node (~96+ cores on H100/H200), spawning
+                // ~24 encode threads + 4 lookahead threads. Under a 16-core SLURM cgroup
+                // that's ~2x oversubscription that burst-preempts the render producer
+                // and causes safe_eval renders to hang / SIGABRT. 4 threads is already
+                // far more than needed for 1232^2 ultrafast (~500 fps encode vs <200 fps
+                // producer), and leaves 12+ cores untouched for the main thread / env
+                // / render producer.
                 execlp("ffmpeg", "ffmpeg", "-y", "-f", "rawvideo", "-pix_fmt", "rgba", "-s", size_str, "-r", "30", "-i",
-                       "-", "-c:v", "libx264", "-pix_fmt", "yuv420p", "-preset", "ultrafast", "-crf", "23", filename,
-                       NULL);
+                       "-", "-c:v", "libx264", "-threads", "4", "-pix_fmt", "yuv420p", "-preset", "ultrafast", "-crf",
+                       "23", filename, NULL);
             }
 #endif
             execlp("ffmpeg", "ffmpeg", "-y", "-f", "rawvideo", "-pix_fmt", "rgba", "-s", size_str, "-r", "30", "-i",
-                   "-", "-c:v", "libx264", "-pix_fmt", "yuv420p", "-preset", "ultrafast", "-crf", "23", filename, NULL);
+                   "-", "-c:v", "libx264", "-threads", "4", "-pix_fmt", "yuv420p", "-preset", "ultrafast", "-crf", "23",
+                   filename, NULL);
             fprintf(stderr, "execlp ffmpeg failed\n");
             _exit(1);
         }


### PR DESCRIPTION
## Problem

libx264 autodetects its thread count from the physical node's CPU count (\`sysconf(_SC_NPROCESSORS_ONLN)\`), not from the SLURM cgroup. On 96+ core H100/H200/A100 nodes, this makes x264 spawn ~24 encode threads + 4 lookahead threads inside a 16-core allocation — a 1.75× oversubscription.

During \`safe_eval\` render, those x264 threads burst-preempt the main Python thread and the OpenGL/PBO render producer whenever a frame arrives on the pipe. In a recent 7-job sample, 4/7 training runs hung at their first \`safe_eval\` render with the ffmpeg encoder crawling at ~1 fps (vs. normal ~30–130 fps), then died after 50–130 seconds with \`Fatal Python error: Aborted\` / SIGABRT in \`binding.vec_render\`.

## Fix

Pass \`-threads 4\` to both \`execlp\` calls for libx264 in \`make_client\` (the EGL/PBO path and the non-EGL fallback). 4 threads is already well above what the render producer can feed:

- ultrafast at 4 threads encodes 1232² at ~500–800 fps
- the render producer tops out around ~100–200 fps
- encoding is no longer the bottleneck, and x264 no longer contends with the producer for the remaining 12 cores

## Why not more threads?

x264's ultrafast thread scaling plateaus between 4 and 8 threads. Going from 4 → 16 gives ~7% more peak encode fps for ~4× more scheduler overhead and a ~4× wider burst-contention window with the producer. Since encoding is already 2–4× faster than the producer at 4 threads, more threads just re-create the problem we're fixing.

## Why not h264_nvenc?

A100, H100, and H200 ship with **0 NVENC chips** per [NVIDIA's video encode support matrix](https://developer.nvidia.com/video-encode-and-decode-gpu-support-matrix-new). Only L40S / L4 on this cluster have NVENC hardware. That's a minority of allocations, so NVENC can't be a blanket replacement for libx264. I tested h264_nvenc inside the container on A100 (gets \`Function not implemented\`) and on L40S (works with \`-init_hw_device cuda=cu:0\`), confirming the hardware-is-absent diagnosis. Keeping libx264 as the portable path.

## Empirical verification

Tested on \`gh109\` (H200) with the fix applied (branch \`ev/active-step-count-metric-fix\` + this commit cherry-picked in):

| Metric | Pre-fix (crashed runs) | Post-fix |
|---|---|---|
| Encode fps | 0.7–2.5 | **30–83** |
| Realtime speed | 0.023×–0.082× | **1.0×–2.78×** |
| Time per view | Never completed (SIGABRT at frame ~127) | **1.3–10.6 s** |
| Outcome | \`Fatal Python error: Aborted\` | Clean finish, x264 epilogue printed |

Full safe_eval render cycle on H200 post-fix: 3 views complete in ~8–20 s (was: hang forever).

## Scope

Single-file change to \`pufferlib/ocean/drive/drive.h\`. No config changes, no new dependencies, no behavior change on the rendering path itself — only the thread-pool size. Existing \`-preset ultrafast -crf 23\` encoder config is untouched.

## Test plan

- [x] Rebuild C extension on cluster, verify \`C binding loaded OK\`
- [x] Launch training job on H200 node (the class that was crashing)
- [x] Verify first \`safe_eval\` render completes with healthy encode rates
- [x] Verify training continues past epoch 250 without SIGABRT
- [x] Optional: run a full 5B-step training to verify stable across many eval cycles