### PR TITLE
enable termination mode 1 for replay mode

### DIFF
--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -5417,7 +5417,7 @@ void c_step(Drive *env) {
 
     // -> 3. Check for episode truncation
     int early_reset = 0;
-    if (env->simulation_mode == SIMULATION_GIGAFLOW && env->termination_mode == 1) {
+    if (env->termination_mode == 1) {
         int count_inactive = 0;
         for (int i = 0; i < env->active_agent_count; i++) {
             int agent_idx = env->active_agent_indices[i];


### PR DESCRIPTION
Removes the guard that prevents to use termination mode 1 (terminate when x% of the agents are inactive) in replay mode. The guard only protects the early reset (which stops the step from computing the next observation and recompute goals), no other functionality. 

It seems early termination is compatible with replay mode, and there's no particular blocker in enabling it for replay mode.  