### PR TITLE
Single-agent CARLA Town10 launcher + program config (stacked on #439)

### DIFF
--- a/scripts/cluster_configs/single_agent_speed_run.yaml
+++ b/scripts/cluster_configs/single_agent_speed_run.yaml
@@ -1,0 +1,58 @@
+# Single-agent "speed run" training program config (for submit_cluster.py).
+# One controlled agent per environment on a single CARLA map (Town10), with many
+# parallel environments sharing one cached copy of the map geometry. Traffic
+# lights are fully disabled (no observation, no metric, no reward penalty). Keys
+# here override pufferlib/config/ocean/drive.ini; submit_cluster.py converts
+# underscores in each key to dashes for the CLI.
+#
+# Launch (3 seeds via the colon sweep):
+#   source /scratch/$USER/venvs/pufferdrive/bin/activate
+#   python scripts/submit_cluster.py \
+#       --save_dir /scratch/$USER/runs --prefix $(date +%Y-%m-%d)_single_agent \
+#       --compute_config scripts/cluster_configs/nyu_greene.yaml \
+#       --program_config scripts/cluster_configs/single_agent_speed_run.yaml \
+#       --container --heartbeat --account <acct> --partition <gpu-partition> --time 720 \
+#       --args train.seed=0:1:2
+
+# Environment: single agent per env, Town10HD only (index 7 in the sorted
+# carla bin dir), shared map cache.
+env.simulation_mode: gigaflow
+env.map_dir: pufferlib/resources/drive/binaries/carla
+env.starting_map: 7
+env.num_maps: 1
+env.min_agents_per_env: 1
+env.max_agents_per_env: 1
+env.num_agents: 1024
+env.use_map_cache: 1
+
+# Single goal waypoint ahead of the agent (route mode uses the default
+# min/max waypoint spacing of 20m/60m to place it).
+env.num_target_waypoints: 1
+
+# Traffic lights fully off: not observed, not scored, no reward penalty.
+env.traffic_light_behavior: 0
+env.obs_slots_traffic_controls_n: 0
+
+# Training
+train.total_timesteps: 1_000_000_000
+
+# Disable the nuPlan-based evaluators (keep validation_gigaflow, which is CARLA).
+eval.validation_replay.enabled: 0
+eval.behaviors_full_dir.enabled: 0
+eval.behaviors_hard_stop.enabled: 0
+eval.behaviors_highway_straight.enabled: 0
+eval.behaviors_lane_change.enabled: 0
+eval.behaviors_merge.enabled: 0
+eval.behaviors_parked_cars.enabled: 0
+eval.behaviors_roundabout.enabled: 0
+eval.behaviors_stopped_traffic.enabled: 0
+eval.behaviors_traffic_light_green.enabled: 0
+eval.behaviors_traffic_light_stop.enabled: 0
+eval.behaviors_unprotected_left.enabled: 0
+eval.behaviors_unprotected_right.enabled: 0
+
+# W&B. Group has no space: submit_cluster.py joins the inner command into a
+# bash -c string without quoting arg values, so a space would split the arg.
+wandb: True
+wandb_project: puffer_drive
+wandb_group: Nightly_Test

--- a/scripts/launch_single_agent.sh
+++ b/scripts/launch_single_agent.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Launch single-agent "speed run" training on the cluster via submit_cluster.py.
+# This is the canonical nightly launch: code-isolated per run (no rebuild SIGBUS),
+# container-wrapped, gpu-heartbeated, date-stamped wandb run names.
+#
+# Run on the login node (it sources the venv and submits from there):
+#   ./scripts/launch_single_agent.sh
+#
+# Overridable via the environment:
+#   PROGRAM_CONFIG  program_config YAML (default: single_agent_speed_run.yaml;
+#                   e.g. single_agent_no_lane_vel.yaml for the reward ablation)
+#   SEEDS           colon sweep passed to --args train.seed (default 0:1:2 -> 3 jobs)
+#   ACCOUNT/PARTITION/TIME   SLURM overrides
+#   PREFIX          run-name prefix (default <date>_single_agent)
+#
+# Examples:
+#   SEEDS=0 PROGRAM_CONFIG=scripts/cluster_configs/single_agent_no_lane_vel.yaml \
+#       ./scripts/launch_single_agent.sh
+#   PARTITION=a100_tandon ./scripts/launch_single_agent.sh   # if h200 QOS is full
+set -euo pipefail
+
+PROGRAM_CONFIG="${PROGRAM_CONFIG:-scripts/cluster_configs/single_agent_speed_run.yaml}"
+COMPUTE_CONFIG="${COMPUTE_CONFIG:-scripts/cluster_configs/nyu_greene.yaml}"
+ACCOUNT="${ACCOUNT:-torch_pr_924_tandon_advanced}"
+PARTITION="${PARTITION:-h200_tandon}"
+TIME="${TIME:-720}"
+SEEDS="${SEEDS:-0:1:2}"
+PREFIX="${PREFIX:-$(date +%Y-%m-%d)_single_agent}"
+
+source "/scratch/$USER/venvs/pufferdrive/bin/activate"
+python scripts/submit_cluster.py \
+    --save_dir "/scratch/$USER/runs" \
+    --prefix "$PREFIX" \
+    --compute_config "$COMPUTE_CONFIG" \
+    --program_config "$PROGRAM_CONFIG" \
+    --container --heartbeat \
+    --account "$ACCOUNT" --partition "$PARTITION" --time "$TIME" \
+    --args "train.seed=$SEEDS"


### PR DESCRIPTION
Adds the launcher script and a submit_cluster.py program config for nightly single-agent training on a single CARLA map.

**Files added:**

- `scripts/launch_single_agent.sh` — user-facing wrapper. Sets the project's SLURM defaults (account, partition, time, container, heartbeat); env vars override per knob. The canonical nightly invocation.
- `scripts/cluster_configs/single_agent_speed_run.yaml` — program config: Town10HD only, one agent per env, 1024 envs sharing one cached map, traffic lights fully off, single-waypoint short-range route goals. Disables the nuPlan-based evaluators; keeps validation_gigaflow.

**Town selection:** `env.map_dir` points at the in-repo `pufferlib/resources/drive/binaries/carla` directory; `env.starting_map: 7` picks Town10HD (the 8th entry in the sorted bin list — Town01–Town07 are 0–6) and `env.num_maps: 1` confines training to it. No extra cluster-side setup needed.

**Depends on:** `use_map_cache=1` from #439. The cache PR is the base of this branch.

**Notes:** uses route-based goal placement (the existing default); the "random goals anywhere" feature that was originally part of this work is not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)