### PR TITLE
drive: use signed v in lane-align velocity term to match GIGAFLOW paper

### DIFF
--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -4244,7 +4244,8 @@ static void compute_rewards(Drive *env, int i) {
 
     // Rl-align (GIGAFLOW): min(cos,0) + vel_align*min(cos*v,0) + 0.0025*(1-|θ|/(π/2))
     float against_lane_penalty = fminf(cos_theta, 0.0f); // negative when >90 degrees off
-    float vel_aligned_penalty = agent->reward_coefs[REWARD_COEF_VEL_ALIGN] * fminf(cos_theta * agent->sim_speed, 0.0f);
+    float vel_aligned_penalty
+        = agent->reward_coefs[REWARD_COEF_VEL_ALIGN] * fminf(cos_theta * agent->sim_speed_signed, 0.0f);
     float alignment_bonus = 0.0025f * (1.0f - theta_f / (M_PI / 2.0f));
 
     float lane_align_reward = agent->reward_coefs[REWARD_COEF_LANE_ALIGN] * env->dt


### PR DESCRIPTION
## Summary

One-line fix in \`compute_rewards\` for \`R_l-align\`. The GIGAFLOW paper defines the velocity-weighted term as

$$\alpha_{\text{vel-align}} \cdot \min(\cos(\theta_f) \cdot v, 0)$$

with **signed** longitudinal velocity \`v\`. The implementation in \`drive.h:4247\` was using the unsigned \`sim_speed\`, which inverts the sign of the product for reverse motion and so flips the four cases that come out of the (heading × motion) truth table:

| heading vs lane | longitudinal v | world motion | paper penalizes? | code before |
|---|---|---|---|---|
| with (cos>0) | forward (v>0) | with lane | no | no ✓ |
| with (cos>0) | reverse (v<0) | **against** | **yes** | no ✗ |
| against (cos<0) | forward (v>0) | against | yes | yes ✓ |
| against (cos<0) | reverse (v<0) | **with** | **no** | yes ✗ |