### PR TITLE
WIP quadrupling the time horizon of the fast evals so we can get better estimates

### DIFF
--- a/AGENTIC_PR
+++ b/AGENTIC_PR
@@ -1,0 +1,9 @@
+Quatre fois plus longue est la route,
+Quatre fois moins tremble la mesure ;
+Ce que l'instant nous laissait en doute,
+La durée patiemment le rassure.
+
+Roulez, voitures, sur vos huit villes,
+Deux mille pas au lieu de cinq cents :
+Les moyennes deviennent tranquilles
+Quand on leur accorde le temps.

--- a/AGENTIC_PR
+++ b/AGENTIC_PR
@@ -1,9 +1,0 @@
-Quatre fois plus longue est la route,
-Quatre fois moins tremble la mesure ;
-Ce que l'instant nous laissait en doute,
-La durée patiemment le rassure.
-
-Roulez, voitures, sur vos huit villes,
-Deux mille pas au lieu de cinq cents :
-Les moyennes deviennent tranquilles
-Quand on leur accorde le temps.

--- a/pufferlib/config/evaluation/benchmark.yaml
+++ b/pufferlib/config/evaluation/benchmark.yaml
@@ -54,7 +54,7 @@ benchmarks:
       num_maps: 8
       max_agents_per_env: 50
       max_scenarios_per_batch: null
-      scenario_length: 500
+      scenario_length: 2000
       control_mode: control_vehicles
       map_dir: pufferlib/resources/drive/binaries/carla
 


### PR DESCRIPTION
## What

`carla_fast` runs 250 scenarios at `scenario_length: 500`. This raises that to `2000` — 4x the horizon, same scenario count.

## Why

500 steps is short enough that per-scenario metrics carry substantial variance, so the fast eval is a noisy estimator of the thing we actually care about. Giving each scenario 4x the steps to average over tightens the estimate without touching scenario sampling or seeds.

2000 is still well under the full `carla` benchmark's 6000, so `carla_fast` stays meaningfully cheaper than the full pass.

## Notes

- **WIP**: the cost is a straight 4x on every `carla_fast` run. That hits training-time eval hardest, which fires every `train.evaluation_interval_epochs` (100 in the nightly recipe) — worth measuring the wall-clock impact on a nightly before this lands.
- Metrics computed over a 500-step horizon are not comparable to ones over 2000. Anything that trends `eval_carla_fast/*` across this change will show a step discontinuity that is an artifact of the horizon, not a policy change.
- No code paths change; this is a config-only edit.