### PR TITLE
temp dropout fix for eval

### DIFF
--- a/.github/workflows/update-smoke-golden.yml
+++ b/.github/workflows/update-smoke-golden.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - '3.0'
       - 'ev/**'
+      - 'yvonne/**'
 
 permissions:
   contents: write

--- a/.github/workflows/update-smoke-golden.yml
+++ b/.github/workflows/update-smoke-golden.yml
@@ -10,7 +10,6 @@ on:
     branches:
       - '3.0'
       - 'ev/**'
-      - 'yvonne/**'
 
 permissions:
   contents: write

--- a/pufferlib/ocean/benchmark/manager.py
+++ b/pufferlib/ocean/benchmark/manager.py
@@ -32,6 +32,8 @@ from pathlib import Path
 import pufferlib
 
 from pufferlib.ocean.benchmark.evaluators import EVALUATOR_REGISTRY, EvalResult, Evaluator
+from pufferlib.ocean.drive.drive import compute_effective_road_obs_count
+from pufferlib.ocean.torch import DriveBackbone
 
 # clean_eval macro — env knobs to zero/enforce. Per-section explicit values
 # win over the macro (see _build_section_config).
@@ -185,10 +187,14 @@ class EvalManager:
                 env_kwargs=[args["env"] for _ in range(num_envs)],
                 **vec_call_kwargs,
             )
+        # TODO: temporary fix for the DriveBackbone slot-count mismatch bug
+        # Swap backbones at the eval layout and restore the training layout after
+        saved_road_slots = _swap_policy_road_slots(policy, args["env"])
         try:
             res = ev.rollout(vecenv, policy, args)
         finally:
             vecenv.close()
+            _restore_policy_road_slots(saved_road_slots)
         return res
 
     def _run_subprocess(self, ev: Evaluator, env_name: str, global_step, epoch=None) -> EvalResult:
@@ -278,6 +284,37 @@ class EvalManager:
                         logger.log(payload)
             except ImportError:
                 pass
+
+
+def _swap_policy_road_slots(policy, env_args: dict) -> list:
+    """
+    Point every DriveBackbone in `policy` at the eval env's road-obs layout
+    DriveBackbone slices the flat obs buffer with the training env's dropout-reduced kept slot counts
+    Eval env emits obs_slots_*_n based on its own config
+    Returns the saved per-module counts for _restore_policy_road_slots
+    """
+    if "obs_slots_lane_n" not in env_args:
+        return []
+    eval_lane_kept = compute_effective_road_obs_count(
+        int(env_args["obs_slots_lane_n"]), float(env_args.get("obs_dropout_lane", 0.0))
+    )
+    eval_boundary_kept = compute_effective_road_obs_count(
+        int(env_args["obs_slots_boundary_n"]), float(env_args.get("obs_dropout_boundary", 0.0))
+    )
+    saved = []
+    for module in policy.modules():
+        if not isinstance(module, DriveBackbone):
+            continue
+        saved.append((module, module.obs_slots_lane_kept, module.obs_slots_boundary_kept))
+        module.obs_slots_lane_kept = eval_lane_kept
+        module.obs_slots_boundary_kept = eval_boundary_kept
+    return saved
+
+
+def _restore_policy_road_slots(saved: list) -> None:
+    for module, lane_kept, boundary_kept in saved:
+        module.obs_slots_lane_kept = lane_kept
+        module.obs_slots_boundary_kept = boundary_kept
 
 
 def _discover_eval_sections(args: dict) -> dict:

--- a/tests/smoke_tests/data/drive_smoke_golden.json
+++ b/tests/smoke_tests/data/drive_smoke_golden.json
@@ -6,7 +6,7 @@
     "comfort_violation_count": 0.7831849157810211,
     "dnf_rate": 0.5625,
     "episode_length": 45.75,
-    "episode_return": -2.6349124908447266,
+    "episode_return": -2.634913980960846,
     "lane_center_rate": 0.7325379699468613,
     "n": 16.0,
     "num_goals_reached": 0.0,

--- a/tests/unit_tests/test_train_eval_dropout.py
+++ b/tests/unit_tests/test_train_eval_dropout.py
@@ -11,12 +11,7 @@ as a shape/view error inside the rollout forward pass.
 Deliberately not tied to any specific fix: it exercises the public pipeline
 (load_config -> load_env -> load_policy -> PuffeRL -> EvalManager) and only
 asserts that nothing crashes, the rollouts actually evaluate agents, and
-training still works after the evals. No golden values, so it runs on any
-host (no QEMU pinning needed) as a plain unit test.
-
-Evals are dispatched via run_one_by_name, NOT maybe_run: maybe_run catches
-evaluator exceptions and continues, which would let a crashing rollout pass
-this test silently.
+training still works after the evals.
 """
 
 import os
@@ -237,12 +232,12 @@ def test_train_then_eval_across_dropout_rates():
                 try:
                     pufferl.utilization.stop()
                 except Exception:
-                    pass
+                    assert False, "PuffeRL.utilization.stop() failed; check for dangling threads"
             if vecenv is not None:
                 try:
                     vecenv.close()
                 except Exception:
-                    pass
+                    assert False, "vecenv.close() failed; check for dangling threads"
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/test_train_eval_dropout.py
+++ b/tests/unit_tests/test_train_eval_dropout.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""
+End-to-end train -> eval consistency test for observation dropout.
+
+Trains a tiny policy on a CPU env with nonzero road-obs dropout, then runs
+the real EvalManager inline-eval path against eval envs whose dropout rate
+differs from training. The policy slices the flat obs buffer by the env's
+dropout-reduced road-slot layout, so any train/eval layout mismatch surfaces
+as a shape/view error inside the rollout forward pass.
+
+Deliberately not tied to any specific fix: it exercises the public pipeline
+(load_config -> load_env -> load_policy -> PuffeRL -> EvalManager) and only
+asserts that nothing crashes, the rollouts actually evaluate agents, and
+training still works after the evals. No golden values, so it runs on any
+host (no QEMU pinning needed) as a plain unit test.
+
+Evals are dispatched via run_one_by_name, NOT maybe_run: maybe_run catches
+evaluator exceptions and continues, which would let a crashing rollout pass
+this test silently.
+"""
+
+import os
+import random
+import signal
+import sys
+
+import numpy as np
+import torch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from pufferlib.ocean.benchmark.manager import EvalManager
+from pufferlib.pufferl import PuffeRL, load_config, load_env, load_policy
+
+SEED = 42
+BPTT_HORIZON = 32  # == scenario_length so episodes complete each epoch
+TRAIN_DROPOUT_LANE = 0.5
+TRAIN_DROPOUT_BOUNDARY = 0.25
+WATCHDOG_SECONDS = 900
+
+# One eval section per layout relation to the training env:
+#   same_dropout    — inherits training dropout (identity layout)
+#   zero_dropout    — clean macro zeroes dropout (wider obs than training)
+#   heavier_dropout — explicit higher dropout (narrower obs than training)
+EVAL_SECTIONS = {
+    "same_dropout": {
+        "type": "multi_scenario",
+        "interval": 1,
+        "mode": "inline",
+        "clean": False,
+    },
+    "zero_dropout": {
+        "type": "multi_scenario",
+        "interval": 1,
+        "mode": "inline",
+        "clean": True,
+    },
+    "heavier_dropout": {
+        "type": "multi_scenario",
+        "interval": 1,
+        "mode": "inline",
+        "clean": False,
+        "env.obs_dropout_lane": 0.75,
+        "env.obs_dropout_boundary": 0.75,
+    },
+}
+
+
+class _DummyLogger:
+    """PuffeRL calls self.logger.log() inside mean_and_log(); no-op it."""
+
+    run_id = "eval_dropout_test"
+
+    def log(self, *args, **kwargs):
+        pass
+
+    def __getattr__(self, _name):
+        return lambda *a, **k: None
+
+
+class _Watchdog:
+    """Hard cap on wall time so a hung rollout fails fast instead of
+    eating the whole CI job."""
+
+    def __enter__(self):
+        signal.signal(signal.SIGALRM, self._fire)
+        signal.alarm(WATCHDOG_SECONDS)
+        return self
+
+    def __exit__(self, *exc):
+        signal.alarm(0)
+        return False
+
+    @staticmethod
+    def _fire(signum, frame):
+        raise TimeoutError(f"train/eval dropout test exceeded {WATCHDOG_SECONDS}s watchdog")
+
+
+def _seed_everything():
+    random.seed(SEED)
+    np.random.seed(SEED)
+    torch.manual_seed(SEED)
+    torch.set_num_threads(1)
+
+
+def _set_existing(section, updates):
+    """Only override keys that already exist, so we never inject an unknown
+    kwarg that a constructor would reject."""
+    for key, value in updates.items():
+        if key in section:
+            section[key] = value
+
+
+def _build_config():
+    # load_config() calls argparse.parse_args(), which would otherwise choke
+    # on pytest's argv. Hide it for the duration of the call.
+    saved_argv = sys.argv
+    sys.argv = [saved_argv[0]]
+    try:
+        args = load_config("puffer_drive")
+    finally:
+        sys.argv = saved_argv
+
+    _set_existing(
+        args["vec"],
+        {
+            "backend": "Serial",
+            "num_envs": 2,
+            "seed": SEED,
+        },
+    )
+
+    _set_existing(
+        args["env"],
+        {
+            "num_agents": 16,
+            "min_agents_per_env": 16,
+            "max_agents_per_env": 16,
+            "action_type": "discrete",
+            "num_maps": 2,
+            "use_map_cache": 1,
+            "map_dir": "pufferlib/resources/drive/binaries/carla",
+            "scenario_length": BPTT_HORIZON,
+            "obs_dropout_lane": TRAIN_DROPOUT_LANE,
+            "obs_dropout_boundary": TRAIN_DROPOUT_BOUNDARY,
+            "seed": SEED,
+        },
+    )
+
+    # Shrink the net: this test checks layout plumbing, not learning.
+    _set_existing(
+        args["policy"],
+        {
+            "ego_input_size": 32,
+            "partner_input_size": 128,
+            "lane_input_size": 64,
+            "boundary_input_size": 64,
+            "traffic_control_input_size": 16,
+            "context_input_size": 8,
+            "backbone_hidden_size": 256,
+            "actor_hidden_size": 128,
+            "critic_hidden_size": 64,
+        },
+    )
+
+    args["wandb"] = False
+    args["neptune"] = False
+    # Replace the ini's eval suites with the three dropout-relation sections.
+    args["eval"] = {name: dict(section) for name, section in EVAL_SECTIONS.items()}
+
+    return args
+
+
+def _finalize_train_config(args, total_agents):
+    minibatch_size = total_agents * BPTT_HORIZON // 4
+    _set_existing(
+        args["train"],
+        {
+            "device": "cpu",
+            "compile": False,
+            "seed": SEED,
+            "torch_deterministic": True,
+            "anneal_lr": False,
+            "learning_rate": 0.001,
+            "update_epochs": 1,
+            "bptt_horizon": BPTT_HORIZON,
+            "minibatch_size": minibatch_size,
+            "max_minibatch_size": minibatch_size,
+            "total_timesteps": 10_000_000,  # large -> never "done" during the test
+            "checkpoint_interval": 10_000_000,
+            "render": False,
+        },
+    )
+    # The training loop itself must not fire evaluators (we dispatch them
+    # explicitly below so their exceptions propagate).
+    return dict(**args["train"], env="puffer_drive", eval={})
+
+
+def _run_train_epoch(pufferl):
+    pufferl.evaluate()
+    pufferl.train()
+
+
+def test_train_then_eval_across_dropout_rates():
+    _seed_everything()
+    args = _build_config()
+
+    vecenv = None
+    pufferl = None
+    with _Watchdog():
+        try:
+            vecenv = load_env("puffer_drive", args)
+            train_config = _finalize_train_config(args, vecenv.num_agents)
+            policy = load_policy(args, vecenv, "puffer_drive")
+            pufferl = PuffeRL(train_config, vecenv, policy, logger=_DummyLogger())
+
+            _run_train_epoch(pufferl)
+
+            manager = EvalManager.from_config(args)
+            for eval_name in EVAL_SECTIONS:
+                result = manager.run_one_by_name(
+                    eval_name,
+                    policy=pufferl.uncompiled_policy,
+                    env_name="puffer_drive",
+                    global_step=0,
+                    epoch=1,
+                )
+                assert result.metrics.get("num_agents_evaluated", 0) > 0, (
+                    f"[eval.{eval_name}] rollout completed but evaluated no agents"
+                )
+
+            # Eval must leave the policy usable on the training layout: a
+            # policy left pointed at an eval layout would crash right here.
+            _run_train_epoch(pufferl)
+        finally:
+            if pufferl is not None and hasattr(pufferl, "utilization"):
+                try:
+                    pufferl.utilization.stop()
+                except Exception:
+                    pass
+            if vecenv is not None:
+                try:
+                    vecenv.close()
+                except Exception:
+                    pass
+
+
+if __name__ == "__main__":
+    test_train_then_eval_across_dropout_rates()
+    print("Train/eval dropout test passed!")


### PR DESCRIPTION
Temporary change:
1. change obs_slots_lane_kept and obs_slots_boundary_kept before and after eval using eval's config
2. enable nightly run with evals