### PR TITLE
drive: static_assert that struct Log stays all-float

### DIFF
--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -221,6 +221,13 @@ typedef struct GridMapEntity GridMapEntity;
 typedef struct GridMap GridMap;
 typedef struct MapCacheEntry MapCacheEntry;
 
+// Every field must be float. env_binding.h's vec_log iterates this struct as
+// a raw float[] (sizeof(Log)/sizeof(float) entries), so a non-float field
+// would be silently type-punned. When adding a field, also bump
+// LOG_NUM_FLOAT_FIELDS below; the _Static_assert catches size mismatches
+// from a forgotten bump or from a wider-than-float field (double/pointer).
+#define LOG_NUM_FLOAT_FIELDS 54
+
 struct Log {
     float n;
     float episode_return;
@@ -280,6 +287,11 @@ struct Log {
     float reward_overspeed;
     float reward_ade;
 };
+_Static_assert(
+    sizeof(struct Log) == LOG_NUM_FLOAT_FIELDS * sizeof(float),
+    "struct Log size mismatch: a field was added without bumping "
+    "LOG_NUM_FLOAT_FIELDS, or a non-float field slipped in (would corrupt "
+    "vec_log's raw-float iteration).");
 
 struct GridMapEntity {
     int entity_idx;   // Index into the road_elements array


### PR DESCRIPTION
## Summary

\`env_binding.h\`'s \`vec_log\` iterates \`struct Log\` as a raw \`float[]\` via \`sizeof(Log)/sizeof(float)\`. The existing comment "Will break horribly if Log has non-float data" warns about it, but nothing enforces the invariant. Adding a \`double\` / pointer field or even an unintended \`int\` could silently type-pun across the aggregation path.

This PR ties a \`LOG_NUM_FLOAT_FIELDS\` macro to the field count and \`_Static_assert\`s at the struct boundary that \`sizeof(struct Log) == LOG_NUM_FLOAT_FIELDS * sizeof(float)\`. Adding a field requires bumping the count; forgetting to bump it, or sneaking in a wider-than-float field, becomes a compile error.

\`\`\`c
#define LOG_NUM_FLOAT_FIELDS 54

struct Log {
    float n;
    ...
    float reward_ade;
};
_Static_assert(
    sizeof(struct Log) == LOG_NUM_FLOAT_FIELDS * sizeof(float),
    "struct Log size mismatch: a field was added without bumping "
    "LOG_NUM_FLOAT_FIELDS, or a non-float field slipped in (would corrupt "
    "vec_log's raw-float iteration).");
\`\`\`

## Gap

A same-sized non-float field (e.g. \`int\`) **with** the count bumped would still match \`sizeof(Log) == N * sizeof(float)\` and slip past the assert — the raw-float iteration would then type-pun the int bytes through \`float\`-typed reads. The comment at the top of the struct calls this out so a contributor is at least warned. A fully type-safe fix would need an X-macro field-registry refactor, which is much more invasive; this PR aims for the cheap, high-coverage defense.

## Test plan

- [x] \`python setup.py build_ext --inplace --force\` clean (only the pre-existing \`maps_checked\` warning).
- [x] Verified that the assertion is meaningful: bumping the count to 55 in a sandbox triggered the expected compile-time error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)