### PR TITLE
Fix global step calcul

### DIFF
--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -366,7 +366,7 @@ class PuffeRL:
             profile("eval_misc", epoch)
             env_id = slice(env_id[0], env_id[-1] + 1)
 
-            self.global_step += int(mask.sum())
+            self.global_step += env_id.stop - env_id.start
 
             profile("eval_copy", epoch)
             o = torch.as_tensor(o)


### PR DESCRIPTION
This pull request makes a small change to the `evaluate` method in `pufferlib/pufferl.py` to improve how `global_step` is incremented. Instead of summing a mask, it now increments by the number of environments being evaluated, which should make the step count more accurate and consistent.

- Updated `global_step` increment logic in the `evaluate` method to use the number of environments evaluated (`env_id.stop - env_id.start`) instead of `mask.sum()`.