### PR TITLE
Partner velocity in ego frame (2D vector) replacing broken scalar

### DIFF
--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -2687,7 +2687,6 @@ float compute_partner_observations(Drive *env, float *obs, int agent_idx, int ob
 
     int ego_idx = env->active_agent_indices[agent_idx];
     Agent *ego_entity = &env->agents[ego_idx];
-    int ego_id = ego_entity->id;
 
     // Ego stats
     float cos_heading = cosf(ego_entity->sim_heading);
@@ -2697,9 +2696,13 @@ float compute_partner_observations(Drive *env, float *obs, int agent_idx, int ob
     int partners_in_radius = 0;
     AgentDistance candidates[MAX_AGENTS];
     for (int i = 0; i < env->num_created_agents; i++) {
-        Agent *partner = &env->agents[i];
-        if (ego_id == partner->id)
+        // Skip the ego itself. Compare by slot index rather than Agent->id:
+        // id is assigned from the file for map-loaded agents and from the slot
+        // index for variably-spawned agents, so mixing modes could produce an
+        // id collision that silently drops a legitimate partner.
+        if (i == ego_idx)
             continue;
+        Agent *partner = &env->agents[i];
         float dx = partner->sim_x - ego_entity->sim_x;
         float dy = partner->sim_y - ego_entity->sim_y;
         float dz = partner->sim_z - ego_entity->sim_z;
@@ -2743,11 +2746,18 @@ float compute_partner_observations(Drive *env, float *obs, int agent_idx, int ob
         float other_sin = sinf(partner->sim_heading);
         obs[obs_idx + 5] = other_cos * cos_heading + other_sin * sin_heading;
         obs[obs_idx + 6] = other_sin * cos_heading - other_cos * sin_heading;
-        float rel_vx = partner->sim_vx - ego_entity->sim_vx;
-        float rel_vy = partner->sim_vy - ego_entity->sim_vy;
-        float rel_speed_magnitude = sqrtf(rel_vx * rel_vx + rel_vy * rel_vy);
-        float rel_v_dot_heading = rel_vx * other_cos + rel_vy * other_sin;
-        obs[obs_idx + 7] = copysignf(rel_speed_magnitude, rel_v_dot_heading) / MAX_SPEED;
+        // Partner scalar speed magnitude. The previous encoding was
+        //   copysignf(|partner_v - ego_v|, (partner_v - ego_v) . partner_heading)
+        // which has no coherent physical interpretation: the sign depended on
+        // the partner's world-frame heading, so a stopped partner reported a
+        // non-zero value whose sign flipped if you rotated the (frozen) car.
+        // Use the partner's own speed magnitude instead — stopped partners
+        // now cleanly report 0, and the partner's direction of motion is
+        // already implicit in the heading obs at obs[+5] / obs[+6] for rigid-
+        // body vehicles (v = sim_speed * heading_unit).
+        float partner_speed =
+            sqrtf(partner->sim_vx * partner->sim_vx + partner->sim_vy * partner->sim_vy);
+        obs[obs_idx + 7] = partner_speed / MAX_SPEED;
         obs_idx += 8;
     }
 

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -153,7 +153,10 @@
 
 #define ROAD_FEATURES 8
 #define ROAD_FEATURES_ONEHOT 14
-#define PARTNER_FEATURES 8
+// Partner obs layout: [rel_x, rel_y, dz, width, length, rel_heading_x,
+// rel_heading_y, rel_vx_ego, rel_vy_ego]. The last two are the partner's
+// velocity relative to ego, rotated into the ego's local frame.
+#define PARTNER_FEATURES 9
 
 #define MAX_CHECKED_LANES 32
 
@@ -2743,14 +2746,23 @@ float compute_partner_observations(Drive *env, float *obs, int agent_idx, int ob
         float other_sin = sinf(partner->sim_heading);
         obs[obs_idx + 5] = other_cos * cos_heading + other_sin * sin_heading;
         obs[obs_idx + 6] = other_sin * cos_heading - other_cos * sin_heading;
-        float partner_speed =
-            sqrtf(partner->sim_vx * partner->sim_vx + partner->sim_vy * partner->sim_vy);
-        obs[obs_idx + 7] = partner_speed / MAX_SPEED;
-        obs_idx += 8;
+        // Partner velocity relative to ego, rotated into ego's local frame.
+        // Same R(-theta_ego) rotation that maps world (dx, dy) to (rel_x, rel_y)
+        // above. Stopped partners report rel_v = -ego_v, which when rotated
+        // gives the ego's own motion with flipped sign — i.e. "from ego's
+        // reference frame, the stopped partner appears to be moving backward
+        // at ego's speed", which is the correct physical signal.
+        float rel_vx_world = partner->sim_vx - ego_entity->sim_vx;
+        float rel_vy_world = partner->sim_vy - ego_entity->sim_vy;
+        float rel_vx_ego = rel_vx_world * cos_heading + rel_vy_world * sin_heading;
+        float rel_vy_ego = -rel_vx_world * sin_heading + rel_vy_world * cos_heading;
+        obs[obs_idx + 7] = rel_vx_ego / MAX_SPEED;
+        obs[obs_idx + 8] = rel_vy_ego / MAX_SPEED;
+        obs_idx += PARTNER_FEATURES;
     }
 
     // Pad remaining partner obs with zero
-    int remaining_partner_obs = (MAX_PARTNER_OBSERVATIONS - cars_seen) * 8;
+    int remaining_partner_obs = (MAX_PARTNER_OBSERVATIONS - cars_seen) * PARTNER_FEATURES;
     memset(&obs[obs_idx], 0, remaining_partner_obs * sizeof(float));
 
     // Return coverage: fraction of partners within radius that fit in obs slots
@@ -3886,7 +3898,7 @@ void draw_agent_obs(Drive *env, int agent_index, int mode, int obs_only, int las
     int obs_idx = ego_dim; // Start after ego obs
     for (int j = 0; j < MAX_PARTNER_OBSERVATIONS; j++) {
         if (agent_obs[obs_idx] == 0 || agent_obs[obs_idx + 1] == 0) {
-            obs_idx += 8; // Move to next agent observation
+            obs_idx += PARTNER_FEATURES; // Move to next agent observation
             continue;
         }
         // Draw position of other agents

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -2746,15 +2746,6 @@ float compute_partner_observations(Drive *env, float *obs, int agent_idx, int ob
         float other_sin = sinf(partner->sim_heading);
         obs[obs_idx + 5] = other_cos * cos_heading + other_sin * sin_heading;
         obs[obs_idx + 6] = other_sin * cos_heading - other_cos * sin_heading;
-        // Partner scalar speed magnitude. The previous encoding was
-        //   copysignf(|partner_v - ego_v|, (partner_v - ego_v) . partner_heading)
-        // which has no coherent physical interpretation: the sign depended on
-        // the partner's world-frame heading, so a stopped partner reported a
-        // non-zero value whose sign flipped if you rotated the (frozen) car.
-        // Use the partner's own speed magnitude instead — stopped partners
-        // now cleanly report 0, and the partner's direction of motion is
-        // already implicit in the heading obs at obs[+5] / obs[+6] for rigid-
-        // body vehicles (v = sim_speed * heading_unit).
         float partner_speed =
             sqrtf(partner->sim_vx * partner->sim_vx + partner->sim_vy * partner->sim_vy);
         obs[obs_idx + 7] = partner_speed / MAX_SPEED;

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -2747,11 +2747,6 @@ float compute_partner_observations(Drive *env, float *obs, int agent_idx, int ob
         obs[obs_idx + 5] = other_cos * cos_heading + other_sin * sin_heading;
         obs[obs_idx + 6] = other_sin * cos_heading - other_cos * sin_heading;
         // Partner velocity relative to ego, rotated into ego's local frame.
-        // Same R(-theta_ego) rotation that maps world (dx, dy) to (rel_x, rel_y)
-        // above. Stopped partners report rel_v = -ego_v, which when rotated
-        // gives the ego's own motion with flipped sign — i.e. "from ego's
-        // reference frame, the stopped partner appears to be moving backward
-        // at ego's speed", which is the correct physical signal.
         float rel_vx_world = partner->sim_vx - ego_entity->sim_vx;
         float rel_vy_world = partner->sim_vy - ego_entity->sim_vy;
         float rel_vx_ego = rel_vx_world * cos_heading + rel_vy_world * sin_heading;

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -154,8 +154,7 @@
 #define ROAD_FEATURES 8
 #define ROAD_FEATURES_ONEHOT 14
 // Partner obs layout: [rel_x, rel_y, dz, width, length, rel_heading_x,
-// rel_heading_y, rel_vx_ego, rel_vy_ego]. The last two are the partner's
-// velocity relative to ego, rotated into the ego's local frame.
+// rel_heading_y, rel_vx_ego, rel_vy_ego].
 #define PARTNER_FEATURES 9
 
 #define MAX_CHECKED_LANES 32

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -2687,6 +2687,7 @@ float compute_partner_observations(Drive *env, float *obs, int agent_idx, int ob
 
     int ego_idx = env->active_agent_indices[agent_idx];
     Agent *ego_entity = &env->agents[ego_idx];
+    int ego_id = ego_entity->id;
 
     // Ego stats
     float cos_heading = cosf(ego_entity->sim_heading);
@@ -2696,13 +2697,9 @@ float compute_partner_observations(Drive *env, float *obs, int agent_idx, int ob
     int partners_in_radius = 0;
     AgentDistance candidates[MAX_AGENTS];
     for (int i = 0; i < env->num_created_agents; i++) {
-        // Skip the ego itself. Compare by slot index rather than Agent->id:
-        // id is assigned from the file for map-loaded agents and from the slot
-        // index for variably-spawned agents, so mixing modes could produce an
-        // id collision that silently drops a legitimate partner.
-        if (i == ego_idx)
-            continue;
         Agent *partner = &env->agents[i];
+        if (ego_id == partner->id)
+            continue;
         float dx = partner->sim_x - ego_entity->sim_x;
         float dy = partner->sim_y - ego_entity->sim_y;
         float dz = partner->sim_z - ego_entity->sim_z;


### PR DESCRIPTION
Replace the broken scalar partner velocity obs dim with a 2D vector: the partner's velocity relative to the ego, rotated into the ego's local frame.

## Previous encoding (broken)

\`\`\`c
float rel_vx = partner->sim_vx - ego_entity->sim_vx;
float rel_vy = partner->sim_vy - ego_entity->sim_vy;
float rel_speed_magnitude = sqrtf(rel_vx * rel_vx + rel_vy * rel_vy);
float rel_v_dot_heading = rel_vx * other_cos + rel_vy * other_sin;
obs[obs_idx + 7] = copysignf(rel_speed_magnitude, rel_v_dot_heading) / MAX_SPEED;
\`\`\`

The magnitude was \`|rel_v|\` in world frame, but the sign came from \`rel_v · partner_world_heading\`. This had no coherent physical interpretation — the sign depended on which way the (possibly stopped) partner happened to be facing, not on any property of the ego's approach. A stopped partner reported nonzero values whose sign flipped if you rotated the frozen car 180°.

## New encoding

\`\`\`c
float rel_vx_world = partner->sim_vx - ego_entity->sim_vx;
float rel_vy_world = partner->sim_vy - ego_entity->sim_vy;
float rel_vx_ego = rel_vx_world * cos_heading + rel_vy_world * sin_heading;
float rel_vy_ego = -rel_vx_world * sin_heading + rel_vy_world * cos_heading;
obs[obs_idx + 7] = rel_vx_ego / MAX_SPEED;
obs[obs_idx + 8] = rel_vy_ego / MAX_SPEED;
\`\`\`

Same \`R(−θ_ego)\` rotation already used to map the partner's world position delta \`(dx, dy)\` into \`(rel_x, rel_y)\` and the partner's world heading unit vector \`(other_cos, other_sin)\` into \`(rel_heading_x, rel_heading_y)\`. Now the partner's velocity vector lives in the ego's coordinate system alongside its position and heading, which is the reference frame the policy actually reasons in.