### PR TITLE
Add Lanelet2 Map Conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,44 @@ Place binaries under `pufferlib/resources/drive/binaries/`.
 - **nuPlan (replay training/eval):** fetched by the default above, or convert
   yourself — see [`docs/nuplan_data.md`](docs/nuplan_data.md).
 
+### Lanelet2 maps
+
+Convert Lanelet2 OSM coordinates to a PufferDrive 3.0 binary. Install the
+optional conversion and PNG-rendering dependencies first. The converter detects
+the local UTM CRS and shifts the projected map to a local metre origin.
+
+```bash
+python -m pip install -e ".[lanelet2]"
+
+python data_utils/lanelet2_to_bin.py INPUT.osm OUTPUT.bin \
+  --validation-report validation.json
+
+python data_utils/visualize_map_bin.py OUTPUT.bin \
+  --png preview.png
+```
+
+The PNG reserves a small panel at the upper right for the road-lane, road-line,
+and road-edge colors. It reports binary segments and connected groups separately
+so split Lanelet2 records are not mistaken for separate visual roads.
+
+Crop coordinates are ordered as `XMIN YMIN XMAX YMAX`. They are measured in
+metres from the automatically selected local origin. For example, this keeps a
+local 9 m by 20 m window from the included fixture:
+
+```bash
+python data_utils/lanelet2_to_bin.py tests/fixtures/lanelet2_tiny.osm \
+  /tmp/lanelet2-crop.bin \
+  --crop 0 0 9 20
+```
+
+The converter validates the emitted binary, including the 3.0 `id == index`
+requirement, and records the detected CRS and local origin in the validation
+report. Use `--link-tolerance-m` only when the source omits explicit shared
+Lanelet2 endpoints. The focused converter includes `road` and `highway` lanelets
+only; regulatory traffic controls are outside this contribution.
+Unitless `speed_limit` values follow Lanelet2 conventions and are converted
+from kilometres per hour to metres per second. Missing values use 50 km/h.
+
 ## Train
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -142,14 +142,6 @@ python data_utils/lanelet2_to_bin.py tests/fixtures/lanelet2_tiny.osm \
   --crop 0 0 9 20
 ```
 
-The converter validates the emitted binary, including the 3.0 `id == index`
-requirement, and records the detected CRS and local origin in the validation
-report. Use `--link-tolerance-m` only when the source omits explicit shared
-Lanelet2 endpoints. The focused converter includes `road` and `highway` lanelets
-only; regulatory traffic controls are outside this contribution.
-Unitless `speed_limit` values follow Lanelet2 conventions and are converted
-from kilometres per hour to metres per second. Missing values use 50 km/h.
-
 ## Train
 
 ```bash

--- a/data_utils/__init__.py
+++ b/data_utils/__init__.py
@@ -1,0 +1,4 @@
+"""PufferDrive data utilities.
+
+- Group reusable map conversion and binary tools.
+"""

--- a/data_utils/lanelet2_conversion.py
+++ b/data_utils/lanelet2_conversion.py
@@ -1,0 +1,304 @@
+"""Lanelet2 OSM conversion.
+
+- Parse supported lanelets and boundaries.
+- Build PufferDrive roads and directed lane links.
+"""
+
+from __future__ import annotations
+
+import re
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+
+if __package__:
+    from .lanelet2_geometry import (
+        arc_lengths,
+        centerline,
+        clip_polyline,
+        detect_utm_epsg,
+        headings,
+        normalise_boundaries,
+        project_epsg_array,
+    )
+else:
+    from lanelet2_geometry import (
+        arc_lengths,
+        centerline,
+        clip_polyline,
+        detect_utm_epsg,
+        headings,
+        normalise_boundaries,
+        project_epsg_array,
+    )
+
+LANE_SURFACE_STREET = 2
+ROAD_LINE_SOLID_SINGLE_WHITE = 12
+ROAD_EDGE_BOUNDARY = 21
+DRIVABLE_SUBTYPES = frozenset({"road", "highway"})
+BOUNDARY_TYPES = frozenset({"line_thin", "line_thick", "road_border", "virtual", "guard_rail", "fence", "wall"})
+EDGE_BOUNDARY_TYPES = frozenset({"road_border", "guard_rail", "fence", "wall"})
+
+
+@dataclass(frozen=True)
+class ConversionConfig:
+    """Store conversion options in metre-based units."""
+
+    crop: Optional[Tuple[float, float, float, float]] = None
+    link_tolerance_m: float = 0.0
+    virtual_as_edge: bool = False
+
+
+@dataclass(frozen=True)
+class ProjectionInfo:
+    """Record the detected CRS and local projected origin."""
+
+    epsg: int
+    origin_easting: float
+    origin_northing: float
+
+
+def _tags(element):
+    """Return an OSM element's tags as a key-value mapping."""
+
+    return {tag.get("k", ""): tag.get("v", "") for tag in element.findall("tag")}
+
+
+def _speed_limit_mps(tags):
+    """Normalize a Lanelet2 speed limit to metres per second."""
+
+    raw = tags.get("speed_limit") or tags.get("maxspeed")
+    if not raw:
+        return 50.0 * 1_000.0 / 3_600.0
+    match = re.search(r"[-+]?\d+(?:\.\d+)?", raw)
+    if match is None:
+        return 50.0 * 1_000.0 / 3_600.0
+    value = float(match.group())
+    lowered = raw.lower()
+    if "mph" in lowered:
+        return value * 1_609.344 / 3_600.0
+    if "m/s" in lowered or "mps" in lowered:
+        return value
+    return value * 1_000.0 / 3_600.0
+
+
+def _lane_record(points, speed_limit_mps):
+    """Build one drivable PufferDrive lane record."""
+
+    cumulative = arc_lengths(points)
+    return {
+        "id": -1,
+        "type": LANE_SURFACE_STREET,
+        "S": len(points),
+        "x": tuple(point[0] for point in points),
+        "y": tuple(point[1] for point in points),
+        "z": (0.0,) * len(points),
+        "headings": tuple(headings(points)),
+        "entry_lanes": [],
+        "exit_lanes": [],
+        "speed_limit": speed_limit_mps,
+        "length": cumulative[-1],
+        "cum_lengths": tuple(cumulative),
+    }
+
+
+def _line_record(points, road_type):
+    """Build one PufferDrive line or edge record."""
+
+    return {
+        "id": -1,
+        "type": road_type,
+        "S": len(points),
+        "x": tuple(point[0] for point in points),
+        "y": tuple(point[1] for point in points),
+        "z": (0.0,) * len(points),
+        "headings": tuple(headings(points)),
+    }
+
+
+def _project_nodes(root):
+    """Project all OSM nodes and shift them to a local metre origin."""
+
+    nodes = root.findall("node")
+    latitudes = [float(node.get("lat")) for node in nodes]
+    longitudes = [float(node.get("lon")) for node in nodes]
+    epsg = detect_utm_epsg(latitudes, longitudes)
+    eastings, northings = project_epsg_array(latitudes, longitudes, epsg)
+    origin_easting = min(eastings)
+    origin_northing = min(northings)
+    node_xy = {
+        int(node.get("id")): (easting - origin_easting, northing - origin_northing)
+        for node, easting, northing in zip(nodes, eastings, northings)
+    }
+    return node_xy, ProjectionInfo(epsg, origin_easting, origin_northing)
+
+
+def _way_nodes(root):
+    """Map each OSM way ID to its ordered node IDs."""
+
+    return {int(way.get("id")): [int(item.get("ref")) for item in way.findall("nd")] for way in root.findall("way")}
+
+
+def _lanelets(root, node_xy, way_nodes, config):
+    """Extract supported drivable lanelets and clipped centerlines."""
+
+    lanelets = []
+    for relation in root.findall("relation"):
+        tags = _tags(relation)
+        if tags.get("type") != "lanelet" or tags.get("subtype", "road") not in DRIVABLE_SUBTYPES:
+            continue
+        members = {
+            item.get("role"): int(item.get("ref")) for item in relation.findall("member") if item.get("type") == "way"
+        }
+        if "left" not in members or "right" not in members:
+            continue
+        boundaries = normalise_boundaries(
+            way_nodes.get(members["left"], ()),
+            way_nodes.get(members["right"], ()),
+            node_xy,
+        )
+        points = clip_polyline(centerline(boundaries, node_xy), config.crop)
+        if len(points) < 2:
+            continue
+        lanelets.append(
+            {
+                "relation_id": int(relation.get("id")),
+                "boundaries": boundaries,
+                "points": points,
+                "speed_limit_mps": _speed_limit_mps(tags),
+            }
+        )
+    return lanelets
+
+
+def _connect_shared_endpoints(lanelets, roads):
+    """Create directed links between lanelets with shared endpoints."""
+
+    relation_index = {item["relation_id"]: index for index, item in enumerate(lanelets)}
+    first_left = {}
+    first_right = {}
+    for item in lanelets:
+        left_ids, right_ids = item["boundaries"]
+        if left_ids:
+            first_left.setdefault(left_ids[0], []).append(item["relation_id"])
+        if right_ids:
+            first_right.setdefault(right_ids[0], []).append(item["relation_id"])
+    for index, item in enumerate(lanelets):
+        left_ids, right_ids = item["boundaries"]
+        successors = set(first_left.get(left_ids[-1], ())) if left_ids else set()
+        if right_ids:
+            successors.update(first_right.get(right_ids[-1], ()))
+        successors.discard(item["relation_id"])
+        roads[index]["exit_lanes"] = sorted(
+            relation_index[item_id] for item_id in successors if item_id in relation_index
+        )
+    for index, road in enumerate(roads):
+        for successor in road["exit_lanes"]:
+            roads[successor]["entry_lanes"].append(index)
+
+
+def _connect_nearby_endpoints(roads, tolerance_m):
+    """Connect otherwise unlinked lane endpoints within a distance limit."""
+
+    if tolerance_m <= 0.0:
+        return
+    tolerance_sq = tolerance_m * tolerance_m
+    for index, road in enumerate(roads):
+        if road["exit_lanes"]:
+            continue
+        end_x, end_y = road["x"][-1], road["y"][-1]
+        candidates = []
+        for successor, candidate in enumerate(roads):
+            if successor == index:
+                continue
+            distance_sq = (candidate["x"][0] - end_x) ** 2 + (candidate["y"][0] - end_y) ** 2
+            if distance_sq <= tolerance_sq:
+                candidates.append((distance_sq, successor))
+        road["exit_lanes"] = [successor for _, successor in sorted(candidates)]
+        for successor in road["exit_lanes"]:
+            if index not in roads[successor]["entry_lanes"]:
+                roads[successor]["entry_lanes"].append(index)
+
+
+def _append_boundaries(root, roads, node_xy, way_nodes, config):
+    """Append supported Lanelet2 boundaries as line or edge records."""
+
+    for way in root.findall("way"):
+        way_type = _tags(way).get("type", "")
+        if way_type not in BOUNDARY_TYPES:
+            continue
+        points = clip_polyline(
+            [node_xy[node_id] for node_id in way_nodes[int(way.get("id"))] if node_id in node_xy],
+            config.crop,
+        )
+        if len(points) < 2:
+            continue
+        is_edge = way_type in EDGE_BOUNDARY_TYPES or (way_type == "virtual" and config.virtual_as_edge)
+        roads.append(_line_record(points, ROAD_EDGE_BOUNDARY if is_edge else ROAD_LINE_SOLID_SINGLE_WHITE))
+
+
+def _map_record(roads):
+    """Wrap converted roads in the PufferDrive map schema."""
+
+    source_name = b"lanelet2"
+    return {
+        "agents": [],
+        "roads": roads,
+        "traffic": [],
+        "objects": [],
+        "lane_graph": {"n": 0, "lane_ids": (), "distances": ()},
+        "scenario_id": source_name.ljust(128, b"\0"),
+        "dataset_name": source_name.ljust(32, b"\0"),
+        "log_length": 0,
+        "log_dt": 0.0,
+        "objects_of_interest": (),
+        "tracks_to_predict": (),
+    }
+
+
+def convert_map(
+    input_path,
+    crop=None,
+    link_tolerance_m=0.0,
+    virtual_as_edge=False,
+):
+    """Convert a Lanelet2 OSM file and return map and projection data."""
+
+    config = ConversionConfig(
+        crop=tuple(crop) if crop is not None else None,
+        link_tolerance_m=link_tolerance_m,
+        virtual_as_edge=virtual_as_edge,
+    )
+    root = ET.parse(input_path).getroot()
+    node_xy, projection = _project_nodes(root)
+    way_nodes = _way_nodes(root)
+    lanelets = _lanelets(root, node_xy, way_nodes, config)
+    if not lanelets:
+        raise ValueError("no drivable Lanelet2 relations were found in the selected area")
+    roads = [_lane_record(item["points"], item["speed_limit_mps"]) for item in lanelets]
+    _connect_shared_endpoints(lanelets, roads)
+    _connect_nearby_endpoints(roads, config.link_tolerance_m)
+    _append_boundaries(root, roads, node_xy, way_nodes, config)
+    for index, road in enumerate(roads):
+        road["id"] = index
+        if road["type"] == LANE_SURFACE_STREET:
+            road["entry_lanes"] = sorted(set(road["entry_lanes"]))
+    return _map_record(roads), projection
+
+
+def build_map(
+    input_path,
+    crop=None,
+    link_tolerance_m=0.0,
+    virtual_as_edge=False,
+):
+    """Convert a Lanelet2 OSM file and return only the map data."""
+
+    map_data, _ = convert_map(
+        input_path,
+        crop=crop,
+        link_tolerance_m=link_tolerance_m,
+        virtual_as_edge=virtual_as_edge,
+    )
+    return map_data

--- a/data_utils/lanelet2_geometry.py
+++ b/data_utils/lanelet2_geometry.py
@@ -1,0 +1,152 @@
+"""Lanelet2 projection and geometry.
+
+- Detect and apply a local UTM projection.
+- Build, resample, orient, and crop road geometry.
+"""
+
+from __future__ import annotations
+
+import math
+from functools import lru_cache
+
+
+WGS84_EPSG = 4326
+GEOMETRY_EPSILON_M = 1e-9
+INTERPOLATION_EPSILON_M = 1e-12
+
+
+def detect_utm_epsg(latitudes, longitudes):
+    """Detect the WGS 84 UTM CRS covering the map center."""
+
+    if len(latitudes) == 0 or len(longitudes) == 0 or len(latitudes) != len(longitudes):
+        raise ValueError("at least one latitude/longitude pair is required")
+    try:
+        from pyproj.aoi import AreaOfInterest
+        from pyproj.database import query_utm_crs_info
+    except ImportError as exc:
+        raise RuntimeError("Lanelet2 conversion requires pyproj>=3.0") from exc
+    latitude = (min(latitudes) + max(latitudes)) * 0.5
+    longitude = (min(longitudes) + max(longitudes)) * 0.5
+    matches = query_utm_crs_info(
+        datum_name="WGS 84",
+        area_of_interest=AreaOfInterest(longitude, latitude, longitude, latitude),
+        contains=True,
+    )
+    if not matches:
+        raise ValueError("no WGS 84 UTM CRS covers the Lanelet2 map centre")
+    return int(matches[0].code)
+
+
+@lru_cache(maxsize=None)
+def _epsg_transformer(epsg):
+    """Create and cache a WGS 84 to projected CRS transformer."""
+
+    try:
+        from pyproj import CRS, Transformer
+    except ImportError as exc:
+        raise RuntimeError("Lanelet2 conversion requires pyproj>=3.0") from exc
+    return Transformer.from_crs(CRS.from_epsg(WGS84_EPSG), CRS.from_epsg(epsg), always_xy=True)
+
+
+def project_epsg_array(latitudes, longitudes, epsg):
+    """Project latitude and longitude arrays to metre coordinates."""
+
+    eastings, northings = _epsg_transformer(epsg).transform(longitudes, latitudes)
+    return [float(value) for value in eastings], [float(value) for value in northings]
+
+
+def arc_lengths(points):
+    """Return cumulative distances along a polyline."""
+
+    cumulative = [0.0]
+    for start, end in zip(points, points[1:]):
+        cumulative.append(cumulative[-1] + math.dist(start, end))
+    return cumulative
+
+
+def resample(points, count):
+    """Resample a polyline to an evenly spaced point count."""
+
+    if len(points) == count:
+        return list(points)
+    if len(points) < 2:
+        return list(points) * count
+    cumulative = arc_lengths(points)
+    if cumulative[-1] <= GEOMETRY_EPSILON_M:
+        return [points[0]] * count
+    result = []
+    segment = 0
+    for index in range(count):
+        target = cumulative[-1] * index / (count - 1)
+        while segment + 1 < len(cumulative) - 1 and cumulative[segment + 1] < target:
+            segment += 1
+        span = cumulative[segment + 1] - cumulative[segment]
+        fraction = (target - cumulative[segment]) / span if span > INTERPOLATION_EPSILON_M else 0.0
+        start, end = points[segment], points[segment + 1]
+        result.append((start[0] + fraction * (end[0] - start[0]), start[1] + fraction * (end[1] - start[1])))
+    return result
+
+
+def normalise_boundaries(left_ids, right_ids, node_xy):
+    """Orient lane boundaries consistently with lane travel direction."""
+
+    left_ids = list(left_ids)
+    right_ids = list(right_ids)
+    left = [node_xy[node_id] for node_id in left_ids if node_id in node_xy]
+    right = [node_xy[node_id] for node_id in right_ids if node_id in node_xy]
+    if len(left) < 2 or len(right) < 2:
+        return left_ids, right_ids
+    left_vector = (left[-1][0] - left[0][0], left[-1][1] - left[0][1])
+    right_vector = (right[-1][0] - right[0][0], right[-1][1] - right[0][1])
+    if left_vector[0] * right_vector[0] + left_vector[1] * right_vector[1] < 0.0:
+        left_ids.reverse()
+        left.reverse()
+    side = (left[0][0] - right[0][0], left[0][1] - right[0][1])
+    if right_vector[0] * side[1] - right_vector[1] * side[0] < 0.0:
+        left_ids.reverse()
+        right_ids.reverse()
+    return left_ids, right_ids
+
+
+def centerline(boundaries, node_xy):
+    """Build a centerline midway between normalized lane boundaries."""
+
+    left_ids, right_ids = boundaries
+    left = [node_xy[node_id] for node_id in left_ids if node_id in node_xy]
+    right = [node_xy[node_id] for node_id in right_ids if node_id in node_xy]
+    if not left or not right:
+        return left or right
+    count = max(len(left), len(right))
+    left = resample(left, count)
+    right = resample(right, count)
+    return [((a[0] + b[0]) * 0.5, (a[1] + b[1]) * 0.5) for a, b in zip(left, right)]
+
+
+def headings(points):
+    """Calculate the heading at each polyline point in radians."""
+
+    if len(points) == 1:
+        return [0.0]
+    values = [math.atan2(end[1] - start[1], end[0] - start[0]) for start, end in zip(points, points[1:])]
+    return values + [values[-1]]
+
+
+def clip_polyline(points, crop):
+    """Clip a polyline and keep its longest valid fragment."""
+
+    if crop is None:
+        return list(points)
+    try:
+        from shapely.geometry import LineString, box
+    except ImportError as exc:
+        raise RuntimeError("Lanelet2 conversion requires shapely>=2.0") from exc
+    geometry = LineString(points).intersection(box(*crop))
+    fragments = [geometry] if geometry.geom_type == "LineString" else list(getattr(geometry, "geoms", ()))
+    fragments = [
+        fragment
+        for fragment in fragments
+        if fragment.geom_type == "LineString" and fragment.length > GEOMETRY_EPSILON_M
+    ]
+    if not fragments:
+        return []
+    return [(float(x), float(y)) for x, y in max(fragments, key=lambda fragment: fragment.length).coords]

--- a/data_utils/lanelet2_to_bin.py
+++ b/data_utils/lanelet2_to_bin.py
@@ -1,0 +1,78 @@
+"""Lanelet2-to-binary command line tool.
+
+- Convert and validate a Lanelet2 OSM map.
+- Write a PufferDrive 3.0 binary and optional JSON report.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+if __package__:
+    from .lanelet2_conversion import convert_map
+    from .lanelet2_validation import validate_bin
+    from .mirror_map_bin import write_bin
+else:
+    from lanelet2_conversion import convert_map
+    from lanelet2_validation import validate_bin
+    from mirror_map_bin import write_bin
+
+
+def parse_args():
+    """Parse conversion paths and optional map-processing settings."""
+
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("input", type=Path)
+    parser.add_argument("output", type=Path)
+    parser.add_argument(
+        "--crop",
+        type=float,
+        nargs=4,
+        metavar=("XMIN", "YMIN", "XMAX", "YMAX"),
+        help="clip output to this local-metre window",
+    )
+    parser.add_argument("--link-tolerance-m", type=float, default=0.0)
+    parser.add_argument("--virtual-as-edge", action="store_true")
+    parser.add_argument("--validation-report", type=Path)
+    return parser.parse_args()
+
+
+def _validate_args(args):
+    """Reject invalid crop and link-tolerance values."""
+
+    if args.crop is not None and (args.crop[0] >= args.crop[2] or args.crop[1] >= args.crop[3]):
+        raise ValueError("crop must satisfy XMIN < XMAX and YMIN < YMAX")
+    if args.link_tolerance_m < 0.0:
+        raise ValueError("link tolerance must be non-negative")
+
+
+def main():
+    """Run conversion, binary validation, and report output."""
+
+    args = parse_args()
+    _validate_args(args)
+    map_data, projection = convert_map(
+        args.input,
+        crop=args.crop,
+        link_tolerance_m=args.link_tolerance_m,
+        virtual_as_edge=args.virtual_as_edge,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    write_bin(map_data, args.output)
+    report = validate_bin(args.output)
+    report["projection"] = {
+        "crs": f"EPSG:{projection.epsg}",
+        "origin_easting": projection.origin_easting,
+        "origin_northing": projection.origin_northing,
+    }
+    if args.validation_report is not None:
+        args.validation_report.parent.mkdir(parents=True, exist_ok=True)
+        args.validation_report.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(report, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/data_utils/lanelet2_validation.py
+++ b/data_utils/lanelet2_validation.py
@@ -1,0 +1,50 @@
+"""Lanelet2 binary validation.
+
+- Check geometry, IDs, and directed lane references.
+- Return a concise conversion summary.
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+
+if __package__:
+    from .lanelet2_conversion import LANE_SURFACE_STREET
+    from .mirror_map_bin import read_bin
+else:
+    from lanelet2_conversion import LANE_SURFACE_STREET
+    from mirror_map_bin import read_bin
+
+GEOMETRY_FIELDS = ("x", "y", "z", "headings")
+
+
+def validate_bin(path):
+    """Validate one generated binary and return its map statistics."""
+
+    data = read_bin(path)
+    roads = data["roads"]
+    lane_count = sum(road["type"] == LANE_SURFACE_STREET for road in roads)
+    if lane_count == 0:
+        raise ValueError("binary contains no drivable lanes")
+    for index, road in enumerate(roads):
+        if road["id"] != index:
+            raise ValueError(f"road id {road['id']} does not match index {index}")
+        if road["S"] < 2:
+            raise ValueError(f"road {index} has fewer than two geometry points")
+        if not all(math.isfinite(value) for key in GEOMETRY_FIELDS for value in road[key]):
+            raise ValueError(f"road {index} contains a non-finite value")
+        if road["type"] != LANE_SURFACE_STREET:
+            continue
+        for lane_id in road["entry_lanes"] + road["exit_lanes"]:
+            if not 0 <= lane_id < lane_count:
+                raise ValueError(f"lane {index} references non-lane road {lane_id}")
+    return {
+        "path": str(path),
+        "bytes": Path(path).stat().st_size,
+        "roads": len(roads),
+        "lanes": lane_count,
+        "directed_links": sum(len(road.get("exit_lanes", ())) for road in roads),
+        "id_equals_index": True,
+    }

--- a/data_utils/visualize_map_bin.py
+++ b/data_utils/visualize_map_bin.py
@@ -1,0 +1,176 @@
+"""PufferDrive binary map preview.
+
+- Render lanes, road lines, and road edges to PNG.
+- Show segment and connected-group counts beside the map.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+
+if __package__:
+    from .mirror_map_bin import read_bin
+else:
+    from mirror_map_bin import read_bin
+
+
+DEFAULT_WIDTH_PX = 900
+DEFAULT_HEIGHT_PX = 900
+ROAD_LINE_COLOR = "#a9b1b8"
+ROAD_LANE_COLOR = "#2f78a8"
+ROAD_EDGE_COLOR = "#20262d"
+LEGEND_PANEL_FRACTION = 0.30
+ELEMENT_LABELS = ("Road lane", "Road line", "Road edge")
+ELEMENT_STYLES = {
+    "Road lane": (ROAD_LANE_COLOR, 1.2, 0.85),
+    "Road line": (ROAD_LINE_COLOR, 0.65, 0.65),
+    "Road edge": (ROAD_EDGE_COLOR, 1.0, 0.9),
+}
+
+
+def _road_style(road_type):
+    """Map a PufferDrive road type to its preview style."""
+
+    if road_type <= 9:
+        label = "Road lane"
+    elif road_type <= 19:
+        label = "Road line"
+    else:
+        label = "Road edge"
+    return label, *ELEMENT_STYLES[label]
+
+
+def _connected_group_count(roads):
+    """Count road groups joined by identical endpoint coordinates."""
+
+    if not roads:
+        return 0
+    parents = list(range(len(roads)))
+
+    def find(index):
+        """Return the canonical index for one connected component."""
+
+        while parents[index] != index:
+            parents[index] = parents[parents[index]]
+            index = parents[index]
+        return index
+
+    endpoints = {}
+    for index, road in enumerate(roads):
+        if not road["x"] or not road["y"]:
+            continue
+        for point in ((road["x"][0], road["y"][0]), (road["x"][-1], road["y"][-1])):
+            other = endpoints.setdefault(point, index)
+            first = find(index)
+            second = find(other)
+            if first != second:
+                parents[first] = second
+    return len({find(index) for index in range(len(roads))})
+
+
+def _element_summary(roads):
+    """Summarize segment and group counts by map-element type."""
+
+    grouped = {label: [] for label in ELEMENT_LABELS}
+    for road in roads:
+        label, _, _, _ = _road_style(road["type"])
+        grouped[label].append(road)
+    return {
+        label: {"segments": len(grouped[label]), "groups": _connected_group_count(grouped[label])}
+        for label in ELEMENT_LABELS
+    }
+
+
+def render_frame(path, width_px=DEFAULT_WIDTH_PX, height_px=DEFAULT_HEIGHT_PX):
+    """Render one binary map as an RGB image array."""
+
+    import matplotlib.pyplot as plt
+    from matplotlib.lines import Line2D
+
+    data = read_bin(path)
+    roads = data["roads"]
+    if not roads:
+        raise ValueError("binary contains no roads")
+    figure = plt.figure(figsize=(width_px / 100, height_px / 100), dpi=100)
+    axes = figure.add_axes((0.02, 0.02, 1.0 - LEGEND_PANEL_FRACTION - 0.04, 0.96))
+    for road in roads:
+        _, color, width, alpha = _road_style(road["type"])
+        axes.plot(road["x"], road["y"], color=color, linewidth=width, alpha=alpha)
+    axes.set_aspect("equal", adjustable="box")
+    axes.margins(0.02)
+    axes.axis("off")
+    summary = _element_summary(roads)
+    handles = []
+    labels = []
+    for label in ELEMENT_LABELS:
+        color, width, alpha = ELEMENT_STYLES[label]
+        handles.append(Line2D((0,), (0,), color=color, linewidth=max(width, 1.5), alpha=alpha))
+        counts = summary[label]
+        group_word = "group" if counts["groups"] == 1 else "groups"
+        labels.append(f"{label}: {counts['segments']} seg. ({counts['groups']} {group_word})")
+    figure.legend(
+        handles,
+        labels,
+        title="Map elements",
+        loc="upper right",
+        bbox_to_anchor=(0.985, 0.985),
+        frameon=False,
+        fontsize=8,
+        title_fontsize=8,
+        handlelength=1.5,
+        handletextpad=0.6,
+    )
+    figure.canvas.draw()
+    frame = np.asarray(figure.canvas.buffer_rgba(), dtype=np.uint8)[..., :3].copy()
+    plt.close(figure)
+    return frame
+
+
+def write_png(input_path, output_path, width_px=DEFAULT_WIDTH_PX, height_px=DEFAULT_HEIGHT_PX):
+    """Render a binary map and write the resulting PNG file."""
+
+    if width_px <= 0 or height_px <= 0:
+        raise ValueError("width and height must be positive")
+    frame = render_frame(input_path, width_px=width_px, height_px=height_px)
+    import imageio.v3 as imageio_v3
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    imageio_v3.imwrite(output_path, frame)
+    return {
+        "input": str(input_path),
+        "output": str(output_path),
+        "width": int(frame.shape[1]),
+        "height": int(frame.shape[0]),
+    }
+
+
+def parse_args():
+    """Parse input, output, and image-size arguments."""
+
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("input", type=Path)
+    parser.add_argument("--png", type=Path, required=True)
+    parser.add_argument("--width", type=int, default=DEFAULT_WIDTH_PX)
+    parser.add_argument("--height", type=int, default=DEFAULT_HEIGHT_PX)
+    return parser.parse_args()
+
+
+def main():
+    """Run PNG rendering and print the generated image size."""
+
+    args = parse_args()
+    result = write_png(
+        args.input,
+        args.png,
+        width_px=args.width,
+        height_px=args.height,
+    )
+    print(f"rendered {result['width']}x{result['height']} PNG from {result['input']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,13 @@ kinetix = [
     'kinetix-env',
 ]
 
+lanelet2 = [
+    'pyproj>=3.0',
+    'shapely>=2.0',
+    'matplotlib>=3.7',
+    'imageio>=2.31',
+]
+
 magent = [
     'gym==0.23',
     'gymnasium==0.29.1',

--- a/tests/fixtures/lanelet2_tiny.osm
+++ b/tests/fixtures/lanelet2_tiny.osm
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6">
+  <node id="1" lat="9.046566245" lon="140.999985406"/>
+  <node id="2" lat="9.046558682" lon="141.000014594"/>
+  <node id="3" lat="9.046713127" lon="141.000024450"/>
+  <node id="4" lat="9.046705134" lon="141.000054622"/>
+  <node id="5" lat="9.046785721" lon="141.000043739"/>
+  <node id="6" lat="9.046777550" lon="141.000074417"/>
+  <way id="101">
+    <nd ref="1"/><nd ref="3"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="102">
+    <nd ref="2"/><nd ref="4"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="103">
+    <nd ref="3"/><nd ref="5"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="104">
+    <nd ref="4"/><nd ref="6"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <relation id="201">
+    <member type="way" ref="101" role="left"/>
+    <member type="way" ref="102" role="right"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="40 km/h"/>
+  </relation>
+  <relation id="202">
+    <member type="way" ref="103" role="left"/>
+    <member type="way" ref="104" role="right"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="40 km/h"/>
+  </relation>
+</osm>

--- a/tests/unit_tests/test_lanelet2_tools.py
+++ b/tests/unit_tests/test_lanelet2_tools.py
@@ -1,0 +1,257 @@
+"""Lanelet2 conversion and preview tests.
+
+- Verify projection, geometry, connectivity, crop, and validation.
+- Exercise the documented conversion and PNG commands end to end.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from data_utils.lanelet2_conversion import (
+    ROAD_EDGE_BOUNDARY,
+    ROAD_LINE_SOLID_SINGLE_WHITE,
+    _connect_nearby_endpoints,
+    _speed_limit_mps,
+    build_map,
+    convert_map,
+)
+from data_utils.lanelet2_geometry import clip_polyline, detect_utm_epsg, project_epsg_array
+from data_utils.lanelet2_validation import validate_bin
+from data_utils.mirror_map_bin import read_bin, write_bin
+
+
+FIXTURE = Path(__file__).resolve().parents[1] / "fixtures" / "lanelet2_tiny.osm"
+
+
+def test_projection_is_detected_from_map_coordinates():
+    """Detect the expected UTM zone and projected Tokyo coordinate."""
+
+    epsg = detect_utm_epsg([35.6], [139.7])
+    eastings, northings = project_epsg_array([35.6], [139.7], epsg)
+
+    assert epsg == 32654
+    assert eastings[0] == pytest.approx(382241.991, abs=0.02)
+    assert northings[0] == pytest.approx(3940361.836, abs=0.02)
+
+
+def test_projection_detects_southern_hemisphere():
+    """Select a southern-hemisphere UTM CRS when required."""
+
+    assert detect_utm_epsg([-33.9], [151.2]) == 32756
+
+
+def test_projection_rejects_missing_coordinates():
+    """Reject projection requests without coordinate pairs."""
+
+    with pytest.raises(ValueError, match="latitude/longitude"):
+        detect_utm_epsg([], [])
+
+
+def test_conversion_uses_an_automatic_local_origin():
+    """Shift converted geometry to an automatically selected origin."""
+
+    map_data, projection = convert_map(FIXTURE)
+    xs = [x for road in map_data["roads"] for x in road["x"]]
+    ys = [y for road in map_data["roads"] for y in road["y"]]
+
+    assert projection.epsg == 32654
+    assert min(xs) == pytest.approx(0.0, abs=1e-6)
+    assert min(ys) == pytest.approx(0.0, abs=1e-6)
+
+
+@pytest.mark.parametrize(
+    "raw, expected_mps",
+    [("36", 10.0), ("36 km/h", 10.0), ("10 m/s", 10.0), ("22.3694 mph", 10.0)],
+)
+def test_speed_limit_units_are_normalized(raw, expected_mps):
+    """Normalize supported speed-limit units to metres per second."""
+
+    assert _speed_limit_mps({"speed_limit": raw}) == pytest.approx(expected_mps, abs=1e-4)
+
+
+def test_missing_speed_limit_uses_standard_road_default():
+    """Use 50 km/h when a lane has no speed-limit tag."""
+
+    assert _speed_limit_mps({}) == pytest.approx(50.0 / 3.6)
+
+
+def test_conversion_reindexes_roads_and_links_lanelets(tmp_path):
+    """Reindex emitted roads and preserve directed lane connectivity."""
+
+    map_data = build_map(FIXTURE)
+    output = tmp_path / "map.bin"
+    write_bin(map_data, output)
+
+    decoded = read_bin(output)
+    lanes = [road for road in decoded["roads"] if road["type"] == 2]
+
+    assert [road["id"] for road in decoded["roads"]] == list(range(len(decoded["roads"])))
+    assert len(lanes) == 2
+    assert lanes[0]["exit_lanes"] == (1,)
+    assert lanes[1]["entry_lanes"] == (0,)
+    assert lanes[1]["exit_lanes"] == ()
+    assert lanes[0]["speed_limit"] == pytest.approx(40.0 / 3.6)
+    assert validate_bin(output)["id_equals_index"] is True
+
+
+def test_centerline_is_between_boundaries_and_has_finite_headings():
+    """Create a forward centerline with finite headings."""
+
+    map_data = build_map(FIXTURE)
+    first_lane = map_data["roads"][0]
+
+    assert first_lane["y"][-1] > first_lane["y"][0]
+    assert all(math.isfinite(value) for value in first_lane["headings"])
+
+
+def test_fixture_is_a_short_straight_connected_segment():
+    """Keep the public fixture small, straight, and connected."""
+
+    roads = build_map(FIXTURE)["roads"]
+    xs = [value for road in roads for value in road["x"]]
+    ys = [value for road in roads for value in road["y"]]
+    lanes = [road for road in roads if road["type"] == 2]
+
+    assert max(xs) - min(xs) < 10.0
+    assert max(ys) - min(ys) < 26.0
+    assert sum(lane["length"] for lane in lanes) == pytest.approx(25.09, abs=0.05)
+    assert max(abs(heading - math.radians(75)) for lane in lanes for heading in lane["headings"]) < 0.01
+
+
+def test_virtual_boundaries_can_be_rendered_as_road_edges(tmp_path):
+    """Allow virtual boundaries to be emitted as road edges."""
+
+    virtual_fixture = tmp_path / "virtual.osm"
+    virtual_fixture.write_text(
+        FIXTURE.read_text().replace('v="line_thin"', 'v="virtual"', 1),
+        encoding="utf-8",
+    )
+    default_map = build_map(virtual_fixture)
+    edge_map = build_map(virtual_fixture, virtual_as_edge=True)
+    changed = [
+        (default["type"], edge["type"])
+        for default, edge in zip(default_map["roads"], edge_map["roads"])
+        if default["type"] != edge["type"]
+    ]
+
+    assert changed == [(ROAD_LINE_SOLID_SINGLE_WHITE, ROAD_EDGE_BOUNDARY)]
+
+
+def test_link_tolerance_connects_nearby_lane_endpoints():
+    """Connect close endpoints when a positive tolerance is configured."""
+
+    roads = [
+        {"x": (0.0, 1.0), "y": (0.0, 0.0), "entry_lanes": [], "exit_lanes": []},
+        {"x": (1.05, 2.0), "y": (0.0, 0.0), "entry_lanes": [], "exit_lanes": []},
+    ]
+
+    _connect_nearby_endpoints(roads, tolerance_m=0.1)
+
+    assert roads[0]["exit_lanes"] == [1]
+    assert roads[1]["entry_lanes"] == [0]
+
+
+def test_crop_rejects_an_empty_selection():
+    """Reject crop windows containing no drivable lanelet."""
+
+    with pytest.raises(ValueError, match="no drivable Lanelet2"):
+        build_map(FIXTURE, crop=(100.0, 100.0, 101.0, 101.0))
+
+
+def test_crop_clips_geometry_at_the_requested_bounds():
+    """Clip polyline geometry exactly at the crop boundaries."""
+
+    points = [(-2.0, 0.5), (0.5, 0.5), (2.0, 0.5)]
+
+    clipped = clip_polyline(points, (0.0, 0.0, 1.0, 1.0))
+
+    assert clipped == [(0.0, 0.5), (0.5, 0.5), (1.0, 0.5)]
+
+
+def test_validator_rejects_lane_links_outside_the_lane_table(tmp_path):
+    """Reject directed links that reference a non-lane record."""
+
+    map_data = build_map(FIXTURE)
+    map_data["roads"][0]["exit_lanes"] = [999]
+    output = tmp_path / "invalid-link.bin"
+    write_bin(map_data, output)
+
+    with pytest.raises(ValueError, match="references non-lane road"):
+        validate_bin(output)
+
+
+def test_renderer_writes_png_from_the_binary(tmp_path):
+    """Render a PNG and report expected element counts."""
+
+    pytest.importorskip("matplotlib")
+    pytest.importorskip("imageio")
+    from data_utils.visualize_map_bin import _element_summary, write_png
+
+    binary = tmp_path / "map.bin"
+    png = tmp_path / "map.png"
+    write_bin(build_map(FIXTURE), binary)
+
+    result = write_png(binary, png, width_px=320, height_px=240)
+
+    assert result["width"] == 320
+    assert result["height"] == 240
+    assert _element_summary(read_bin(binary)["roads"]) == {
+        "Road lane": {"segments": 2, "groups": 1},
+        "Road line": {"segments": 4, "groups": 2},
+        "Road edge": {"segments": 0, "groups": 0},
+    }
+    assert png.stat().st_size > 1_000
+
+
+def test_documented_cli_converts_and_renders_the_fixture(tmp_path):
+    """Run the documented crop, validation, and preview workflow."""
+
+    pytest.importorskip("matplotlib")
+    pytest.importorskip("imageio")
+    converter = REPO_ROOT / "data_utils" / "lanelet2_to_bin.py"
+    visualizer = REPO_ROOT / "data_utils" / "visualize_map_bin.py"
+    binary = tmp_path / "map.bin"
+    report = tmp_path / "validation.json"
+    png = tmp_path / "map.png"
+
+    subprocess.run(
+        [
+            sys.executable,
+            str(converter),
+            str(FIXTURE),
+            str(binary),
+            "--crop",
+            "0",
+            "0",
+            "9",
+            "20",
+            "--validation-report",
+            str(report),
+        ],
+        check=True,
+    )
+    subprocess.run(
+        [sys.executable, str(visualizer), str(binary), "--png", str(png), "--width", "320", "--height", "240"],
+        check=True,
+    )
+
+    validation = validate_bin(binary)
+    assert validation["id_equals_index"] is True
+    assert validation["lanes"] == 2
+    decoded = read_bin(binary)
+    assert all(0.0 <= x <= 9.0 for road in decoded["roads"] for x in road["x"])
+    assert all(0.0 <= y <= 20.0 for road in decoded["roads"] for y in road["y"])
+    report_data = json.loads(report.read_text())
+    assert report_data["projection"]["crs"] == "EPSG:32654"
+    assert png.stat().st_size > 1_000


### PR DESCRIPTION
Hello, I'm Joonho Lee, an engineer at SCIEN, a TIER IV partner company.
Thank you for reviewing this contribution.

## What

- Add an optional Lanelet2 OSM to PufferDrive 3.0 binary converter.
- Add binary validation and a PNG map preview command.
- Add a small straight-road fixture and focused tests.

## Why

Lanelet2 maps need projection, topology conversion, and binary validation before
they can be loaded by PufferDrive. This adds a reproducible command-line path for
that workflow.

## Notes

- The converter detects the local UTM projection and metre origin.
- Lanelet2 `road` and `highway` relations become drivable lanes.
- Shared boundary endpoints create directed lane links.
- Crop coordinates use metres from the detected local origin.
- Emitted road IDs are validated against their binary indices.
- The source Lanelet2 map is not included because it may contain
  security-sensitive or copyrighted data.

## Testing

- `python -m pytest -q tests/unit_tests/test_lanelet2_tools.py` — 19 passed
- `python -m compileall -q data_utils/lanelet2_*.py data_utils/visualize_map_bin.py` — passed
- Standard and cropped conversion, validation, and PNG rendering — passed
- PufferDrive `Drive` load, reset, and one step — passed with finite rewards

## Usage

```bash
python -m pip install -e ".[lanelet2]"

python data_utils/lanelet2_to_bin.py INPUT.osm OUTPUT.bin \
  --validation-report validation.json

python data_utils/visualize_map_bin.py OUTPUT.bin \
  --png preview.png
```

Optional crop:

```bash
python data_utils/lanelet2_to_bin.py INPUT.osm OUTPUT.bin \
  --crop XMIN YMIN XMAX YMAX
```
