### PR TITLE
(WIP) Fix silent agent attrition when spawn positions can't fit goals

### DIFF
--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -1800,9 +1800,9 @@ static bool generate_new_goals_from_route(Drive *env, Agent *agent) {
     // Places num_goals goals along the agent's route by native lane arc-length.
     // Replay follows the loaded route to its end; gigaflow route source random-walks a fresh route
     // when the current one runs out.
+    // Returns false without mutating removal state when no placement fits; the
+    // caller decides whether to resample a spawn position or remove the agent.
     if (agent->route == NULL || agent->route_length <= 0) {
-        invalidate_agent(agent);
-        agent->removed = 1;
         return false;
     }
 
@@ -1841,10 +1841,8 @@ static bool generate_new_goals_from_route(Drive *env, Agent *agent) {
         route_remaining_meters += env->road_elements[agent->route[route_idx]].length;
     }
 
-    // Replay: once the agent is essentially at the end of its logged route, retire it.
+    // Replay: once the agent is essentially at the end of its logged route, it is done.
     if (env->simulation_mode == SIMULATION_REPLAY && route_remaining_meters <= env->goal_radius) {
-        invalidate_agent(agent);
-        agent->removed = 1;
         return false;
     }
 
@@ -1880,11 +1878,6 @@ static bool generate_new_goals_from_route(Drive *env, Agent *agent) {
         // Free-roam route source: random-walk a fresh route from the current lane, then retry once.
         int start_lane_idx = (agent->current_lane_idx != -1) ? agent->current_lane_idx : agent->route[base_route_idx];
         if (!compute_new_route(env, agent, start_lane_idx)) {
-            invalidate_agent(agent);
-            agent->removed = 1;
-            printf(
-                "[GIGAFLOW WARNING] -> Failed to compute new route for agent %d. Removing from simulation.\n",
-                agent->id);
             return false;
         }
         agent->current_route_idx = 0;
@@ -1909,12 +1902,6 @@ static bool generate_new_goals_from_route(Drive *env, Agent *agent) {
             goal_z,
             goal_lane);
         if (placed_goal_count < env->num_goals) {
-            invalidate_agent(agent);
-            agent->removed = 1;
-            printf(
-                "[GIGAFLOW ERROR] -> New route for agent %d is too short for goal generation. Removing from "
-                "simulation.\n",
-                agent->id);
             return false;
         }
         commit_goals(env, agent, goal_x, goal_y, goal_z, goal_lane, placed_goal_count, 0);
@@ -3204,9 +3191,10 @@ static bool spawn_agent(Drive *env, int agent_idx, int num_agents) {
     float spawn_x, spawn_y, spawn_z, spawn_heading;
     RoadMapElement *start_lane;
     int start_lane_idx;
-    bool is_agent_spawned = false;
 
-    // Sampling rejection loop
+    // Sampling rejection loop. A candidate position is rejected on collision,
+    // offroad, stop-line crossing, or when no route/goals fit from it (short
+    // or dead-end lanes) — the next attempt resamples a fresh position.
     // TARGET: Only one attempt should be sufficient in most cases
     const int MAX_SPAWN_ATTEMPTS = 30;
     for (int attempt = 0; attempt < MAX_SPAWN_ATTEMPTS; attempt++) {
@@ -3272,55 +3260,50 @@ static bool spawn_agent(Drive *env, int agent_idx, int num_agents) {
             continue;
         }
 
-        is_agent_spawned = true;
-        break;
-    }
+        // Update simulation state
+        agent->sim_x = spawn_x;
+        agent->sim_y = spawn_y;
+        agent->sim_z = spawn_z;
+        agent->sim_heading = spawn_heading;
+        agent->cos_heading = cosf(spawn_heading);
+        agent->sin_heading = sinf(spawn_heading);
+        copy_pose_to_prev(agent);
+        agent->sim_length = spawn_length;
+        agent->sim_width = spawn_width;
+        agent->sim_height = spawn_height;
+        update_agent_radius(agent);
+        agent->sim_valid = 1;
+        agent->wheelbase = 0.6f * spawn_length;
+        agent->current_lane_idx = start_lane_idx;
+        float spawn_speed = clip(env->spawn_initial_speed, 0.0f, MAX_SPEED);
+        agent->sim_vx = spawn_speed * agent->cos_heading;
+        agent->sim_vy = spawn_speed * agent->sin_heading;
+        agent->yaw_rate = 0.0f;
+        update_agent_speed(agent);
 
-    if (!is_agent_spawned) {
-        printf("[GIGAFLOW WARNING] -> Failed to find a collision-free spawn position for agent %d\n", agent->id);
-        return is_agent_spawned;
-    }
-
-    // Update simulation state
-    agent->sim_x = spawn_x;
-    agent->sim_y = spawn_y;
-    agent->sim_z = spawn_z;
-    agent->sim_heading = spawn_heading;
-    agent->cos_heading = cosf(spawn_heading);
-    agent->sin_heading = sinf(spawn_heading);
-    copy_pose_to_prev(agent);
-    agent->sim_length = spawn_length;
-    agent->sim_width = spawn_width;
-    agent->sim_height = spawn_height;
-    update_agent_radius(agent);
-    agent->sim_valid = 1;
-    agent->wheelbase = 0.6f * spawn_length;
-    agent->current_lane_idx = start_lane_idx;
-    float spawn_speed = clip(env->spawn_initial_speed, 0.0f, MAX_SPEED);
-    agent->sim_vx = spawn_speed * agent->cos_heading;
-    agent->sim_vy = spawn_speed * agent->sin_heading;
-    agent->yaw_rate = 0.0f;
-    update_agent_speed(agent);
-
-    if (env->goal_source == GOAL_SOURCE_MAP) {
-        if (!generate_new_goals_from_map(env, agent)) {
-            printf("[GIGAFLOW WARNING] -> Failed to generate map goals for agent %d\n", agent_idx);
-            return false;
+        if (env->goal_source == GOAL_SOURCE_MAP) {
+            if (!generate_new_goals_from_map(env, agent)) {
+                continue;
+            }
+            return true;
         }
+
+        if (!compute_new_route(env, agent, start_lane_idx)) {
+            continue;
+        }
+
+        if (!generate_new_goals_from_route(env, agent)) {
+            continue;
+        }
+
         return true;
     }
 
-    if (!compute_new_route(env, agent, start_lane_idx)) {
-        printf("[GIGAFLOW WARNING] -> Failed to compute a new route for agent %d\n", agent_idx);
-        return false; // Failed to compute new goal
-    }
-
-    // Compute initial goal
-    if (!generate_new_goals_from_route(env, agent)) {
-        return false;
-    }
-
-    return true;
+    printf(
+        "[GIGAFLOW WARNING] -> No viable spawn position/route/goals for agent %d after %d attempts\n",
+        agent->id,
+        MAX_SPAWN_ATTEMPTS);
+    return false;
 }
 
 static void set_start_position(Drive *env) {
@@ -3869,15 +3852,20 @@ void init(Drive *env) {
                 agent->current_goal_z = agent->list_goal_z[0];
             }
         }
-    } else if (env->goal_source == GOAL_SOURCE_MAP) {
-        for (int i = 0; i < env->active_agent_count; i++) {
-            Agent *agent = &env->agents[env->active_agent_indices[i]];
-            generate_new_goals_from_map(env, agent);
-        }
-    } else if (env->goal_source == GOAL_SOURCE_ROUTE) {
-        for (int i = 0; i < env->active_agent_count; i++) {
-            Agent *agent = &env->agents[env->active_agent_indices[i]];
-            generate_new_goals_from_route(env, agent);
+    } else if (env->goal_source == GOAL_SOURCE_MAP || env->goal_source == GOAL_SOURCE_ROUTE) {
+        // Gigaflow agents already received goals inside spawn_agent; re-rolling
+        // here could fail and strand a removed agent in the active set.
+        if (env->simulation_mode != SIMULATION_GIGAFLOW) {
+            for (int i = 0; i < env->active_agent_count; i++) {
+                Agent *agent = &env->agents[env->active_agent_indices[i]];
+                bool goals_ok = (env->goal_source == GOAL_SOURCE_MAP) ? generate_new_goals_from_map(env, agent)
+                                                                      : generate_new_goals_from_route(env, agent);
+                if (!goals_ok) {
+                    printf("[DRIVE WARNING] -> No goals fit for agent %d at init; removing\n", agent->id);
+                    invalidate_agent(agent);
+                    agent->removed = 1;
+                }
+            }
         }
     }
 }
@@ -5303,7 +5291,11 @@ void c_reset(Drive *env) {
             agent->current_goal_y = agent->list_goal_y[0];
             agent->current_goal_z = agent->list_goal_z[0];
         } else {
-            generate_new_goals_from_route(env, agent);
+            if (!generate_new_goals_from_route(env, agent)) {
+                printf("[DRIVE WARNING] -> No goals fit for agent %d on reset; removing\n", agent->id);
+                invalidate_agent(agent);
+                agent->removed = 1;
+            }
         }
         compute_metrics(env, agent_idx, x);
     }
@@ -5453,8 +5445,9 @@ void c_step(Drive *env) {
         if (!regen) {
             continue;
         }
-        // On regen failure remove the agent (route helper self-invalidates; the extra call is idempotent),
-        // otherwise a stale current_goal_idx >= goal_count leaves an empty goal window and the agent freezes.
+        // On regen failure remove the agent, otherwise a stale
+        // current_goal_idx >= goal_count leaves an empty goal window and the
+        // agent freezes.
         bool regen_ok = (env->goal_source == GOAL_SOURCE_MAP) ? generate_new_goals_from_map(env, agent)
                                                               : generate_new_goals_from_route(env, agent);
         if (!regen_ok) {

--- a/tests/drive/test_drive_env_smoke.c
+++ b/tests/drive/test_drive_env_smoke.c
@@ -7,9 +7,18 @@ static int run_case(const char *name, const char *map_file, int simulation_mode,
     int obs_size = compute_observation_size(&env);
 
     EXPECT_TRUE(env.active_agent_count > 0);
+    if (simulation_mode == SIMULATION_GIGAFLOW) {
+        // Gigaflow must spawn every requested agent; a shortfall means spawn
+        // silently dropped agents (e.g. goal generation failed on a position
+        // that should have been resampled).
+        EXPECT_EQ_INT(env.active_agent_count, num_agents);
+    }
     EXPECT_TRUE(env.observations != NULL);
     EXPECT_TRUE(env.rewards != NULL);
     EXPECT_TRUE(drive_all_finite(env.observations, env.active_agent_count * obs_size));
+    for (int i = 0; i < env.active_agent_count; i++) {
+        EXPECT_TRUE(!env.agents[env.active_agent_indices[i]].removed);
+    }
 
     int saw_log = 0;
     for (int t = 0; t < env.scenario_length + 5; t++) {
@@ -25,6 +34,9 @@ static int run_case(const char *name, const char *map_file, int simulation_mode,
             int terminal_flags = (agent->metrics_array[COLLISION_IDX] > 0.0f)
                 + (agent->metrics_array[OFFROAD_IDX] > 0.0f) + (agent->metrics_array[RED_LIGHT_IDX] > 0.0f);
             EXPECT_TRUE(terminal_flags <= 1);
+            if (simulation_mode == SIMULATION_GIGAFLOW) {
+                EXPECT_TRUE(!agent->removed);
+            }
         }
     }
 

--- a/tests/drive/test_drive_goals.c
+++ b/tests/drive/test_drive_goals.c
@@ -117,9 +117,39 @@ static int test_map_goals_carry_lane_and_track_slot_zero(void) {
 // Route goal source (walks the agent's own route).
 // ---------------------------------------------------------------------------
 
+static int test_route_goal_source_no_attrition(void) {
+    // Route source used to drop agents whose sampled spawn position sat on short
+    // or dead-end lanes (common on cropped nuPlan maps): route + goal generation
+    // ran only after the position was accepted, so the failure was never
+    // resampled. Spawn now rejects such positions like collisions; every
+    // requested agent must come up live with a full goal set.
+    srand(7);
+    Drive env = drive_test_make_env(drive_nuplan_map(), SIMULATION_GIGAFLOW, 32, 0);
+    EXPECT_EQ_INT(env.active_agent_count, 32);
+    for (int i = 0; i < env.active_agent_count; i++) {
+        Agent *agent = &env.agents[env.active_agent_indices[i]];
+        EXPECT_FALSE(agent->removed);
+        EXPECT_EQ_INT(agent->goal_count, env.num_goals);
+    }
+
+    // The episode-boundary respawn takes the same path; it must not shed agents
+    // either (c_reset at timestep 0 is the no-op init path, so force past it).
+    env.timestep = 1;
+    c_reset(&env);
+    EXPECT_EQ_INT(env.active_agent_count, 32);
+    for (int i = 0; i < env.active_agent_count; i++) {
+        Agent *agent = &env.agents[env.active_agent_indices[i]];
+        EXPECT_FALSE(agent->removed);
+        EXPECT_EQ_INT(agent->goal_count, env.num_goals);
+    }
+    free_allocated(&env);
+    return 0;
+}
+
 static int test_route_goals_full_set_or_removed(void) {
-    // The route path front-aligns the full num_goals set or (after a route retry) removes the
-    // agent; it must never leave a live agent with a partial set.
+    // The route path must never leave a live agent with a partial goal set:
+    // active agents either carry the full front-aligned num_goals set or were
+    // removed by the spawn/reset caller after every placement attempt failed.
     srand(5);
     Drive env = drive_test_make_env(drive_carla_map(), SIMULATION_GIGAFLOW, 32, 0);
     for (int i = 0; i < env.active_agent_count; i++) {
@@ -250,6 +280,7 @@ int main(void) {
     RUN_TEST(test_commit_goals_back_align_pads_front_with_lane_minus_one);
     RUN_TEST(test_map_goal_source_no_attrition);
     RUN_TEST(test_map_goals_carry_lane_and_track_slot_zero);
+    RUN_TEST(test_route_goal_source_no_attrition);
     RUN_TEST(test_route_goals_full_set_or_removed);
     RUN_TEST(test_route_goals_front_aligned_with_lanes);
     RUN_TEST(test_roll_goals_slides_window_and_appends);


### PR DESCRIPTION
## What

Fixes gigaflow spawn silently dropping agents whose sampled position can't fit a route + goals, and adds tests that fail on any agent attrition.

- `spawn_agent`: the state commit, route computation, and goal generation now live *inside* the position rejection loop — a position on short/dead-end lanes is rejected and resampled exactly like a colliding or offroad one. This extends the same retry principle the map goal source already uses (`generate_new_goals_from_map`'s fresh-cell retry, covered by `test_map_goal_source_no_attrition`).
- `generate_new_goals_from_route`: returns failure without invalidating/removing the agent; each caller now handles failure explicitly (resample at spawn, remove with a warning at replay init/reset, remove at mid-episode regen as before).
- Init no longer re-rolls goals for gigaflow agents (they already got goals in `spawn_agent`); the re-roll could fail and strand a `removed=1` agent inside the active set.
- `test_drive_goals`: new `test_route_goal_source_no_attrition` — on the nuPlan map, all 32 requested agents must spawn live with full goal sets, both at env creation and through the episode-boundary respawn path. Also updates the `test_route_goals_full_set_or_removed` contract comment to the new caller-owns-removal semantics.
- `test_drive_env_smoke`: asserts gigaflow spawns every requested agent and that no active agent is ever `removed` (checked after creation and at every step, which covers the mid-run episode reset).

## Why

On the nuPlan test map, 8 of 32 requested agents were silently dropped at env creation (25% batch shrinkage), one agent sat in the active set already removed with re-rolled goals, and after the first episode reset 8 of 24 active agents (33%) spent the whole episode as dead, terminal-masked observation slots. The only traces were `[GIGAFLOW ERROR]` printfs — no test failed and no metric moved. The failures are position-specific (nuPlan bins are cropped scenario-local maps whose lane graph dead-ends at the crop boundary), so resampling fixes them: with this change all 32 agents spawn and survive on the same map/seed.

## Notes

- Before the fix, both new tests fail with `active_agent_count == 24, expected 32` (verified against the unfixed header); after it, the full C suite and the Python unit tests (81 passed) are green, and the `[GIGAFLOW WARNING/ERROR]` spam in the smoke test output is gone.
- Replay mode is unaffected by the spawn change (replay agents don't go through `spawn_agent`); its total-failure paths keep the previous remove-the-agent semantics, now with explicit call-site handling and a single warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)