### PR TITLE
Add rollout_dtype configuration for observation data type handling

### DIFF
--- a/pufferlib/config/puffer_drive.yaml
+++ b/pufferlib/config/puffer_drive.yaml
@@ -226,6 +226,7 @@ train:
   anneal_lr: true
   amp: true
   precision: bfloat16
+  rollout_dtype: float32
   total_timesteps: 500000000000
   learning_rate: 0.0005
   gamma: 0.999

--- a/pufferlib/config/puffer_drive.yaml
+++ b/pufferlib/config/puffer_drive.yaml
@@ -224,7 +224,6 @@ train:
   device: cuda
   optimizer: adamw
   anneal_lr: true
-  amp: true
   precision: bfloat16
   rollout_dtype: float32
   total_timesteps: 500000000000

--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -170,8 +170,6 @@ class PuffeRL:
         use_cuda = is_cuda_device(device)
         if precision == "bfloat16" and use_cuda and not torch.cuda.is_bf16_supported():
             raise pufferlib.APIUsageError("bfloat16 precision requires a CUDA device with bf16 support")
-        if precision == "bfloat16" and not config.get("amp", True):
-            raise pufferlib.APIUsageError("bfloat16 precision requires train.amp=True")
 
         rollout_dtype = config.get("rollout_dtype", "float32")
         if rollout_dtype == "float32":
@@ -308,7 +306,7 @@ class PuffeRL:
 
         # Automatic mixed precision
         self.amp_context = contextlib.nullcontext()
-        if config.get("amp", True) and use_cuda and precision == "bfloat16":
+        if use_cuda and precision == "bfloat16":
             self.amp_context = torch.amp.autocast(device_type="cuda", dtype=getattr(torch, precision))
 
         # Initializations
@@ -2103,7 +2101,7 @@ def _run_eval_rollout(
         env_continuous = isinstance(vecenv.single_action_space, pufferlib.spaces.Box)
         discrete_policy_on_continuous_env = env_continuous and not uncompiled_policy.is_continuous
         device = torch_device(args["train"]["device"])
-        use_bfloat16 = args["train"]["amp"] and args["train"]["precision"] == "bfloat16" and is_cuda_device(device)
+        use_bfloat16 = args["train"]["precision"] == "bfloat16" and is_cuda_device(device)
         if use_bfloat16 and not torch.cuda.is_bf16_supported():
             raise pufferlib.APIUsageError("bfloat16 evaluation requires CUDA BF16 support")
         eval_amp_context = torch.amp.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=use_bfloat16)

--- a/pufferlib/pufferl.py
+++ b/pufferlib/pufferl.py
@@ -173,14 +173,23 @@ class PuffeRL:
         if precision == "bfloat16" and not config.get("amp", True):
             raise pufferlib.APIUsageError("bfloat16 precision requires train.amp=True")
 
-        obs_dtype = pufferlib.pytorch.numpy_to_torch_dtype_dict[obs_space.dtype]
+        rollout_dtype = config.get("rollout_dtype", "float32")
+        if rollout_dtype == "float32":
+            obs_dtype = pufferlib.pytorch.numpy_to_torch_dtype_dict[obs_space.dtype]
+        elif rollout_dtype == "float16" and np.issubdtype(obs_space.dtype, np.floating):
+            obs_dtype = getattr(torch, rollout_dtype)
+        else:
+            raise pufferlib.APIUsageError(
+                f"Invalid rollout_dtype {rollout_dtype} for observation dtype {obs_space.dtype}"
+            )
+        self.compress_observations = rollout_dtype != "float32"
 
         self.observations = torch.zeros(
             segments,
             horizon,
             *obs_space.shape,
             dtype=obs_dtype,
-            pin_memory=device == "cuda" and config["cpu_offload"],
+            pin_memory=use_cuda and config["cpu_offload"],
             device="cpu" if config["cpu_offload"] else device,
         )
         self.actions = torch.zeros(
@@ -193,13 +202,12 @@ class PuffeRL:
         self.values = torch.zeros(segments, horizon, device=device)
         self.logprobs = torch.zeros(segments, horizon, device=device)
         self.rewards = torch.zeros(segments, horizon, device=device)
-        self.terminals = torch.zeros(segments, horizon, device=device)
-        self.truncations = torch.zeros(segments, horizon, device=device)
-        self.ratio = torch.ones(segments, horizon, device=device)
-        self.importance = torch.ones(segments, horizon, device=device)
+        self.terminals = torch.zeros(segments, horizon, device=device, dtype=torch.bool)
+        if config["use_rnn"]:
+            self.ratio = torch.ones(segments, horizon, device=device)
         self.masks = torch.zeros(segments, horizon, device=device, dtype=torch.bool)
-        self.ep_lengths = torch.zeros(total_agents, device=device, dtype=torch.int32)
-        self.ep_indices = torch.arange(total_agents, device=device, dtype=torch.int32)
+        self.ep_lengths = torch.zeros(total_agents, dtype=torch.int32)
+        self.ep_indices = torch.arange(total_agents, dtype=torch.int32)
         self.free_idx = total_agents
         self.render = config["render"]
         self.render_interval = config["render_interval"]
@@ -385,12 +393,15 @@ class PuffeRL:
 
             profile("eval_copy", epoch)
             o = torch.as_tensor(o)
-            o_device = o.to(device)  # , non_blocking=True)
+            if self.compress_observations:
+                o_device = o.to(device=device, dtype=self.observations.dtype, non_blocking=True).float()
+            else:
+                o_device = o.to(device, non_blocking=True)
             r = torch.as_tensor(r).to(device)  # , non_blocking=True)
             d = torch.as_tensor(d).to(device)  # , non_blocking=True)
             t = torch.as_tensor(t).to(device)  # , non_blocking=True)
-            done_mask = (d + t).clamp(max=1.0)
             m = torch.as_tensor(mask).to(device)  # , non_blocking=True)
+            done_mask = (d + t).clamp(max=1.0)
 
             # Obs distribution stats (max/min/mean across the batch and obs
             # dims, appended per env step). Surfaces clipping / unbounded
@@ -445,8 +456,7 @@ class PuffeRL:
                     trunc_mask = (t > 0) & (d == 0)
                     r = r + trunc_mask.to(r.dtype) * config["gamma"] * self.values[batch_rows, l - 1]
                 self.rewards[batch_rows, l] = r
-                self.terminals[batch_rows, l] = done_mask.float()
-                self.truncations[batch_rows, l] = t.float()
+                self.terminals[batch_rows, l] = done_mask.bool()
                 self.values[batch_rows, l] = value.flatten().float()
                 self.masks[batch_rows, l] = m
 
@@ -454,7 +464,7 @@ class PuffeRL:
                 self.ep_lengths[env_id] += 1
                 if l + 1 >= config["bptt_horizon"]:
                     num_full = env_id.stop - env_id.start
-                    self.ep_indices[env_id] = self.free_idx + torch.arange(num_full, device=config["device"]).int()
+                    self.ep_indices[env_id] = self.free_idx + torch.arange(num_full, dtype=torch.int32)
                     self.ep_lengths[env_id] = 0
                     self.free_idx += num_full
                     self.full_rows += num_full
@@ -482,7 +492,7 @@ class PuffeRL:
 
         profile("eval_misc", epoch)
         self.free_idx = self.total_agents
-        self.ep_indices = torch.arange(self.total_agents, device=device, dtype=torch.int32)
+        self.ep_indices = torch.arange(self.total_agents, dtype=torch.int32)
         self.ep_lengths.zero_()
         profile.end()
         return pufferlib.utils.reduce_environment_metrics(self.stats)
@@ -509,7 +519,7 @@ class PuffeRL:
         self.epoch += 1
         done_training = self.global_step >= config["total_timesteps"]
         if done_training or self.global_step == 0 or time.time() > self.last_log_time + 0.25:
-            self.losses = losses
+            self.losses = {k: v.item() if isinstance(v, torch.Tensor) else v for k, v in losses.items()}
             logs = self.mean_and_log()
             self.print_dashboard()
             self.stats = defaultdict(list)
@@ -554,6 +564,8 @@ class PuffeRL:
     def _ppo_loss(self, mb_obs, mb_actions, mb_logprobs, mb_values, mb_returns, mb_adv, adv_weights=None):
         config = self.config
         state = dict(action=mb_actions, lstm_h=None, lstm_c=None)
+        if self.compress_observations:
+            mb_obs = mb_obs.float()
         with self.amp_context:
             logits, newvalue = self.policy(mb_obs, state)
         logits = logits_to_float(logits)
@@ -611,12 +623,12 @@ class PuffeRL:
             newvalue,
             ratio,
             {
-                "policy_loss": pg_loss.item(),
-                "value_loss": v_loss.item(),
-                "entropy": entropy_loss.item(),
-                "old_approx_kl": old_approx_kl.item(),
-                "approx_kl": approx_kl.item(),
-                "clipfrac": clipfrac.item(),
+                "policy_loss": pg_loss.detach(),
+                "value_loss": v_loss.detach(),
+                "entropy": entropy_loss.detach(),
+                "old_approx_kl": old_approx_kl,
+                "approx_kl": approx_kl,
+                "clipfrac": clipfrac,
             },
         )
 
@@ -625,7 +637,7 @@ class PuffeRL:
         device = config["device"]
 
         masks = self.masks.bool()
-        terminals = torch.maximum(self.terminals, (~masks).float())
+        terminals = (self.terminals | ~masks).float()
         advantages = compute_puff_advantage(
             self.values,
             self.rewards,
@@ -690,7 +702,7 @@ class PuffeRL:
             profile("train_misc", epoch)
             for key, value in stats.items():
                 losses[key] += value / self.total_minibatches
-            losses["importance"] += ratio.mean().item() / self.total_minibatches
+            losses["importance"] += ratio.detach().mean() / self.total_minibatches
 
             profile("learn", epoch)
             loss.backward()

--- a/tests/eval/test_eval.py
+++ b/tests/eval/test_eval.py
@@ -131,7 +131,6 @@ def _standalone_eval_args(benchmark_config_path):
             "seed": SEED,
             "device": "cpu",
             "compile": False,
-            "amp": False,
             "torch_deterministic": True,
         }
     )
@@ -357,7 +356,6 @@ def _replay_render_args():
             "seed": SEED,
             "device": "cpu",
             "compile": False,
-            "amp": False,
         }
     )
     args["vec"].update({"seed": SEED, "num_envs": 2, "num_workers": 2})
@@ -517,7 +515,6 @@ def _training_args(tmp_path, benchmark_config_path, evaluation_enabled):
             "seed": SEED,
             "device": "cpu",
             "compile": False,
-            "amp": False,
             "precision": "float32",
             "torch_deterministic": True,
             "anneal_lr": False,
@@ -681,7 +678,6 @@ def _sdc_eval_args(benchmark_config_path, benchmark_name, map_dir):
             "seed": SEED,
             "device": "cpu",
             "compile": False,
-            "amp": False,
             "torch_deterministic": True,
         }
     )


### PR DESCRIPTION
## What

- Add `train.rollout_dtype` to control observation rollout-buffer storage as `float32` or `float16`.
- Cast compressed observations back to float32 before policy inference and PPO updates.
- Reduce rollout-state memory usage with boolean terminal masks, CPU episode bookkeeping, and RNN-only ratio allocation.
- Keep loss statistics on-device until logging to avoid unnecessary synchronization.
- Remove the redundant `train.amp` option; CUDA bfloat16 autocast is now determined by `train.precision`.

## Why

Rollout observations dominate buffer memory. Optional float16 storage reduces memory use and transfer volume while preserving float32 policy inputs. Using `precision` as the single mixed-precision control also removes contradictory AMP configuration states.

## Notes

- `rollout_dtype` defaults to `float32`, preserving existing rollout storage behavior.
- `float16` rollout storage is accepted only for floating-point observation spaces.
- `precision: bfloat16` enables autocast on supported CUDA devices; `float32` and CPU execution do not use autocast.