### PR TITLE
WIP: Modal nightly cron — stacked on Greene PR (do not merge)

### DIFF
--- a/scripts/modal/Dockerfile
+++ b/scripts/modal/Dockerfile
@@ -1,0 +1,90 @@
+# Base image for PufferDrive nightly training on Modal.
+#
+# Matches the NYU Greene Singularity sif as closely as possible:
+#   - CUDA 12.8.1 + cuDNN runtime
+#   - Ubuntu 24.04
+#   - Python 3.12
+#
+# The actual repo (and the built .so files) are baked into the image at deploy
+# time by scripts/modal/modal_app.py via copy_local_dir + run_commands. This
+# Dockerfile only handles the slow, version-stable layer: system libs, Python,
+# torch.
+#
+# Build context is the repo root (not scripts/modal/). Don't reference
+# repo files here — modal_app.py copies them in afterward so changes don't
+# invalidate the slow base.
+
+FROM nvidia/cuda:12.8.1-cudnn-devel-ubuntu24.04
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONNOUSERSITE=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    # Multi-arch so the same image runs on T4 (sm_75), A100 (sm_80), L4/L40S
+    # (sm_89), and H100/H200 (sm_90). Build is ~3-4x slower than single-arch
+    # but lets us swap Modal gpu= strings without rebuilding the image.
+    TORCH_CUDA_ARCH_LIST="7.5;8.0;8.9;9.0"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        clang \
+        ccache \
+        ca-certificates \
+        curl \
+        git \
+        ninja-build \
+        pkg-config \
+        # OpenMP for the drive C extension
+        libomp-dev \
+        # EGL + GL for the headless render path in drive.h (eval.validation_gigaflow)
+        libegl1 \
+        libegl-dev \
+        libgles2-mesa-dev \
+        libgl1-mesa-dev \
+        libglvnd-dev \
+        # Raylib's X11 deps — used by the GLFW fallback when EGL isn't picked
+        libx11-dev \
+        libxcursor-dev \
+        libxinerama-dev \
+        libxi-dev \
+        libxrandr-dev \
+        # Headless display server for the GLFW fallback path
+        xvfb \
+        # ffmpeg for validation_gigaflow video encoding
+        ffmpeg \
+        # Python toolchain
+        python3.12 \
+        python3.12-dev \
+        python3.12-venv \
+        python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install uv — faster, deterministic resolver, replaces pip + venv + the
+# constraints-file dance. Modal disallows the Dockerfile ADD directive, so
+# fetch via curl.
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.local/bin:${PATH}"
+
+# Project venv at /opt/venv (kept off the overlay/image filesystem in
+# spirit — symbolic of the cluster's /scratch/$USER/venvs layout).
+RUN uv venv /opt/venv --python 3.12
+ENV PATH="/opt/venv/bin:${PATH}" \
+    VIRTUAL_ENV="/opt/venv"
+
+RUN uv pip install setuptools wheel
+
+# torch from pypi is built against CUDA 13; pull the cu128 wheel instead so it
+# matches the base image's CUDA toolkit. setup.py's CUDAExtension path checks
+# this and refuses to build if torch and host CUDA disagree.
+RUN uv pip install --index-url https://download.pytorch.org/whl/cu128 torch
+
+# Pin numpy<2 and pandas<2.2 here so the later `uv pip install -e .` resolve
+# can't drag numpy 2 in via pandas 3 and break the C extension's numpy 1 ABI
+# (NPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION in setup.py). uv's resolver
+# respects these caps when computing the install_requires solution, unlike
+# pip which would gladly upgrade pre-installed pandas during -e .
+RUN uv pip install "numpy<2" "pandas<2.2"
+
+WORKDIR /workspace

--- a/scripts/modal/README.md
+++ b/scripts/modal/README.md
@@ -1,0 +1,72 @@
+# Modal nightly training
+
+Nightly cron that launches PufferDrive training on Modal — 3 seeds of
+`single_agent_speed_run.yaml` plus 3 seeds of `nightly_best.yaml`, all on
+1× A100-80GB in parallel. Single-agent runs log to wandb project
+`nightly-single`; multi-agent to `nightly-multi`. In each project the
+`wandb_group` is today's UTC date so a night's 3 seeds cluster together in
+the UI. All under the `emerge_` org.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `Dockerfile` | CUDA 12.8.1 + cuDNN + Ubuntu 24.04 base, system libs, Python 3.12, torch. Slow layer — rarely rebuilt. |
+| `modal_app.py` | Modal app — bakes the repo + builds C extensions on top of the Dockerfile, defines the per-seed `train` function and the `nightly` cron entrypoint. |
+
+The training yamls themselves live in `scripts/cluster_configs/` and are shared
+with the Greene-side launcher.
+
+## One-time setup
+
+```bash
+# Install + auth Modal CLI (host machine)
+pip install modal
+modal token new
+
+# Create the wandb secret. Paste the API key from https://wandb.ai/authorize.
+modal secret create wandb-emerge WANDB_API_KEY=<key>
+```
+
+## Deploy the nightly cron
+
+```bash
+modal deploy scripts/modal/modal_app.py
+```
+
+Modal hashes the source — re-run after any code change to rebuild the image
+and update the deployed cron. The first deploy builds the Dockerfile (~5 min);
+subsequent deploys only rebuild the `pip install -e .` layer when repo files
+change (~1 min).
+
+The cron is `0 4 * * *` (04:00 UTC daily). Adjust the `modal.Cron(...)` arg in
+`modal_app.py` to change the wall-clock time.
+
+## Trigger runs manually
+
+```bash
+# Run the full 6-job fan-out now (without waiting for cron):
+modal run scripts/modal/modal_app.py::nightly
+
+# Run a single seed/config (useful for smoke tests):
+modal run scripts/modal/modal_app.py::train \
+    --yaml-path scripts/cluster_configs/single_agent_speed_run.yaml \
+    --seed 0 --run-name local_smoke --wandb-group smoke
+```
+
+## Inspect / cancel
+
+```bash
+modal app list                                      # show deployed apps
+modal app logs pufferdrive-nightly                  # tail logs (running app)
+modal app stop pufferdrive-nightly                  # remove the cron
+```
+
+Per-container logs (one per training run) appear in the Modal dashboard
+under the `pufferdrive-nightly` app.
+
+## Cost note
+
+A100-80GB on Modal is ~$3.20/h. A 12 h training run × 6 jobs = ~$230/night.
+Bring down by lowering `train.total_timesteps` in the yamls, dropping the
+`--gpu` to `A100` (40GB), or limiting to fewer seeds.

--- a/scripts/modal/modal_app.py
+++ b/scripts/modal/modal_app.py
@@ -1,0 +1,252 @@
+"""Nightly PufferDrive training on Modal.
+
+Schedules a cron that, every night, launches:
+  - 3 seeds × scripts/cluster_configs/single_agent_speed_run.yaml →
+    wandb project `nightly-single`, group = today's UTC date
+  - 3 seeds × scripts/cluster_configs/nightly_best.yaml →
+    wandb project `nightly-multi`, group = today's UTC date
+each on its own 1× A100-80GB container, all in parallel.
+
+One-time setup:
+  modal token new                     # if not already authenticated
+  modal secret create wandb-emerge WANDB_API_KEY=<paste from wandb.ai/authorize>
+
+Deploy the cron (idempotent — re-run after each code change):
+  modal deploy scripts/modal/modal_app.py
+
+Trigger the full nightly fan-out manually (without waiting for cron):
+  modal run scripts/modal/modal_app.py::nightly
+
+Trigger one run manually:
+  modal run scripts/modal/modal_app.py::train \\
+      --yaml-path scripts/cluster_configs/single_agent_speed_run.yaml \\
+      --seed 0 --run-name local_smoke --wandb-group smoke \\
+      --wandb-project nightly-single
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import modal
+
+# ---------------------------------------------------------------------------
+# Image: Dockerfile base + repo + built C extensions.
+# ---------------------------------------------------------------------------
+# Modal re-imports this module inside the container to find function
+# definitions, so module-level path resolution has to work in both contexts.
+# Locally (modal run / modal deploy) the file lives at
+# <repo>/scripts/modal/modal_app.py — three levels deep, setup.py is at the
+# resolved repo root. In the container Modal mirrors it to /root/modal_app.py
+# where the image is already built and these path references are inert; the
+# baked repo lives at /workspace via add_local_dir.
+def _resolve_repo_root() -> Path:
+    here = Path(__file__).resolve()
+    for ancestor in (here.parent, *here.parents):
+        if (ancestor / "setup.py").exists():
+            return ancestor
+    return Path("/workspace")
+
+
+REPO_ROOT = _resolve_repo_root()
+DOCKERFILE = REPO_ROOT / "scripts" / "modal" / "Dockerfile"
+
+_IGNORE_SEGMENTS = (
+    ".git/",
+    ".venv/",
+    "wandb/",
+    "experiments/",
+    "runs/",
+    "build/",
+    "extern/",
+    "__pycache__/",
+    ".pytest_cache/",
+    ".mypy_cache/",
+    ".ruff_cache/",
+)
+
+
+def _ignore(path) -> bool:
+    """add_local_dir ignore callable: True drops the file from the image."""
+    s = str(path)
+    return any(seg in s for seg in _IGNORE_SEGMENTS)
+
+
+image = (
+    modal.Image.from_dockerfile(str(DOCKERFILE))
+    .workdir("/workspace")
+    .add_local_dir(str(REPO_ROOT), "/workspace", copy=True, ignore=_ignore)
+    # `-e .` triggers setup.py build_ext for the C + CUDA extensions.
+    # --no-build-isolation lets uv use the torch already in /opt/venv
+    # instead of building it in a fresh sandbox (~2 min saved).
+    # The trailing numpy<2 / pandas<2.2 are additional constraints fed
+    # to uv's resolver alongside install_requires — without them an
+    # unconstrained `pandas` in setup.py would resolve to pandas 3+ and
+    # drag numpy 2 in, breaking the C extension's numpy 1 ABI
+    # (NPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION in setup.py).
+    .run_commands(
+        'uv pip install --no-build-isolation -e . "numpy<2" "pandas<2.2"',
+        # Smoke-import to fail the build early if extensions didn't compile.
+        "python -c 'import pufferlib.ocean.drive.binding; "
+        "import pufferlib._C; print(\"extensions OK\")'",
+    )
+)
+
+app = modal.App("pufferdrive-nightly", image=image)
+
+# ---------------------------------------------------------------------------
+# Secrets + wandb routing.
+# ---------------------------------------------------------------------------
+# Create with:
+#   modal secret create wandb-emerge WANDB_API_KEY=<key>
+WANDB_SECRET = modal.Secret.from_name("wandb-emerge")
+WANDB_PROJECT_SINGLE = "nightly-single"
+WANDB_PROJECT_MULTI = "nightly-multi"
+WANDB_ENTITY = "emerge_"
+
+# ---------------------------------------------------------------------------
+# yaml-to-CLI conversion. Mirrors scripts/submit_cluster.py's logic so the
+# same yamls work on Modal and Greene.
+# ---------------------------------------------------------------------------
+BOOLEAN_FLAGS = {"wandb", "neptune"}
+
+
+def yaml_to_cli_args(cfg: dict) -> list[str]:
+    args: list[str] = []
+    for key, val in cfg.items():
+        cli_key = key.replace("_", "-")
+        if key in BOOLEAN_FLAGS:
+            if val in (True, "True", "true", 1, "1"):
+                args.append(f"--{cli_key}")
+            # False: omit the flag entirely
+            continue
+        args.append(f"--{cli_key}")
+        args.append(str(val))
+    return args
+
+
+# ---------------------------------------------------------------------------
+# Per-run training function. One container per call.
+# ---------------------------------------------------------------------------
+@app.function(
+    gpu="A100-80GB",
+    # Enough cores for drive.ini's vec.num_workers default (20) plus headroom.
+    # PufferLib refuses to start if num_workers > os.cpu_count().
+    cpu=24,
+    # Enough RAM for the C-side map cache + vec env workers. Bump for the
+    # multi-agent (nightly_best) config which loads heavier maps.
+    memory=32 * 1024,
+    # 12h cap; nightly runs at total_timesteps=1B/10B can take this long. Bump
+    # if a real run wedges short of completion.
+    timeout=12 * 3600,
+    secrets=[WANDB_SECRET],
+    # Retries on container infra failure (preempt, OOM at boot). The training
+    # job itself shouldn't restart on RL crashes — let the run die so we
+    # notice.
+    retries=modal.Retries(max_retries=1, backoff_coefficient=1.0),
+)
+def train(
+    yaml_path: str,
+    seed: int,
+    run_name: str,
+    wandb_group: str,
+    wandb_project: str,
+) -> str:
+    """Run one training job. Returns the run_name on success."""
+    import os
+    import subprocess
+
+    import yaml
+
+    cfg_path = Path("/workspace") / yaml_path
+    cfg = yaml.safe_load(cfg_path.read_text())
+
+    cli_args = yaml_to_cli_args(cfg)
+    cli_args += [
+        "--train.seed",
+        str(seed),
+        # PufferLib refuses to start if num_workers > os.cpu_count(). Modal's
+        # T4/A100 containers come with ~16 logical cores; pin workers/envs
+        # to a safe value regardless of yaml/drive.ini defaults.
+        "--vec.num-workers",
+        "8",
+        "--vec.num-envs",
+        "8",
+        "--wandb-project",
+        wandb_project,
+        "--wandb-group",
+        wandb_group,
+        "--run-name",
+        run_name,
+    ]
+
+    # pufferl.py has no --wandb-entity flag; wandb picks the entity up from
+    # WANDB_ENTITY in the env. WANDB_API_KEY arrives via the wandb-emerge
+    # Modal secret.
+    env = {**os.environ, "WANDB_ENTITY": WANDB_ENTITY}
+
+    cmd = ["python", "-m", "pufferlib.pufferl", "train", "puffer_drive", *cli_args]
+    print(f"[modal] launching: {' '.join(cmd)}", flush=True)
+    subprocess.run(cmd, check=True, cwd="/workspace", env=env)
+    return run_name
+
+
+# ---------------------------------------------------------------------------
+# Cron entrypoint — fans out to 6 parallel `train` calls.
+# ---------------------------------------------------------------------------
+# Schedule: 04:00 UTC daily ≈ midnight ET / 21:00 PT previous day. Adjust if
+# the user wants a different wall-clock time.
+@app.function(
+    timeout=60 * 60,
+    secrets=[WANDB_SECRET],
+    schedule=modal.Cron("0 4 * * *"),
+)
+def nightly() -> None:
+    """Fan out to per-seed, per-config training runs in parallel.
+
+    Single-agent runs land in wandb project `nightly-single`, multi-agent in
+    `nightly-multi`. Within each project the wandb_group is today's UTC date
+    so a night's 3 seeds cluster together.
+    """
+    from datetime import datetime, timezone
+
+    date = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
+    seeds = [0, 1, 2]
+
+    jobs: list[tuple[str, int, str, str, str]] = []
+    for seed in seeds:
+        jobs.append(
+            (
+                "scripts/cluster_configs/single_agent_speed_run.yaml",
+                seed,
+                f"{date}_seed{seed}",
+                date,
+                WANDB_PROJECT_SINGLE,
+            )
+        )
+        jobs.append(
+            (
+                "scripts/cluster_configs/nightly_best.yaml",
+                seed,
+                f"{date}_seed{seed}",
+                date,
+                WANDB_PROJECT_MULTI,
+            )
+        )
+
+    print(f"[modal] nightly fan-out: {len(jobs)} runs", flush=True)
+    # starmap blocks until every run finishes. exceptions in a single run
+    # propagate; other runs continue.
+    results = list(train.starmap(jobs, return_exceptions=True))
+    for (yaml_path, seed, run_name, _group, project), result in zip(jobs, results):
+        status = "OK" if not isinstance(result, BaseException) else f"FAIL: {result!r}"
+        print(f"[modal] {project}/{run_name} ({yaml_path}, seed={seed}): {status}", flush=True)
+
+
+# ---------------------------------------------------------------------------
+# Local entrypoint (modal run scripts/modal/modal_app.py::nightly).
+# ---------------------------------------------------------------------------
+@app.local_entrypoint()
+def main() -> None:
+    """Default `modal run` target — triggers the nightly fan-out immediately."""
+    nightly.remote()


### PR DESCRIPTION
## Summary

WIP — runs the same nightly fan-out as the Greene launcher (sibling PR), on Modal with a built-in cron schedule.

**Stacked on top of #497** — base is \`ev/nightly_runs_greene\` because \`modal_app.py\` reads the yamls added in that PR at runtime. Merge order: #497, then this.

- \`scripts/modal/Dockerfile\` — CUDA 12.8.1 / Ubuntu 24.04 / Python 3.12 / uv / torch cu128 base. Multi-arch CUDA (sm_75 / sm_80 / sm_89 / sm_90) so one image runs on T4 / A100 / L4 / L40S / H100 / H200 without rebuild.
- \`scripts/modal/modal_app.py\` — Modal app with:
  - per-seed \`train()\` on 1× A100-80GB (cpu=24, memory=32GB, timeout=12h, retries=1)
  - \`nightly()\` cron at 04:00 UTC fanning out to 6 parallel runs (3 seeds × {single, multi})
  - routes to wandb projects \`nightly-single\` / \`nightly-multi\`, group = today's UTC date
- \`scripts/modal/README.md\` — setup / deploy / manual trigger workflow.

## Status

Smoke-validated end-to-end on A100-80GB:
- wandb run live: <https://wandb.ai/emerge_/nightly-modal/runs/n8a85v5z>
- ~200K SPS, full PPO + Drive metric pipeline confirmed (entropy, episode_return, offroad_rate, num_goals_reached, dnf_rate, …)

## Why WIP / do not merge

- Hasn't been run with the multi-agent (\`nightly_best.yaml\`) yaml on Modal yet — needs to fit in the 12h container timeout.
- Cost is non-trivial — 6 × A100-80GB-hours/night ≈ a few hundred / month. Wait for a real multi-agent number before flipping cron on.
- Image-cache caveat: changing the Dockerfile invalidates everything below it. Want to settle the apt list before this lands so subsequent edits don't trigger 5-min apt rebuilds.

## Test plan

- [ ] Smoke training run on A100-80GB to ≥10M steps (in progress)
- [ ] Manual \`modal run scripts/modal/modal_app.py::nightly\` to verify the 6-job fan-out
- [ ] Multi-agent yaml runs to completion in a 12h container
- [ ] Verify wandb run finalization (model upload) lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)