### PR TITLE
isolate_code: never link the in-repo save root into the snapshot

### DIFF
--- a/scripts/submit_cluster.py
+++ b/scripts/submit_cluster.py
@@ -243,9 +243,13 @@ def isolate_code(project_root: str, save_dir: str) -> str:
     # symlinks, so snapshots must live outside it.
     project_root_resolved = Path(project_root).resolve()
     save_dir_resolved = Path(save_dir).resolve()
+    save_root_entry = None
     if save_dir_resolved.is_relative_to(project_root_resolved):
         snapshots_root = project_root_resolved.parent / f"{project_root_resolved.name}_code_snapshots"
         save_dir_rel = save_dir_resolved.relative_to(project_root_resolved)
+        # The in-repo save root holds run outputs (and held snapshots before
+        # they moved out of the repo) — never link it into the snapshot.
+        save_root_entry = save_dir_rel.parts[0]
         isolated_root = str(snapshots_root / save_dir_rel / "code")
     else:
         isolated_root = os.path.join(save_dir, "code")
@@ -261,6 +265,8 @@ def isolate_code(project_root: str, save_dir: str) -> str:
         dst = os.path.join(isolated_root, entry)
         # Do not symlink ancestors to avoid infinite recursion
         if isolated_root_real.is_relative_to(Path(src).resolve()):
+            continue
+        if entry == save_root_entry:
             continue
         if os.path.exists(dst) or os.path.islink(dst):
             if os.path.isdir(dst) and not os.path.islink(dst):


### PR DESCRIPTION
## What

`isolate_code()` now explicitly skips the in-repo save root (e.g. `experiments/`) when building the snapshot's symlink farm, and the change is covered by the existing regression test.

## Why

#522 moved snapshots for in-repo save dirs outside the repo, but the symlink loop still guarded only against linking *ancestors of the snapshot*. With the snapshot relocated, the save root is no longer an ancestor, so the guard stopped firing and every snapshot regained an `experiments` symlink pointing back into the repo — exactly the shape #522's own regression test forbids. The unit suite has been red on the `3.0` tip since #522 merged (`test_save_dir_inside_project_creates_no_symlink_cycle`).

## Notes

- 81/81 unit tests pass with this fix (verified on this branch's parent in the mimolette-defaults work; the fix commit is identical).
- No behavior change for out-of-repo save dirs — `save_root_entry` stays `None` and the loop is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)