### PR TITLE
WIP: Modal nightly cron for PufferDrive training (do not merge)

### DIFF
--- a/scripts/cluster_configs/nightly_best.yaml
+++ b/scripts/cluster_configs/nightly_best.yaml
@@ -125,8 +125,11 @@ eval.behaviors_traffic_light_stop.enabled: 0
 eval.behaviors_unprotected_left.enabled: 0
 eval.behaviors_unprotected_right.enabled: 0
 
-# W&B — project nightly-multi-agent; group has no space (submit_cluster.py
-# joins the inner command without quoting arg values).
+# W&B — group has no space (submit_cluster.py joins the inner command
+# without quoting arg values). Launchers (launch_nightly_best.sh and
+# Modal's nightly()) override wandb_group to today's date at launch so
+# runs cluster by night in the UI; the static value here is just the
+# fallback for ad-hoc invocations.
 wandb: True
-wandb_project: nightly-multi-agent
-wandb_group: Nightly_MultiAgent
+wandb_project: nightly-multi
+wandb_group: nightly-multi

--- a/scripts/cluster_configs/nightly_best.yaml
+++ b/scripts/cluster_configs/nightly_best.yaml
@@ -1,0 +1,132 @@
+# Multi-agent "best launch" nightly training program config.
+# Derived from the oignons2 (emerge/temp_training) configuration at:
+#   weights/oignons2/config.yaml
+# Adapted to NYU Greene cluster paths and resource shape. Multi-agent gigaflow
+# training over the 8 local CARLA maps with the oignons2 policy architecture,
+# reward shaping (conditioning + randomization on), and partner-blindness /
+# phantom-braking perturbations enabled. Keys here override
+# pufferlib/config/ocean/drive.ini.
+#
+# Launch via scripts/launch_nightly_best.sh (3 seeds, date-stamped).
+
+# Environment — multi-agent gigaflow over all 8 local CARLA towns
+env.simulation_mode: gigaflow
+env.map_dir: pufferlib/resources/drive/binaries/carla
+env.num_maps: 8
+env.num_agents: 720000
+env.min_agents_per_env: 1
+env.max_agents_per_env: 150
+env.use_map_cache: 1
+env.scenario_length: 1200
+# 0 disables periodic scenario resampling — every sub-env keeps the same map
+# for the full run instead of swapping every 38400 steps.
+env.resample_frequency: 0
+env.termination_mode: 1
+env.inactive_agent_threshold: 0.4
+env.dynamics_model: jerk
+env.target_type: static
+env.spawn_initial_speed: 0.0
+env.dt: 0.3
+env.traffic_light_behavior: 1
+env.collision_behavior: 1
+env.offroad_behavior: 1
+
+# Goal setup — three sequential waypoints, route-based placement [20, 60m]
+env.num_target_waypoints: 3
+env.min_waypoint_spacing: 20.0
+env.max_waypoint_spacing: 60.0
+env.goal_radius: 2.0
+env.goal_speed: 3.0
+
+# Observation shaping (matches oignons2)
+env.obs_slots_lane_n: 80
+env.obs_slots_boundary_n: 80
+env.obs_slots_partners_n: 16
+env.obs_slots_traffic_controls_n: 4
+env.obs_range_partner_m: 200.0
+env.obs_range_road_front_m: 200.0
+env.obs_range_road_behind_m: 40.0
+env.obs_range_road_side_m: 50.0
+env.obs_range_traffic_control_m: 100.0
+env.obs_norm_xy_offset_m: 200.0
+env.obs_norm_goal_offset_m: 200.0
+env.obs_norm_road_seg_length_m: 10.0
+env.obs_norm_road_seg_width_m: 5.0
+env.obs_norm_veh_length_m: 15.0
+env.obs_norm_veh_width_m: 10.0
+env.obs_dropout_lane: 0.5
+env.obs_dropout_boundary: 0.4
+
+# Perturbations (on during training; eval's clean macro zeros these)
+env.partner_blindness_prob: 0.03
+env.partner_blindness_trigger_prob: 0.05
+env.phantom_braking_prob: 0.02
+env.phantom_braking_trigger_prob: 0.02
+env.phantom_braking_duration: 10
+
+# Reward shaping (oignons2 weights + conditioning/randomization on)
+env.reward_conditioning: true
+env.reward_randomization: true
+env.reward_goal: 1.0
+env.reward_collision: 1.5
+env.reward_offroad: 1.5
+env.reward_stop_line: 1.0
+env.reward_comfort: 0.05
+env.reward_lane_align: 0.025
+env.reward_vel_align: 1.0
+env.reward_lane_center: 0.005
+env.reward_velocity: 0.0025
+env.reward_reverse: 0.005
+env.reward_timestep: 2.5e-05
+env.reward_overspeed: 0.05
+
+# Policy — 3x1024 backbone, split actor/critic, gigaflow encoder
+policy.input_size: 256
+policy.backbone_hidden_size: 1024
+policy.backbone_num_layers: 3
+policy.actor_hidden_size: 1024
+policy.actor_num_layers: 0
+policy.critic_hidden_size: 1024
+policy.critic_num_layers: 0
+policy.split_network: true
+policy.encoder_gigaflow: true
+policy.dropout: 0.0
+
+# Training — 10B steps, large minibatch, compiled bfloat16
+train.total_timesteps: 10_000_000_000
+train.learning_rate: 0.0005
+train.minibatch_size: 153600
+train.max_minibatch_size: 153600
+train.update_epochs: 3
+train.bptt_horizon: 128
+train.compile: true
+train.precision: bfloat16
+train.normalize_rewards: false
+train.checkpoint_interval: 500
+train.optimizer: adamw
+
+# Eval — keep validation_gigaflow (CARLA sweep) inline, disable everything else
+# (validation_replay needs nuPlan bins; behaviors_* need labelled scene
+# categories not used in this nightly). Interval 250 keeps eval cost ~5% of
+# wall-clock instead of ~85%.
+eval.validation_defaults.interval: 250
+eval.validation_replay.enabled: 0
+eval.validation_gigaflow.render_backend: egl
+eval.behaviors_full_dir.enabled: 0
+eval.behaviors_hard_stop.enabled: 0
+eval.behaviors_highway_straight.enabled: 0
+eval.behaviors_lane_change.enabled: 0
+eval.behaviors_merge.enabled: 0
+eval.behaviors_parked_cars.enabled: 0
+eval.behaviors_roundabout.enabled: 0
+eval.behaviors_stopped_traffic.enabled: 0
+eval.behaviors_traffic_light_green.enabled: 0
+eval.behaviors_traffic_light_stop.enabled: 0
+eval.behaviors_unprotected_left.enabled: 0
+eval.behaviors_unprotected_right.enabled: 0
+
+# W&B — project nightly-multi-agent; group has no space (submit_cluster.py
+# joins the inner command without quoting arg values).
+wandb: True
+wandb_project: nightly-multi-agent
+wandb_group: Nightly_MultiAgent

--- a/scripts/cluster_configs/single_agent_speed_run.yaml
+++ b/scripts/cluster_configs/single_agent_speed_run.yaml
@@ -67,6 +67,9 @@ eval.behaviors_unprotected_right.enabled: 0
 
 # W&B. Group has no space: submit_cluster.py joins the inner command into a
 # bash -c string without quoting arg values, so a space would split the arg.
+# Launchers (launch_single_agent.sh and Modal's nightly()) override
+# wandb_group to today's date at launch so runs cluster by night in the UI;
+# the static value here is just the fallback for ad-hoc invocations.
 wandb: True
-wandb_project: single_agent_nightly_test
-wandb_group: Nightly_Test
+wandb_project: nightly-single
+wandb_group: nightly-single

--- a/scripts/launch_nightly_best.sh
+++ b/scripts/launch_nightly_best.sh
@@ -44,5 +44,5 @@ for SEED in "${SEED_LIST[@]}"; do
         --program_config "$PROGRAM_CONFIG" \
         --container --heartbeat \
         --account "$ACCOUNT" --partition "$PARTITION" --time "$TIME" --mem "$MEM" \
-        --args "train.seed=$SEED" "run_name=${DATE_STAMP}_seed${SEED}"
+        --args "train.seed=$SEED" "run_name=${DATE_STAMP}_seed${SEED}" "wandb_group=${DATE_STAMP}"
 done

--- a/scripts/launch_nightly_best.sh
+++ b/scripts/launch_nightly_best.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Launch multi-agent "nightly best" training on the cluster via submit_cluster.py.
+# Mirrors launch_single_agent.sh but uses the oignons2-derived nightly_best.yaml
+# (multi-agent gigaflow over 8 CARLA towns, 10B total steps). Code-isolated per
+# run, container-wrapped, gpu-heartbeated, date-stamped wandb run names.
+#
+# Run on the login node (it sources the venv and submits from there):
+#   ./scripts/launch_nightly_best.sh
+#
+# Overridable via the environment:
+#   PROGRAM_CONFIG  program_config YAML (default: nightly_best.yaml)
+#   SEEDS           colon sweep passed to --args train.seed (default 0:1:2 -> 3 jobs)
+#   ACCOUNT/PARTITION/TIME   SLURM overrides
+#   MEM             SLURM --mem (default 192gb; the multi-agent config plus
+#                   inline validation_gigaflow eval can spike past 128gb at
+#                   epoch 250)
+#   PREFIX          run-name prefix (default <date>_multi_agent)
+#
+# Examples:
+#   SEEDS=0 ./scripts/launch_nightly_best.sh                  # one-seed dry run
+#   PARTITION=h100_tandon ./scripts/launch_nightly_best.sh    # if h200 QOS is full
+set -euo pipefail
+
+PROGRAM_CONFIG="${PROGRAM_CONFIG:-scripts/cluster_configs/nightly_best.yaml}"
+COMPUTE_CONFIG="${COMPUTE_CONFIG:-scripts/cluster_configs/nyu_greene.yaml}"
+ACCOUNT="${ACCOUNT:-torch_pr_924_tandon_advanced}"
+PARTITION="${PARTITION:-h200_tandon}"
+TIME="${TIME:-1800}"
+MEM="${MEM:-192gb}"
+SEEDS="${SEEDS:-0:1:2}"
+PREFIX="${PREFIX:-$(date +%Y-%m-%d)_multi_agent}"
+DATE_STAMP="$(date +%Y-%m-%d)"
+
+source "/scratch/$USER/venvs/pufferdrive/bin/activate"
+
+# One submission per seed so we can pass a per-seed run_name (wandb display
+# name like 2026-05-31_seed0).
+IFS=':' read -ra SEED_LIST <<< "$SEEDS"
+for SEED in "${SEED_LIST[@]}"; do
+    python scripts/submit_cluster.py \
+        --save_dir "/scratch/$USER/runs" \
+        --prefix "$PREFIX" \
+        --compute_config "$COMPUTE_CONFIG" \
+        --program_config "$PROGRAM_CONFIG" \
+        --container --heartbeat \
+        --account "$ACCOUNT" --partition "$PARTITION" --time "$TIME" --mem "$MEM" \
+        --args "train.seed=$SEED" "run_name=${DATE_STAMP}_seed${SEED}"
+done

--- a/scripts/launch_single_agent.sh
+++ b/scripts/launch_single_agent.sh
@@ -41,5 +41,5 @@ for SEED in "${SEED_LIST[@]}"; do
         --program_config "$PROGRAM_CONFIG" \
         --container --heartbeat \
         --account "$ACCOUNT" --partition "$PARTITION" --time "$TIME" \
-        --args "train.seed=$SEED" "run_name=${DATE_STAMP}_seed${SEED}"
+        --args "train.seed=$SEED" "run_name=${DATE_STAMP}_seed${SEED}" "wandb_group=${DATE_STAMP}"
 done

--- a/scripts/modal/Dockerfile
+++ b/scripts/modal/Dockerfile
@@ -22,8 +22,10 @@ ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONNOUSERSITE=1 \
     PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
-    # Modal A100-80GB is sm_80. Single-arch keeps the C extension build fast.
-    TORCH_CUDA_ARCH_LIST=8.0
+    # Multi-arch so the same image runs on T4 (sm_75), A100 (sm_80), L4/L40S
+    # (sm_89), and H100/H200 (sm_90). Build is ~3-4x slower than single-arch
+    # but lets us swap Modal gpu= strings without rebuilding the image.
+    TORCH_CUDA_ARCH_LIST="7.5;8.0;8.9;9.0"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
@@ -59,17 +61,30 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
-RUN ln -sf /usr/bin/python3.12 /usr/local/bin/python && \
-    ln -sf /usr/bin/python3.12 /usr/local/bin/python3
+# Install uv — faster, deterministic resolver, replaces pip + venv + the
+# constraints-file dance. Modal disallows the Dockerfile ADD directive, so
+# fetch via curl.
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.local/bin:${PATH}"
 
-# Heaviest pip deps go in their own layer so iterating on the rest of the
-# image doesn't redownload torch (~2GB).
-RUN python -m pip install --upgrade --break-system-packages \
-        pip \
-        setuptools \
-        wheel
-RUN python -m pip install --break-system-packages \
-        "torch>=2.4" \
-        "numpy<2"
+# Project venv at /opt/venv (kept off the overlay/image filesystem in
+# spirit — symbolic of the cluster's /scratch/$USER/venvs layout).
+RUN uv venv /opt/venv --python 3.12
+ENV PATH="/opt/venv/bin:${PATH}" \
+    VIRTUAL_ENV="/opt/venv"
+
+RUN uv pip install setuptools wheel
+
+# torch from pypi is built against CUDA 13; pull the cu128 wheel instead so it
+# matches the base image's CUDA toolkit. setup.py's CUDAExtension path checks
+# this and refuses to build if torch and host CUDA disagree.
+RUN uv pip install --index-url https://download.pytorch.org/whl/cu128 torch
+
+# Pin numpy<2 and pandas<2.2 here so the later `uv pip install -e .` resolve
+# can't drag numpy 2 in via pandas 3 and break the C extension's numpy 1 ABI
+# (NPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION in setup.py). uv's resolver
+# respects these caps when computing the install_requires solution, unlike
+# pip which would gladly upgrade pre-installed pandas during -e .
+RUN uv pip install "numpy<2" "pandas<2.2"
 
 WORKDIR /workspace

--- a/scripts/modal/Dockerfile
+++ b/scripts/modal/Dockerfile
@@ -1,0 +1,75 @@
+# Base image for PufferDrive nightly training on Modal.
+#
+# Matches the NYU Greene Singularity sif as closely as possible:
+#   - CUDA 12.8.1 + cuDNN runtime
+#   - Ubuntu 24.04
+#   - Python 3.12
+#
+# The actual repo (and the built .so files) are baked into the image at deploy
+# time by scripts/modal/modal_app.py via copy_local_dir + run_commands. This
+# Dockerfile only handles the slow, version-stable layer: system libs, Python,
+# torch.
+#
+# Build context is the repo root (not scripts/modal/). Don't reference
+# repo files here — modal_app.py copies them in afterward so changes don't
+# invalidate the slow base.
+
+FROM nvidia/cuda:12.8.1-cudnn-devel-ubuntu24.04
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONNOUSERSITE=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    # Modal A100-80GB is sm_80. Single-arch keeps the C extension build fast.
+    TORCH_CUDA_ARCH_LIST=8.0
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        clang \
+        ccache \
+        ca-certificates \
+        curl \
+        git \
+        ninja-build \
+        pkg-config \
+        # OpenMP for the drive C extension
+        libomp-dev \
+        # EGL + GL for the headless render path in drive.h (eval.validation_gigaflow)
+        libegl1 \
+        libegl-dev \
+        libgles2-mesa-dev \
+        libgl1-mesa-dev \
+        libglvnd-dev \
+        # Raylib's X11 deps — used by the GLFW fallback when EGL isn't picked
+        libx11-dev \
+        libxcursor-dev \
+        libxinerama-dev \
+        libxi-dev \
+        libxrandr-dev \
+        # Headless display server for the GLFW fallback path
+        xvfb \
+        # ffmpeg for validation_gigaflow video encoding
+        ffmpeg \
+        # Python toolchain
+        python3.12 \
+        python3.12-dev \
+        python3.12-venv \
+        python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN ln -sf /usr/bin/python3.12 /usr/local/bin/python && \
+    ln -sf /usr/bin/python3.12 /usr/local/bin/python3
+
+# Heaviest pip deps go in their own layer so iterating on the rest of the
+# image doesn't redownload torch (~2GB).
+RUN python -m pip install --upgrade --break-system-packages \
+        pip \
+        setuptools \
+        wheel
+RUN python -m pip install --break-system-packages \
+        "torch>=2.4" \
+        "numpy<2"
+
+WORKDIR /workspace

--- a/scripts/modal/README.md
+++ b/scripts/modal/README.md
@@ -2,8 +2,10 @@
 
 Nightly cron that launches PufferDrive training on Modal — 3 seeds of
 `single_agent_speed_run.yaml` plus 3 seeds of `nightly_best.yaml`, all on
-1× A100-80GB in parallel, all logging to wandb project `nightly-modal` in the
-`emerge_` org.
+1× A100-80GB in parallel. Single-agent runs log to wandb project
+`nightly-single`; multi-agent to `nightly-multi`. In each project the
+`wandb_group` is today's UTC date so a night's 3 seeds cluster together in
+the UI. All under the `emerge_` org.
 
 ## Files
 

--- a/scripts/modal/README.md
+++ b/scripts/modal/README.md
@@ -1,0 +1,70 @@
+# Modal nightly training
+
+Nightly cron that launches PufferDrive training on Modal — 3 seeds of
+`single_agent_speed_run.yaml` plus 3 seeds of `nightly_best.yaml`, all on
+1× A100-80GB in parallel, all logging to wandb project `nightly-modal` in the
+`emerge_` org.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `Dockerfile` | CUDA 12.8.1 + cuDNN + Ubuntu 24.04 base, system libs, Python 3.12, torch. Slow layer — rarely rebuilt. |
+| `modal_app.py` | Modal app — bakes the repo + builds C extensions on top of the Dockerfile, defines the per-seed `train` function and the `nightly` cron entrypoint. |
+
+The training yamls themselves live in `scripts/cluster_configs/` and are shared
+with the Greene-side launcher.
+
+## One-time setup
+
+```bash
+# Install + auth Modal CLI (host machine)
+pip install modal
+modal token new
+
+# Create the wandb secret. Paste the API key from https://wandb.ai/authorize.
+modal secret create wandb-emerge WANDB_API_KEY=<key>
+```
+
+## Deploy the nightly cron
+
+```bash
+modal deploy scripts/modal/modal_app.py
+```
+
+Modal hashes the source — re-run after any code change to rebuild the image
+and update the deployed cron. The first deploy builds the Dockerfile (~5 min);
+subsequent deploys only rebuild the `pip install -e .` layer when repo files
+change (~1 min).
+
+The cron is `0 4 * * *` (04:00 UTC daily). Adjust the `modal.Cron(...)` arg in
+`modal_app.py` to change the wall-clock time.
+
+## Trigger runs manually
+
+```bash
+# Run the full 6-job fan-out now (without waiting for cron):
+modal run scripts/modal/modal_app.py::nightly
+
+# Run a single seed/config (useful for smoke tests):
+modal run scripts/modal/modal_app.py::train \
+    --yaml-path scripts/cluster_configs/single_agent_speed_run.yaml \
+    --seed 0 --run-name local_smoke --wandb-group smoke
+```
+
+## Inspect / cancel
+
+```bash
+modal app list                                      # show deployed apps
+modal app logs pufferdrive-nightly                  # tail logs (running app)
+modal app stop pufferdrive-nightly                  # remove the cron
+```
+
+Per-container logs (one per training run) appear in the Modal dashboard
+under the `pufferdrive-nightly` app.
+
+## Cost note
+
+A100-80GB on Modal is ~$3.20/h. A 12 h training run × 6 jobs = ~$230/night.
+Bring down by lowering `train.total_timesteps` in the yamls, dropping the
+`--gpu` to `A100` (40GB), or limiting to fewer seeds.

--- a/scripts/modal/modal_app.py
+++ b/scripts/modal/modal_app.py
@@ -31,40 +31,59 @@ import modal
 # ---------------------------------------------------------------------------
 # Image: Dockerfile base + repo + built C extensions.
 # ---------------------------------------------------------------------------
-REPO_ROOT = Path(__file__).resolve().parents[2]
+# Modal re-imports this module inside the container to find function
+# definitions, so module-level path resolution has to work in both contexts.
+# Locally (modal run / modal deploy) the file lives at
+# <repo>/scripts/modal/modal_app.py — three levels deep, setup.py is at the
+# resolved repo root. In the container Modal mirrors it to /root/modal_app.py
+# where the image is already built and these path references are inert; the
+# baked repo lives at /workspace via add_local_dir.
+def _resolve_repo_root() -> Path:
+    here = Path(__file__).resolve()
+    for ancestor in (here.parent, *here.parents):
+        if (ancestor / "setup.py").exists():
+            return ancestor
+    return Path("/workspace")
+
+
+REPO_ROOT = _resolve_repo_root()
 DOCKERFILE = REPO_ROOT / "scripts" / "modal" / "Dockerfile"
 
+_IGNORE_SEGMENTS = (
+    ".git/",
+    ".venv/",
+    "wandb/",
+    "experiments/",
+    "runs/",
+    "build/",
+    "extern/",
+    "__pycache__/",
+    ".pytest_cache/",
+    ".mypy_cache/",
+    ".ruff_cache/",
+)
+
+
+def _ignore(path) -> bool:
+    """add_local_dir ignore callable: True drops the file from the image."""
+    s = str(path)
+    return any(seg in s for seg in _IGNORE_SEGMENTS)
+
+
 image = (
-    modal.Image.from_dockerfile(
-        str(DOCKERFILE),
-        context_mount=modal.Mount.from_local_dir(
-            str(REPO_ROOT),
-            remote_path="/workspace",
-            # Skip heavy artefacts that aren't needed at runtime.
-            condition=lambda p: not any(
-                seg in p
-                for seg in (
-                    ".git/",
-                    ".venv/",
-                    "wandb/",
-                    "experiments/",
-                    "runs/",
-                    "build/",
-                    "extern/",
-                    "__pycache__/",
-                    ".pytest_cache/",
-                    ".mypy_cache/",
-                    ".ruff_cache/",
-                )
-            ),
-        ),
-    )
+    modal.Image.from_dockerfile(str(DOCKERFILE))
     .workdir("/workspace")
+    .add_local_dir(str(REPO_ROOT), "/workspace", copy=True, ignore=_ignore)
     # `-e .` triggers setup.py build_ext for the C + CUDA extensions.
-    # --no-build-isolation lets it see the torch already in the base image
-    # (otherwise pip builds a fresh torch in a sandbox — slow).
+    # --no-build-isolation lets uv use the torch already in /opt/venv
+    # instead of building it in a fresh sandbox (~2 min saved).
+    # The trailing numpy<2 / pandas<2.2 are additional constraints fed
+    # to uv's resolver alongside install_requires — without them an
+    # unconstrained `pandas` in setup.py would resolve to pandas 3+ and
+    # drag numpy 2 in, breaking the C extension's numpy 1 ABI
+    # (NPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION in setup.py).
     .run_commands(
-        "pip install --break-system-packages --no-build-isolation -e .",
+        'uv pip install --no-build-isolation -e . "numpy<2" "pandas<2.2"',
         # Smoke-import to fail the build early if extensions didn't compile.
         "python -c 'import pufferlib.ocean.drive.binding; "
         "import pufferlib._C; print(\"extensions OK\")'",
@@ -108,6 +127,12 @@ def yaml_to_cli_args(cfg: dict) -> list[str]:
 # ---------------------------------------------------------------------------
 @app.function(
     gpu="A100-80GB",
+    # Enough cores for drive.ini's vec.num_workers default (20) plus headroom.
+    # PufferLib refuses to start if num_workers > os.cpu_count().
+    cpu=24,
+    # Enough RAM for the C-side map cache + vec env workers. Bump for the
+    # multi-agent (nightly_best) config which loads heavier maps.
+    memory=32 * 1024,
     # 12h cap; nightly runs at total_timesteps=1B/10B can take this long. Bump
     # if a real run wedges short of completion.
     timeout=12 * 3600,
@@ -124,6 +149,7 @@ def train(
     wandb_group: str,
 ) -> str:
     """Run one training job. Returns the run_name on success."""
+    import os
     import subprocess
 
     import yaml
@@ -135,19 +161,29 @@ def train(
     cli_args += [
         "--train.seed",
         str(seed),
+        # PufferLib refuses to start if num_workers > os.cpu_count(). Modal's
+        # T4/A100 containers come with ~16 logical cores; pin workers/envs
+        # to a safe value regardless of yaml/drive.ini defaults.
+        "--vec.num-workers",
+        "8",
+        "--vec.num-envs",
+        "8",
         "--wandb-project",
         WANDB_PROJECT,
-        "--wandb-entity",
-        WANDB_ENTITY,
         "--wandb-group",
         wandb_group,
         "--run-name",
         run_name,
     ]
 
+    # pufferl.py has no --wandb-entity flag; wandb picks the entity up from
+    # WANDB_ENTITY in the env. WANDB_API_KEY arrives via the wandb-emerge
+    # Modal secret.
+    env = {**os.environ, "WANDB_ENTITY": WANDB_ENTITY}
+
     cmd = ["python", "-m", "pufferlib.pufferl", "train", "puffer_drive", *cli_args]
     print(f"[modal] launching: {' '.join(cmd)}", flush=True)
-    subprocess.run(cmd, check=True, cwd="/workspace")
+    subprocess.run(cmd, check=True, cwd="/workspace", env=env)
     return run_name
 
 
@@ -156,8 +192,11 @@ def train(
 # ---------------------------------------------------------------------------
 # Schedule: 04:00 UTC daily ≈ midnight ET / 21:00 PT previous day. Adjust if
 # the user wants a different wall-clock time.
-@app.function(timeout=60 * 60, secrets=[WANDB_SECRET])
-@modal.schedule(modal.Cron("0 4 * * *"))
+@app.function(
+    timeout=60 * 60,
+    secrets=[WANDB_SECRET],
+    schedule=modal.Cron("0 4 * * *"),
+)
 def nightly() -> None:
     """Fan out to per-seed, per-config training runs in parallel."""
     from datetime import datetime, timezone

--- a/scripts/modal/modal_app.py
+++ b/scripts/modal/modal_app.py
@@ -1,10 +1,11 @@
 """Nightly PufferDrive training on Modal.
 
 Schedules a cron that, every night, launches:
-  - 3 seeds × scripts/cluster_configs/single_agent_speed_run.yaml
-  - 3 seeds × scripts/cluster_configs/nightly_best.yaml
-each on its own 1× A100-80GB container, all in parallel. All 6 runs log to the
-same wandb project (overridden here, not in the yamls) under distinct groups.
+  - 3 seeds × scripts/cluster_configs/single_agent_speed_run.yaml →
+    wandb project `nightly-single`, group = today's UTC date
+  - 3 seeds × scripts/cluster_configs/nightly_best.yaml →
+    wandb project `nightly-multi`, group = today's UTC date
+each on its own 1× A100-80GB container, all in parallel.
 
 One-time setup:
   modal token new                     # if not already authenticated
@@ -19,7 +20,8 @@ Trigger the full nightly fan-out manually (without waiting for cron):
 Trigger one run manually:
   modal run scripts/modal/modal_app.py::train \\
       --yaml-path scripts/cluster_configs/single_agent_speed_run.yaml \\
-      --seed 0 --run-name local_smoke --wandb-group smoke
+      --seed 0 --run-name local_smoke --wandb-group smoke \\
+      --wandb-project nightly-single
 """
 
 from __future__ import annotations
@@ -98,7 +100,8 @@ app = modal.App("pufferdrive-nightly", image=image)
 # Create with:
 #   modal secret create wandb-emerge WANDB_API_KEY=<key>
 WANDB_SECRET = modal.Secret.from_name("wandb-emerge")
-WANDB_PROJECT = "nightly-modal"
+WANDB_PROJECT_SINGLE = "nightly-single"
+WANDB_PROJECT_MULTI = "nightly-multi"
 WANDB_ENTITY = "emerge_"
 
 # ---------------------------------------------------------------------------
@@ -147,6 +150,7 @@ def train(
     seed: int,
     run_name: str,
     wandb_group: str,
+    wandb_project: str,
 ) -> str:
     """Run one training job. Returns the run_name on success."""
     import os
@@ -169,7 +173,7 @@ def train(
         "--vec.num-envs",
         "8",
         "--wandb-project",
-        WANDB_PROJECT,
+        wandb_project,
         "--wandb-group",
         wandb_group,
         "--run-name",
@@ -198,28 +202,35 @@ def train(
     schedule=modal.Cron("0 4 * * *"),
 )
 def nightly() -> None:
-    """Fan out to per-seed, per-config training runs in parallel."""
+    """Fan out to per-seed, per-config training runs in parallel.
+
+    Single-agent runs land in wandb project `nightly-single`, multi-agent in
+    `nightly-multi`. Within each project the wandb_group is today's UTC date
+    so a night's 3 seeds cluster together.
+    """
     from datetime import datetime, timezone
 
     date = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
     seeds = [0, 1, 2]
 
-    jobs: list[tuple[str, int, str, str]] = []
+    jobs: list[tuple[str, int, str, str, str]] = []
     for seed in seeds:
         jobs.append(
             (
                 "scripts/cluster_configs/single_agent_speed_run.yaml",
                 seed,
-                f"{date}_single_seed{seed}",
-                "modal_single_agent",
+                f"{date}_seed{seed}",
+                date,
+                WANDB_PROJECT_SINGLE,
             )
         )
         jobs.append(
             (
                 "scripts/cluster_configs/nightly_best.yaml",
                 seed,
-                f"{date}_multi_seed{seed}",
-                "modal_multi_agent",
+                f"{date}_seed{seed}",
+                date,
+                WANDB_PROJECT_MULTI,
             )
         )
 
@@ -227,9 +238,9 @@ def nightly() -> None:
     # starmap blocks until every run finishes. exceptions in a single run
     # propagate; other runs continue.
     results = list(train.starmap(jobs, return_exceptions=True))
-    for (yaml_path, seed, run_name, _group), result in zip(jobs, results):
+    for (yaml_path, seed, run_name, _group, project), result in zip(jobs, results):
         status = "OK" if not isinstance(result, BaseException) else f"FAIL: {result!r}"
-        print(f"[modal] {run_name} ({yaml_path}, seed={seed}): {status}", flush=True)
+        print(f"[modal] {project}/{run_name} ({yaml_path}, seed={seed}): {status}", flush=True)
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/modal/modal_app.py
+++ b/scripts/modal/modal_app.py
@@ -1,0 +1,202 @@
+"""Nightly PufferDrive training on Modal.
+
+Schedules a cron that, every night, launches:
+  - 3 seeds × scripts/cluster_configs/single_agent_speed_run.yaml
+  - 3 seeds × scripts/cluster_configs/nightly_best.yaml
+each on its own 1× A100-80GB container, all in parallel. All 6 runs log to the
+same wandb project (overridden here, not in the yamls) under distinct groups.
+
+One-time setup:
+  modal token new                     # if not already authenticated
+  modal secret create wandb-emerge WANDB_API_KEY=<paste from wandb.ai/authorize>
+
+Deploy the cron (idempotent — re-run after each code change):
+  modal deploy scripts/modal/modal_app.py
+
+Trigger the full nightly fan-out manually (without waiting for cron):
+  modal run scripts/modal/modal_app.py::nightly
+
+Trigger one run manually:
+  modal run scripts/modal/modal_app.py::train \\
+      --yaml-path scripts/cluster_configs/single_agent_speed_run.yaml \\
+      --seed 0 --run-name local_smoke --wandb-group smoke
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import modal
+
+# ---------------------------------------------------------------------------
+# Image: Dockerfile base + repo + built C extensions.
+# ---------------------------------------------------------------------------
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCKERFILE = REPO_ROOT / "scripts" / "modal" / "Dockerfile"
+
+image = (
+    modal.Image.from_dockerfile(
+        str(DOCKERFILE),
+        context_mount=modal.Mount.from_local_dir(
+            str(REPO_ROOT),
+            remote_path="/workspace",
+            # Skip heavy artefacts that aren't needed at runtime.
+            condition=lambda p: not any(
+                seg in p
+                for seg in (
+                    ".git/",
+                    ".venv/",
+                    "wandb/",
+                    "experiments/",
+                    "runs/",
+                    "build/",
+                    "extern/",
+                    "__pycache__/",
+                    ".pytest_cache/",
+                    ".mypy_cache/",
+                    ".ruff_cache/",
+                )
+            ),
+        ),
+    )
+    .workdir("/workspace")
+    # `-e .` triggers setup.py build_ext for the C + CUDA extensions.
+    # --no-build-isolation lets it see the torch already in the base image
+    # (otherwise pip builds a fresh torch in a sandbox — slow).
+    .run_commands(
+        "pip install --break-system-packages --no-build-isolation -e .",
+        # Smoke-import to fail the build early if extensions didn't compile.
+        "python -c 'import pufferlib.ocean.drive.binding; "
+        "import pufferlib._C; print(\"extensions OK\")'",
+    )
+)
+
+app = modal.App("pufferdrive-nightly", image=image)
+
+# ---------------------------------------------------------------------------
+# Secrets + wandb routing.
+# ---------------------------------------------------------------------------
+# Create with:
+#   modal secret create wandb-emerge WANDB_API_KEY=<key>
+WANDB_SECRET = modal.Secret.from_name("wandb-emerge")
+WANDB_PROJECT = "nightly-modal"
+WANDB_ENTITY = "emerge_"
+
+# ---------------------------------------------------------------------------
+# yaml-to-CLI conversion. Mirrors scripts/submit_cluster.py's logic so the
+# same yamls work on Modal and Greene.
+# ---------------------------------------------------------------------------
+BOOLEAN_FLAGS = {"wandb", "neptune"}
+
+
+def yaml_to_cli_args(cfg: dict) -> list[str]:
+    args: list[str] = []
+    for key, val in cfg.items():
+        cli_key = key.replace("_", "-")
+        if key in BOOLEAN_FLAGS:
+            if val in (True, "True", "true", 1, "1"):
+                args.append(f"--{cli_key}")
+            # False: omit the flag entirely
+            continue
+        args.append(f"--{cli_key}")
+        args.append(str(val))
+    return args
+
+
+# ---------------------------------------------------------------------------
+# Per-run training function. One container per call.
+# ---------------------------------------------------------------------------
+@app.function(
+    gpu="A100-80GB",
+    # 12h cap; nightly runs at total_timesteps=1B/10B can take this long. Bump
+    # if a real run wedges short of completion.
+    timeout=12 * 3600,
+    secrets=[WANDB_SECRET],
+    # Retries on container infra failure (preempt, OOM at boot). The training
+    # job itself shouldn't restart on RL crashes — let the run die so we
+    # notice.
+    retries=modal.Retries(max_retries=1, backoff_coefficient=1.0),
+)
+def train(
+    yaml_path: str,
+    seed: int,
+    run_name: str,
+    wandb_group: str,
+) -> str:
+    """Run one training job. Returns the run_name on success."""
+    import subprocess
+
+    import yaml
+
+    cfg_path = Path("/workspace") / yaml_path
+    cfg = yaml.safe_load(cfg_path.read_text())
+
+    cli_args = yaml_to_cli_args(cfg)
+    cli_args += [
+        "--train.seed",
+        str(seed),
+        "--wandb-project",
+        WANDB_PROJECT,
+        "--wandb-entity",
+        WANDB_ENTITY,
+        "--wandb-group",
+        wandb_group,
+        "--run-name",
+        run_name,
+    ]
+
+    cmd = ["python", "-m", "pufferlib.pufferl", "train", "puffer_drive", *cli_args]
+    print(f"[modal] launching: {' '.join(cmd)}", flush=True)
+    subprocess.run(cmd, check=True, cwd="/workspace")
+    return run_name
+
+
+# ---------------------------------------------------------------------------
+# Cron entrypoint — fans out to 6 parallel `train` calls.
+# ---------------------------------------------------------------------------
+# Schedule: 04:00 UTC daily ≈ midnight ET / 21:00 PT previous day. Adjust if
+# the user wants a different wall-clock time.
+@app.function(timeout=60 * 60, secrets=[WANDB_SECRET])
+@modal.schedule(modal.Cron("0 4 * * *"))
+def nightly() -> None:
+    """Fan out to per-seed, per-config training runs in parallel."""
+    from datetime import datetime, timezone
+
+    date = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
+    seeds = [0, 1, 2]
+
+    jobs: list[tuple[str, int, str, str]] = []
+    for seed in seeds:
+        jobs.append(
+            (
+                "scripts/cluster_configs/single_agent_speed_run.yaml",
+                seed,
+                f"{date}_single_seed{seed}",
+                "modal_single_agent",
+            )
+        )
+        jobs.append(
+            (
+                "scripts/cluster_configs/nightly_best.yaml",
+                seed,
+                f"{date}_multi_seed{seed}",
+                "modal_multi_agent",
+            )
+        )
+
+    print(f"[modal] nightly fan-out: {len(jobs)} runs", flush=True)
+    # starmap blocks until every run finishes. exceptions in a single run
+    # propagate; other runs continue.
+    results = list(train.starmap(jobs, return_exceptions=True))
+    for (yaml_path, seed, run_name, _group), result in zip(jobs, results):
+        status = "OK" if not isinstance(result, BaseException) else f"FAIL: {result!r}"
+        print(f"[modal] {run_name} ({yaml_path}, seed={seed}): {status}", flush=True)
+
+
+# ---------------------------------------------------------------------------
+# Local entrypoint (modal run scripts/modal/modal_app.py::nightly).
+# ---------------------------------------------------------------------------
+@app.local_entrypoint()
+def main() -> None:
+    """Default `modal run` target — triggers the nightly fan-out immediately."""
+    nightly.remote()


### PR DESCRIPTION
## Summary

WIP scaffolding to run nightly PufferDrive training on Modal.

Adds:
- \`scripts/modal/Dockerfile\` — CUDA 12.8.1 / Ubuntu 24.04 / Python 3.12 / uv / torch cu128 base image. Multi-arch CUDA (sm_75 / sm_80 / sm_89 / sm_90) so one image runs on T4 / A100 / L4 / H100.
- \`scripts/modal/modal_app.py\` — Modal app with a per-seed \`train()\` function on 1× A100-80GB and a \`nightly()\` cron at 04:00 UTC that fans out to 6 parallel runs (3 seeds × {single_agent, multi_agent}). Logs to wandb project \`nightly-modal\` under \`emerge_\`.
- \`scripts/modal/README.md\` — \`modal token new\` → \`modal secret create wandb-emerge ...\` → \`modal deploy\` workflow.
- \`scripts/cluster_configs/nightly_best.yaml\` — multi-agent training config (ported from \`nightly_best_launch\` branch) so the same yaml works for the Greene launcher and Modal.

## Status

Smoke test on A100-80GB is **running end-to-end** as of opening this PR:
- wandb run: <https://wandb.ai/emerge_/nightly-modal/runs/n8a85v5z>
- ~200K SPS, ETA ~1h 20m to 1B steps

What's known to work after the smoke:
- ✓ Image build (~5 min first time, ~2 min on iterations; cached layers shared across runs)
- ✓ \`uv pip install -e .\` builds C + CUDA extensions on the image
- ✓ wandb auth via Modal secret
- ✓ Training subprocess starts, PPO loop converges (entropy ↓, episode_return ↑, offroad_rate ↓)

## Why WIP / do not merge

- Hasn't been run with the multi-agent (\`nightly_best.yaml\`) config yet — it has 720k agents and 10B total_timesteps; needs to fit in the 12h Modal timeout per container.
- Cost on Modal is non-trivial — 6 × A100-80GB-hours/night = a few hundred / month. Wait for a real cost number from the first full multi-agent run before merging anything that auto-fires.
- A few rough edges I'd want to clean up first: cpu/memory split per yaml (smaller for single-agent, larger for multi), maybe an env knob to scale total_timesteps for cheaper smoke runs.

## Test plan

- [ ] Smoke training run on A100-80GB to ≥10M steps without OOM / crash (in progress now)
- [ ] Manual \`modal run scripts/modal/modal_app.py::nightly\` to verify the 6-job fan-out
- [ ] Multi-agent yaml runs to completion in a 12h container
- [ ] Verify wandb run finalization (model upload) lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)