### PR TITLE
Fix distance-per-infraction aggregation using global totals

### DIFF
--- a/pufferlib/ocean/drive/binding.c
+++ b/pufferlib/ocean/drive/binding.c
@@ -1989,7 +1989,6 @@ static int my_log(PyObject *dict, Env *env, Log *log, float n) {
     assign_to_dict(dict, "avg_distance_per_infraction", avg_distance_per_infraction);
     assign_to_dict(dict, "total_distance_travelled_sum", total_distance_travelled);
     assign_to_dict(dict, "total_infraction_count", total_infractions);
-
     assign_to_dict(dict, "reward_components/collision", log->reward_collision);
     assign_to_dict(dict, "reward_components/offroad", log->reward_offroad);
     assign_to_dict(dict, "reward_components/red_light", log->reward_red_light);

--- a/pufferlib/ocean/drive/binding.c
+++ b/pufferlib/ocean/drive/binding.c
@@ -1987,6 +1987,8 @@ static int my_log(PyObject *dict, Env *env, Log *log, float n) {
     assign_to_dict(dict, "score", log->score);
     assign_to_dict(dict, "avg_speed_per_agent", log->avg_speed_per_agent);
     assign_to_dict(dict, "avg_distance_per_infraction", avg_distance_per_infraction);
+    assign_to_dict(dict, "total_distance_travelled_sum", total_distance_travelled);
+    assign_to_dict(dict, "total_infraction_count", total_infractions);
 
     assign_to_dict(dict, "reward_components/collision", log->reward_collision);
     assign_to_dict(dict, "reward_components/offroad", log->reward_offroad);

--- a/pufferlib/ocean/evaluation_utils/evaluation_utils.py
+++ b/pufferlib/ocean/evaluation_utils/evaluation_utils.py
@@ -7,6 +7,7 @@ import pandas as pd
 import yaml
 
 import pufferlib
+import pufferlib.utils
 
 
 MAX_C_SEED = 2**31 - 1
@@ -300,11 +301,13 @@ def _build_eval_report(episode_summaries, num_scenarios):
     lead_cols = [col for col in ("map_name", "scenario_id") if col in df.columns]
     df = df[lead_cols + [col for col in df.columns if col not in lead_cols]]
 
-    metric_means = df.drop(columns=["seed"], errors="ignore").select_dtypes(include=[np.number]).mean().to_dict()
+    numeric_metrics = df.drop(columns=["seed"], errors="ignore").select_dtypes(include=[np.number])
+    metric_lists = {key: numeric_metrics[key].dropna().tolist() for key in numeric_metrics}
+    metric_means = pufferlib.utils.reduce_environment_metrics(metric_lists)
     summary = {
         "num_scenarios": num_scenarios,
         "num_episodes": int(len(df)),
-        "metrics_mean": {key: float(value) for key, value in metric_means.items()},
+        "metrics_mean": metric_means,
     }
     return df, summary
 

--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -75,6 +75,8 @@ HIDDEN_DASHBOARD_METRICS = {
     "multi_lane_score",
     "multi_lane_time",
     "speed_limit_compliance",
+    "total_distance_travelled_sum",
+    "total_infraction_count",
 }
 
 
@@ -461,7 +463,7 @@ class PuffeRL:
         self.ep_indices = torch.arange(self.total_agents, device=device, dtype=torch.int32)
         self.ep_lengths.zero_()
         profile.end()
-        return self.stats
+        return pufferlib.utils.reduce_environment_metrics(self.stats)
 
     @record
     def train(self):
@@ -777,14 +779,7 @@ class PuffeRL:
 
     def mean_and_log(self):
         config = self.config
-        for k in list(self.stats.keys()):
-            v = self.stats[k]
-            try:
-                v = np.mean(v)
-            except:
-                del self.stats[k]
-
-            self.stats[k] = v
+        self.stats = pufferlib.utils.reduce_environment_metrics(self.stats)
 
         device = config["device"]
         agent_steps = int(dist_sum(self.global_step, device))

--- a/pufferlib/utils.py
+++ b/pufferlib/utils.py
@@ -6,9 +6,7 @@ import subprocess
 import numpy as np
 
 
-def reduce_environment_metrics(metric_lists, sum_keys=None):
-    sum_keys = set() if sum_keys is None else set(sum_keys)
-
+def reduce_environment_metrics(metric_lists):
     # Preserve raw sums and sample counts so log batches with different numbers
     # of completed episodes contribute with the correct weight.
     local_metrics = {}
@@ -23,7 +21,7 @@ def reduce_environment_metrics(metric_lists, sum_keys=None):
     for key, (value_sum, value_count) in local_metrics.items():
         if key in ("total_distance_travelled_sum", "total_infraction_count"):
             continue
-        reduced_metrics[key] = value_sum if key in sum_keys else value_sum / max(value_count, 1)
+        reduced_metrics[key] = value_sum / max(value_count, 1)
 
     if total_distance is not None and total_infractions is not None:
         reduced_metrics["total_distance_travelled"] = total_distance[0]

--- a/pufferlib/utils.py
+++ b/pufferlib/utils.py
@@ -1,6 +1,36 @@
 import os
+import numbers
 import shutil
 import subprocess
+
+import numpy as np
+
+
+def reduce_environment_metrics(metric_lists, sum_keys=None):
+    sum_keys = set() if sum_keys is None else set(sum_keys)
+
+    # Preserve raw sums and sample counts so log batches with different numbers
+    # of completed episodes contribute with the correct weight.
+    local_metrics = {}
+    for key, values in metric_lists.items():
+        if not values or not isinstance(values[0], numbers.Number):
+            continue
+        local_metrics[key] = (float(np.sum(values)), len(values))
+
+    reduced_metrics = {}
+    total_distance = local_metrics.get("total_distance_travelled_sum")
+    total_infractions = local_metrics.get("total_infraction_count")
+    for key, (value_sum, value_count) in local_metrics.items():
+        if key in ("total_distance_travelled_sum", "total_infraction_count"):
+            continue
+        reduced_metrics[key] = value_sum if key in sum_keys else value_sum / max(value_count, 1)
+
+    if total_distance is not None and total_infractions is not None:
+        reduced_metrics["total_distance_travelled"] = total_distance[0]
+        reduced_metrics["total_infractions"] = total_infractions[0]
+        reduced_metrics["avg_distance_per_infraction"] = total_distance[0] / max(total_infractions[0], 1.0)
+
+    return reduced_metrics
 
 
 def render_videos(config, vecenv, logger, epoch, global_step, bin_path):

--- a/tests/eval/test_eval.py
+++ b/tests/eval/test_eval.py
@@ -237,6 +237,52 @@ def test_multiprocess_eval_dispatches_all_scenarios_and_maps(carla_evaluation):
         "opendrive__Town03",
         "opendrive__Town04",
     }
+    assert {
+        "avg_distance_per_infraction",
+        "total_distance_travelled_sum",
+        "total_infraction_count",
+    }.issubset(metrics.columns)
+    expected_episode_average = metrics["total_distance_travelled_sum"] / metrics["total_infraction_count"].clip(
+        lower=1.0
+    )
+    np.testing.assert_allclose(metrics["avg_distance_per_infraction"], expected_episode_average)
+
+    metric_summary = summary["metrics_mean"]
+    expected_global_average = metrics["total_distance_travelled_sum"].sum() / max(
+        metrics["total_infraction_count"].sum(), 1.0
+    )
+    assert metric_summary["total_distance_travelled"] == pytest.approx(metrics["total_distance_travelled_sum"].sum())
+    assert metric_summary["total_infractions"] == pytest.approx(metrics["total_infraction_count"].sum())
+    assert metric_summary["avg_distance_per_infraction"] == pytest.approx(expected_global_average)
+
+
+def test_eval_report_reduces_distance_per_infraction_from_raw_totals():
+    episode_summaries = [
+        {
+            "map_name": "town01.bin",
+            "seed": 1,
+            "collision_rate": 0.0,
+            "avg_distance_per_infraction": 100.0,
+            "total_distance_travelled_sum": 100.0,
+            "total_infraction_count": 1.0,
+        },
+        {
+            "map_name": "town02.bin",
+            "seed": 2,
+            "collision_rate": 1.0,
+            "avg_distance_per_infraction": 10.0,
+            "total_distance_travelled_sum": 100.0,
+            "total_infraction_count": 10.0,
+        },
+    ]
+
+    metrics, summary = drive_benchmark._build_eval_report(episode_summaries, num_scenarios=2)
+
+    assert metrics["avg_distance_per_infraction"].tolist() == [100.0, 10.0]
+    assert summary["metrics_mean"]["collision_rate"] == 0.5
+    assert summary["metrics_mean"]["total_distance_travelled"] == 200.0
+    assert summary["metrics_mean"]["total_infractions"] == 11.0
+    assert summary["metrics_mean"]["avg_distance_per_infraction"] == pytest.approx(200.0 / 11.0)
 
 
 def test_seed_replay_writes_exactly_identical_metrics(carla_evaluation):

--- a/tests/smoke_tests/test_drive_train.py
+++ b/tests/smoke_tests/test_drive_train.py
@@ -57,6 +57,7 @@ import torch
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from pufferlib.pufferl import PuffeRL, load_config, load_env, load_policy
+from pufferlib.utils import reduce_environment_metrics
 
 SEED = 42
 EPOCHS = 2  # small: CI emulates the CPU under QEMU where torch is ~30x slower
@@ -207,11 +208,7 @@ def _capture_metrics(pufferl):
 
     losses = {k: float(v) for k, v in pufferl.losses.items() if _is_number(v)}
 
-    env_means = {}
-    for k, vals in env_acc.items():
-        nums = [x for x in vals if _is_number(x)]
-        if nums and len(nums) == len(vals):
-            env_means[k] = float(np.mean(nums))
+    env_means = reduce_environment_metrics(env_acc)
 
     return losses, env_means
 


### PR DESCRIPTION
Changes avg_distance_per_infraction from the mean of per-scenario averages to a global average computed from total distance and total infractions.
A small example of the new avg_distance computed compare to the old one : 
<img width="512" height="263" alt="image" src="https://github.com/user-attachments/assets/08d2320c-c538-4087-af07-40c08d083eca" />
