### PR TITLE
added parameter to disable value bootstrapping

### DIFF
--- a/pufferlib/config/puffer_drive.yaml
+++ b/pufferlib/config/puffer_drive.yaml
@@ -229,6 +229,8 @@ train:
   max_grad_norm: 0.5
   normalize_rewards: false
   ent_coef: 0.01
+  # enable value bootstrap to simulate infinite time horizon
+  use_value_bootstrapping: true
   # ---
   adam_beta1: 0.9
   adam_beta2: 0.999

--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -444,7 +444,7 @@ class PuffeRL:
                 # Ideally we add `gamma * V(s_{t+1})` on truncation steps, but Drive resets in C so
                 # the value at index `l` is post-reset. We use `values[..., l-1]` as a heuristic
                 # proxy for the pre-reset terminal value (bootstrap term is not clipped).
-                if l > 0:
+                if l > 0 and config["use_value_bootstrapping"]:
                     trunc_mask = (t > 0) & (d == 0)
                     r = r + trunc_mask.to(r.dtype) * config["gamma"] * self.values[batch_rows, l - 1]
                 self.rewards[batch_rows, l] = r


### PR DESCRIPTION
Value bootstrapping can cause instability of the value estimates with short episodes (e.g. nuplan). We therefore add it as a config parameter with a true default. 