### PR TITLE
(WIP) Add root Makefile with one-command test entry points

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,64 @@
+# Test entry points. Run `make help` (or bare `make`) for usage.
+# Targets call .venv/bin/python directly — no venv activation needed.
+PYTHON := .venv/bin/python
+
+.DEFAULT_GOAL := help
+
+# The compiled C extension the Python tests import. It depends on the sim
+# sources, so `make test` rebuilds it only when a .c/.h file actually changed.
+EXT_SUFFIX := $(shell $(PYTHON) -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))" 2>/dev/null)
+BINDING := pufferlib/ocean/drive/binding$(EXT_SUFFIX)
+DRIVE_SOURCES := $(wildcard pufferlib/ocean/drive/*.c) $(wildcard pufferlib/ocean/drive/*.h) setup.py
+
+.PHONY: help test rebuild ensure-test-deps test-unit test-c test-smoke test-notebooks test-docker-smoke
+
+help:
+	@echo "PufferDrive test targets:"
+	@echo ""
+	@echo "  make test               Run the local suites (unit + C + smoke + notebooks),"
+	@echo "                          fail-fast. Rebuilds the C extension first if any"
+	@echo "                          .c/.h changed; installs test deps if missing."
+	@echo "  make rebuild            Force-rebuild the C extension unconditionally"
+	@echo ""
+	@echo "  make test-unit          Python unit tests (tests/unit_tests)"
+	@echo "  make test-c             C sim tests (tests/drive: dynamics, geometry, IDM, ...)"
+	@echo "  make test-smoke         Replay-HTML smoke test"
+	@echo "  make test-notebooks     Execute every checked-in notebook end-to-end"
+	@echo ""
+	@echo "  make test-docker-smoke  Full smoke suite in Docker (train/rollout/eval goldens)"
+
+$(BINDING): $(DRIVE_SOURCES)
+	$(PYTHON) setup.py build_ext --inplace --force
+
+# Local suites, fast-failing first: Python unit tests, C sim tests,
+# replay-HTML smoke test, then the notebook executions (slowest). The
+# Docker smoke suite stays opt-in — it needs a Docker daemon.
+test: test-unit test-c test-smoke test-notebooks
+
+rebuild:
+	$(PYTHON) setup.py build_ext --inplace --force
+
+# Notebook deps (the `test` extra in pyproject.toml) are installed on demand
+# so `make test` works from a bare `uv pip install -e .` checkout.
+ensure-test-deps:
+	@$(PYTHON) -c "import jupytext, nbclient, ipykernel" 2>/dev/null || uv pip install -e '.[test]'
+
+test-unit: $(BINDING)
+	$(PYTHON) -m pytest -v tests/unit_tests
+
+test-c:
+	$(MAKE) -C tests/drive test
+
+test-smoke: $(BINDING)
+	$(PYTHON) -m pytest -v tests/smoke_tests/test_validation_replay_html.py
+
+test-notebooks: $(BINDING) ensure-test-deps
+	$(PYTHON) -m pytest -v tests/notebooks
+
+test-docker-smoke:
+	@command -v docker >/dev/null || { \
+		echo "error: docker not found. This suite runs in a Linux container —"; \
+		echo "install Docker Desktop, or rely on the CI smoke job instead."; \
+		exit 1; }
+	docker build -f tests/smoke_tests/Dockerfile -t pufferdrive-smoke .
+	docker run --rm pufferdrive-smoke

--- a/README.md
+++ b/README.md
@@ -13,6 +13,31 @@ uv pip install -e .
 python setup.py build_ext --inplace --force
 ```
 
+## Tests
+
+```bash
+# Run the local suites: Python unit tests, C sim tests, replay-HTML smoke
+# test, notebook executions. Rebuilds the C extension automatically when a
+# .c/.h file changed, and installs missing test deps.
+make test
+
+# Individual suites
+make test-unit       # tests/unit_tests
+make test-c          # tests/drive (dynamics, geometry, IDM, collisions, ...)
+make test-smoke      # replay-HTML smoke test
+make test-notebooks  # execute every checked-in notebook end-to-end
+
+# Force-rebuild the C extension regardless of timestamps
+make rebuild
+
+# Opt-in: full smoke suite in Docker (train/rollout/eval goldens)
+make test-docker-smoke
+```
+
+`make help` (or bare `make`) prints this list. Targets call `.venv/bin/python`
+directly, so no venv activation is needed. If your interpreter lives elsewhere
+(conda, a cluster venv), override it: `make PYTHON=/path/to/python test`.
+
 ## Install (HPC cluster)
 
 For the NYU cluster, PufferDrive recommends a **mixed Singularity + venv** layout:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -226,6 +226,13 @@ cleanrl = [
     'tyro==0.8.6',
 ]
 
+test = [
+    'pytest',
+    'jupytext',
+    'nbclient',
+    'ipykernel',
+]
+
 [project.scripts]
 puffer = "pufferlib.pufferl:main"
 

--- a/tests/drive/Makefile
+++ b/tests/drive/Makefile
@@ -35,7 +35,11 @@ SMOKE_BINS := $(SMOKE_SRCS:%.c=$(BUILD_DIR)/%)
 RENDER_BINS := $(RENDER_SRCS:%.c=$(BUILD_DIR)/%)
 PERF_BINS := $(PERF_SRCS:%.c=$(BUILD_DIR)/%)
 
-$(BUILD_DIR)/%: %.c include/test.h include/drive_fixture.h
+# Sim headers are compiled into every test binary; without them as
+# prerequisites, editing drive.h leaves stale test binaries behind.
+DRIVE_HEADERS := $(wildcard $(ROOT)/pufferlib/ocean/drive/*.h)
+
+$(BUILD_DIR)/%: %.c include/test.h include/drive_fixture.h $(DRIVE_HEADERS)
 	mkdir -p $(BUILD_DIR)
 	$(CC) $(CFLAGS) $< $(LDLIBS_DRIVE) -o $@
 


### PR DESCRIPTION
## What

Adds a root `Makefile` so the whole local test story is one dependency-tracked command, plus usage docs:

- `make test` — Python unit tests, C sim tests, replay-HTML smoke test, and notebook executions, fail-fast in that order (slowest last). The compiled extension is a real make target depending on `pufferlib/ocean/drive/*.c`/`*.h` + `setup.py`, so it rebuilds via `build_ext` exactly when a source changed — no separate rebuild step, no unnecessary rebuilds.
- `make rebuild` — unconditional force-rebuild of the extension.
- Notebook deps are declared once as a `test` extra in `pyproject.toml` (`pytest`, `jupytext`, `nbclient`, `ipykernel`) and auto-installed by an `ensure-test-deps` step (`uv pip install -e '.[test]'`) only when the imports are missing, so `make test` works from a bare `uv pip install -e .` checkout.
- `make test-unit` / `test-c` / `test-smoke` / `test-notebooks` — individual suites; `make test-docker-smoke` stays opt-in (needs a Docker daemon).
- `make help` is the default target, so a bare `make` prints usage instead of launching the suite.
- `tests/drive/Makefile`: test binaries now list the sim headers as prerequisites — previously editing `drive.h` left stale test binaries that silently tested old code.
- README gains a "Tests" section after Install (local).

## Why

Running the tests previously required knowing three different invocations spread across CI config, plus remembering to rebuild the extension after C changes (pytest imports the compiled binding — a stale build tests old code). Dependency tracking makes that automatic in both directions: rebuild when needed, skip when not.

## Notes

- Verified: no-op `make test` goes straight to pytest; `touch drive.h` triggers `build_ext` (and C test binary recompiles); missing notebook deps are installed once, then the check is a no-op. Full `make test` run is green end-to-end (unit + C + smoke + 6 notebooks).
- Targets call `.venv/bin/python` directly, so no venv activation is needed.
- Note for Apple's bundled GNU Make 3.81: timestamp comparison is second-granular, so an edit within the same second as a build may not trigger a rebuild — irrelevant in practice for human editing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)