### PR TITLE
Preload and share Drive map caches across worker processes

### DIFF
--- a/pufferlib/config/puffer_drive.yaml
+++ b/pufferlib/config/puffer_drive.yaml
@@ -64,6 +64,8 @@ env:
   traffic_light_behavior: stop
   # Share static map geometry (roads/grid/lane-graph) across envs using the same map - 0 off, 1 on
   use_map_cache: 1
+  # Load all configured maps before fork so workers inherit shared geometry - 0 off, 1 on
+  preload_map_cache: 0
   # Precompute neighboring road entities for observation queries - 0 off, 1 on
   use_neighbor_cache: 1
   # Number of steps before reset

--- a/pufferlib/config_schema.py
+++ b/pufferlib/config_schema.py
@@ -99,6 +99,7 @@ class DriveEnvConfig:
     offroad_behavior: InfractionBehavior = MISSING
     traffic_light_behavior: InfractionBehavior = MISSING
     use_map_cache: int = MISSING
+    preload_map_cache: int = MISSING
     use_neighbor_cache: int = MISSING
     scenario_length: int = MISSING
     resample_frequency: int = MISSING

--- a/pufferlib/ocean/drive/binding.c
+++ b/pufferlib/ocean/drive/binding.c
@@ -26,10 +26,17 @@ static PyObject *map_cache_live_count_py(
     return PyLong_FromLong(live);
 }
 
+static PyObject *map_cache_preload_py(PyObject *self __attribute__((unused)), PyObject *args, PyObject *kwargs);
+static PyObject *map_cache_release_py(PyObject *self __attribute__((unused)), PyObject *args, PyObject *kwargs);
+
 // clang-format off
 #define MY_METHODS \
     {"map_cache_size", map_cache_size_py, METH_NOARGS, "Map cache slot count."}, \
-    {"map_cache_live_count", map_cache_live_count_py, METH_NOARGS, "Map cache live count."}
+    {"map_cache_live_count", map_cache_live_count_py, METH_NOARGS, "Map cache live count."}, \
+    {"map_cache_preload", (PyCFunction) map_cache_preload_py, METH_VARARGS | METH_KEYWORDS, \
+     "Build and retain configured map geometry for forked workers."}, \
+    {"map_cache_release", (PyCFunction) map_cache_release_py, METH_VARARGS | METH_KEYWORDS, \
+     "Release map geometry retained for forked workers."}
 // clang-format on
 
 #include "../env_binding.h"
@@ -1857,6 +1864,89 @@ static PyObject *my_shared(PyObject *self, PyObject *args, PyObject *kwargs) {
     PyTuple_SetItem(tuple, 1, resized_map_ids);
     PyTuple_SetItem(tuple, 2, final_env_count);
     return tuple;
+}
+
+static int unpack_map_cache_args(PyObject *kwargs, Drive *config, const char ***paths, int *num_map_files) {
+    PyObject *map_files = PyDict_GetItemString(kwargs, "map_files");
+    if (map_files == NULL || !PyList_Check(map_files)) {
+        PyErr_SetString(PyExc_TypeError, "map_files must be a list of strings");
+        return -1;
+    }
+    Py_ssize_t map_file_count = PyList_Size(map_files);
+    if (map_file_count <= 0 || map_file_count > INT_MAX) {
+        PyErr_SetString(PyExc_ValueError, "map_files must contain between 1 and INT_MAX paths");
+        return -1;
+    }
+    *num_map_files = (int) map_file_count;
+    config->use_map_cache = 1;
+    config->use_neighbor_cache = (int) unpack(kwargs, "use_neighbor_cache");
+    config->obs_lane_stride = (int) unpack(kwargs, "obs_lane_stride");
+    config->obs_boundary_stride = (int) unpack(kwargs, "obs_boundary_stride");
+    config->obs_range_road_front_m = (float) unpack(kwargs, "obs_range_road_front_m");
+    config->obs_range_road_behind_m = (float) unpack(kwargs, "obs_range_road_behind_m");
+    config->obs_range_road_side_m = (float) unpack(kwargs, "obs_range_road_side_m");
+    if (PyErr_Occurred()) {
+        return -1;
+    }
+    if (config->use_neighbor_cache < 0 || config->use_neighbor_cache > 1 || config->obs_lane_stride < 1
+        || config->obs_boundary_stride < 1 || !isfinite(config->obs_range_road_front_m)
+        || !isfinite(config->obs_range_road_behind_m) || !isfinite(config->obs_range_road_side_m)
+        || config->obs_range_road_front_m < 0.0f || config->obs_range_road_behind_m < 0.0f
+        || config->obs_range_road_side_m < 0.0f) {
+        PyErr_SetString(PyExc_ValueError, "invalid map cache configuration");
+        return -1;
+    }
+    *paths = (const char **) malloc(*num_map_files * sizeof(char *));
+    if (*paths == NULL) {
+        PyErr_NoMemory();
+        return -1;
+    }
+    for (int i = 0; i < *num_map_files; i++) {
+        (*paths)[i] = PyUnicode_AsUTF8(PyList_GetItem(map_files, i));
+        if ((*paths)[i] == NULL) {
+            free(*paths);
+            return -1;
+        }
+    }
+    return 0;
+}
+
+static PyObject *map_cache_preload_py(
+    PyObject *self __attribute__((unused)),
+    PyObject *args __attribute__((unused)),
+    PyObject *kwargs) {
+    Drive config = {0};
+    const char **paths;
+    int num_map_files;
+    if (unpack_map_cache_args(kwargs, &config, &paths, &num_map_files) != 0) {
+        return NULL;
+    }
+    int cached = preload_map_cache(&config, paths, num_map_files);
+    free(paths);
+    if (cached < 0) {
+        PyErr_SetString(PyExc_RuntimeError, "map_cache_preload failed to load or build a map binary");
+        return NULL;
+    }
+    return PyLong_FromLong((long) cached);
+}
+
+static PyObject *map_cache_release_py(
+    PyObject *self __attribute__((unused)),
+    PyObject *args __attribute__((unused)),
+    PyObject *kwargs) {
+    Drive config = {0};
+    const char **paths;
+    int num_map_files;
+    if (unpack_map_cache_args(kwargs, &config, &paths, &num_map_files) != 0) {
+        return NULL;
+    }
+    int released = release_preloaded_map_cache(&config, paths, num_map_files);
+    free(paths);
+    if (released != 0) {
+        PyErr_SetString(PyExc_RuntimeError, "map_cache_release failed: preload configuration drifted");
+        return NULL;
+    }
+    Py_RETURN_NONE;
 }
 
 static int my_init(Env *env, PyObject *args, PyObject *kwargs) {

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -2904,13 +2904,6 @@ void remove_bad_trajectories(Drive *env) {
     env->timestep = 0;
 }
 
-static int compute_vision_range(Drive *env) {
-    int vision_half_range = (int) ceilf(
-        fmaxf(fmaxf(env->obs_range_road_front_m, env->obs_range_road_behind_m), env->obs_range_road_side_m)
-        / GRID_CELL_SIZE);
-    return 2 * vision_half_range + 1;
-}
-
 void init(Drive *env) {
     env->human_agent_idx = 0;
     env->timestep = 0;
@@ -3039,114 +3032,13 @@ void init(Drive *env) {
 }
 
 void c_close(Drive *env) {
-    for (int i = 0; i < env->num_total_agents; i++) {
-        free_agent(&env->agents[i]);
-    }
-    for (int i = 0; i < env->num_traffic_elements; i++) {
-        free_traffic_element(&env->traffic_elements[i]);
-    }
-    free(env->agents);
-    free(env->traffic_elements);
     free(env->active_agent_indices);
     free(env->logs);
-    if (env->shared_map != NULL) {
-        // Geometry is borrowed from the cache. Release our reference; free the
-        // entry only on the last reference, and only in the process that built it.
-        env->shared_map->ref_count--;
-        if (env->shared_map->ref_count <= 0 && env->shared_map->owner_pid == getpid()) {
-            free_shared_map_data(env->shared_map);
-        }
-        env->shared_map = NULL;
-    } else {
-        // Geometry is owned by this env: free it.
-        for (int i = 0; i < env->num_road_elements; i++) {
-            free_road_element(&env->road_elements[i]);
-        }
-        free(env->road_elements);
-        free(env->neighbor_offsets);
-        free_grid_map(env->grid_map);
-        free_lane_graph(&env->lane_graph);
-    }
-
     free(env->obs_neighbor_scratch);
     free(env->static_agent_indices);
     free(env->expert_static_agent_indices);
-    free(env->objects_of_interest);
-    free(env->tracks_to_predict);
-    free(env->map_name);
     free(env->ini_file);
-}
-
-static int release_preloaded_map_cache(Drive *config, const char **map_files, int num_map_files) {
-    if (num_map_files == 0) {
-        return 0;
-    }
-    struct SharedMapData **released = (struct SharedMapData **) malloc(num_map_files * sizeof(struct SharedMapData *));
-    if (released == NULL) {
-        return -1;
-    }
-    for (int i = 0; i < num_map_files; i++) {
-        Drive env = *config;
-        env.map_name = (char *) map_files[i];
-        struct SharedMapData *shared = map_cache_lookup(&env);
-        if (shared == NULL || shared->ref_count <= 0) {
-            for (int released_idx = 0; released_idx < i; released_idx++) {
-                released[released_idx]->ref_count++;
-            }
-            fprintf(stderr, "[ERROR] -> map_cache release miss (config drift): %s\n", env.map_name);
-            free(released);
-            return -1;
-        }
-        shared->ref_count--;
-        released[i] = shared;
-    }
-    free(released);
-    for (int cache_idx = 0; cache_idx < g_map_cache_count; cache_idx++) {
-        struct SharedMapData *shared = g_map_cache[cache_idx];
-        if (shared != NULL && shared->ref_count == 0 && shared->owner_pid == getpid()) {
-            free_shared_map_data(shared);
-        }
-    }
-    return 0;
-}
-
-static int preload_map_cache(Drive *config, const char **map_files, int num_map_files) {
-    for (int i = 0; i < num_map_files; i++) {
-        Drive env = *config;
-        env.map_name = strdup(map_files[i]);
-        struct SharedMapData *shared = map_cache_lookup(&env);
-        if (shared != NULL) {
-            env.grid_map = shared->grid_map;
-            env.neighbor_offsets = shared->neighbor_offsets;
-            if (env.use_neighbor_cache && env.grid_map->neighbor_cache_entities == NULL) {
-                cache_neighbor_offsets(&env);
-            }
-            shared->ref_count++;
-            free(env.map_name);
-            continue;
-        }
-        if (load_map_binary(env.map_name, &env) != 0) {
-            fprintf(stderr, "[ERROR] -> Failed to load map binary: %s\n", env.map_name);
-            c_close(&env);
-            release_preloaded_map_cache(config, map_files, i);
-            return -1;
-        }
-        if (init_grid_map(&env) != 0) {
-            fprintf(stderr, "[ERROR] -> Failed to build grid map for map: %s\n", env.map_name);
-            c_close(&env);
-            release_preloaded_map_cache(config, map_files, i);
-            return -1;
-        }
-        env.grid_map->vision_range = compute_vision_range(&env);
-        init_neighbor_offsets(&env);
-        if (env.use_neighbor_cache) {
-            cache_neighbor_offsets(&env);
-        }
-        env.shared_map = map_cache_store(&env);
-        env.shared_map->ref_count++;
-        c_close(&env);
-    }
-    return g_map_cache_count;
+    free_loaded_map_data(env);
 }
 
 static int compute_observation_size(Drive *env) {

--- a/pufferlib/ocean/drive/drive.h
+++ b/pufferlib/ocean/drive/drive.h
@@ -166,8 +166,8 @@ struct SharedMapData {
     pid_t owner_pid;
 };
 
-// Per-process map cache. Built lazily in init(); freeing is gated by per-entry
-// owner_pid in c_close.
+// Cached geometry is read-only after construction. Forked workers inherit the
+// parent's entries copy-on-write and never free parent-owned entries.
 static struct SharedMapData **g_map_cache = NULL;
 static int g_map_cache_count = 0;
 
@@ -2904,6 +2904,13 @@ void remove_bad_trajectories(Drive *env) {
     env->timestep = 0;
 }
 
+static int compute_vision_range(Drive *env) {
+    int vision_half_range = (int) ceilf(
+        fmaxf(fmaxf(env->obs_range_road_front_m, env->obs_range_road_behind_m), env->obs_range_road_side_m)
+        / GRID_CELL_SIZE);
+    return 2 * vision_half_range + 1;
+}
+
 void init(Drive *env) {
     env->human_agent_idx = 0;
     env->timestep = 0;
@@ -2937,27 +2944,12 @@ void init(Drive *env) {
             fprintf(stderr, "[ERROR] -> Failed to build grid map for map: %s\n", env->map_name);
             return;
         }
-        int vision_half_range = (int) ceilf(
-            fmaxf(fmaxf(env->obs_range_road_front_m, env->obs_range_road_behind_m), env->obs_range_road_side_m)
-            / GRID_CELL_SIZE);
-        env->grid_map->vision_range = 2 * vision_half_range + 1;
+        env->grid_map->vision_range = compute_vision_range(env);
         init_neighbor_offsets(env);
         if (env->use_map_cache) {
             // Transfer the just-built geometry into a shared, ref-counted entry that
             // this env borrows (ref_count starts at 1).
-            struct SharedMapData *entry = (struct SharedMapData *) calloc(1, sizeof(struct SharedMapData));
-            entry->map_name = strdup(env->map_name);
-            entry->road_elements = env->road_elements;
-            entry->num_road_elements = env->num_road_elements;
-            entry->grid_map = env->grid_map;
-            entry->neighbor_offsets = env->neighbor_offsets;
-            entry->lane_graph = env->lane_graph;
-            entry->obs_lane_stride = env->obs_lane_stride;
-            entry->obs_boundary_stride = env->obs_boundary_stride;
-            entry->ref_count = 1;
-            entry->owner_pid = getpid();
-            map_cache_insert(entry);
-            env->shared_map = entry;
+            env->shared_map = map_cache_store(env);
         }
     }
     if (env->use_neighbor_cache && env->grid_map->neighbor_cache_entities == NULL) {
@@ -3083,6 +3075,78 @@ void c_close(Drive *env) {
     free(env->tracks_to_predict);
     free(env->map_name);
     free(env->ini_file);
+}
+
+static int release_preloaded_map_cache(Drive *config, const char **map_files, int num_map_files) {
+    if (num_map_files == 0) {
+        return 0;
+    }
+    struct SharedMapData **released = (struct SharedMapData **) malloc(num_map_files * sizeof(struct SharedMapData *));
+    if (released == NULL) {
+        return -1;
+    }
+    for (int i = 0; i < num_map_files; i++) {
+        Drive env = *config;
+        env.map_name = (char *) map_files[i];
+        struct SharedMapData *shared = map_cache_lookup(&env);
+        if (shared == NULL || shared->ref_count <= 0) {
+            for (int released_idx = 0; released_idx < i; released_idx++) {
+                released[released_idx]->ref_count++;
+            }
+            fprintf(stderr, "[ERROR] -> map_cache release miss (config drift): %s\n", env.map_name);
+            free(released);
+            return -1;
+        }
+        shared->ref_count--;
+        released[i] = shared;
+    }
+    free(released);
+    for (int cache_idx = 0; cache_idx < g_map_cache_count; cache_idx++) {
+        struct SharedMapData *shared = g_map_cache[cache_idx];
+        if (shared != NULL && shared->ref_count == 0 && shared->owner_pid == getpid()) {
+            free_shared_map_data(shared);
+        }
+    }
+    return 0;
+}
+
+static int preload_map_cache(Drive *config, const char **map_files, int num_map_files) {
+    for (int i = 0; i < num_map_files; i++) {
+        Drive env = *config;
+        env.map_name = strdup(map_files[i]);
+        struct SharedMapData *shared = map_cache_lookup(&env);
+        if (shared != NULL) {
+            env.grid_map = shared->grid_map;
+            env.neighbor_offsets = shared->neighbor_offsets;
+            if (env.use_neighbor_cache && env.grid_map->neighbor_cache_entities == NULL) {
+                cache_neighbor_offsets(&env);
+            }
+            shared->ref_count++;
+            free(env.map_name);
+            continue;
+        }
+        if (load_map_binary(env.map_name, &env) != 0) {
+            fprintf(stderr, "[ERROR] -> Failed to load map binary: %s\n", env.map_name);
+            c_close(&env);
+            release_preloaded_map_cache(config, map_files, i);
+            return -1;
+        }
+        if (init_grid_map(&env) != 0) {
+            fprintf(stderr, "[ERROR] -> Failed to build grid map for map: %s\n", env.map_name);
+            c_close(&env);
+            release_preloaded_map_cache(config, map_files, i);
+            return -1;
+        }
+        env.grid_map->vision_range = compute_vision_range(&env);
+        init_neighbor_offsets(&env);
+        if (env.use_neighbor_cache) {
+            cache_neighbor_offsets(&env);
+        }
+        env.shared_map = map_cache_store(&env);
+        env.shared_map->ref_count++;
+        c_close(&env);
+    }
+    return g_map_cache_count;
 }
 
 static int compute_observation_size(Drive *env) {

--- a/pufferlib/ocean/drive/drive.py
+++ b/pufferlib/ocean/drive/drive.py
@@ -67,6 +67,7 @@ class Drive(pufferlib.PufferEnv):
         offroad_behavior="ignore",
         traffic_light_behavior="ignore",
         use_map_cache=0,
+        preload_map_cache=0,
         use_neighbor_cache=1,
         capture_replay=False,
         replay_worker_idx=0,
@@ -104,6 +105,7 @@ class Drive(pufferlib.PufferEnv):
         non_sdc_controller="policy",
         non_vehicle_controller="auto",
         map_dir=None,
+        config_only=False,
         goal_regen_mode="finite",
         goal_source="route",
         obs_goal_lane_distance=False,
@@ -210,6 +212,13 @@ class Drive(pufferlib.PufferEnv):
         if use_map_cache not in (0, 1):
             raise ValueError(f"use_map_cache must be 0 (off) or 1 (on). Got: {use_map_cache}")
         self.use_map_cache = use_map_cache
+        if preload_map_cache not in (0, 1):
+            raise ValueError(f"preload_map_cache must be 0 (off) or 1 (on). Got: {preload_map_cache}")
+        if preload_map_cache and not use_map_cache:
+            raise ValueError("preload_map_cache requires use_map_cache=1")
+        self.preload_map_cache = preload_map_cache
+        self._map_cache_preloaded = False
+        self._preloaded_map_cache_kwargs = None
         self.capture_replay = bool(capture_replay)
         self.replay_worker_idx = replay_worker_idx
         self._replay_captures = []
@@ -450,6 +459,11 @@ class Drive(pufferlib.PufferEnv):
 
         self.current_num_eval_scenarios = self._next_eval_batch_size()
 
+        self.num_agents = num_agents
+        self.c_envs = None
+        if config_only:
+            return
+
         # Iterate through all maps to count total agents that can be initialized for each map
         agent_offsets, map_ids, num_envs = binding.shared(
             map_files=self.map_files,
@@ -478,7 +492,6 @@ class Drive(pufferlib.PufferEnv):
         # stops stepping and emitting so it can't re-process or double-count.
         self._eval_exhausted = self.eval_mode and self.current_num_eval_scenarios == 0
 
-        self.num_agents = num_agents
         self.agent_offsets = agent_offsets
         self.map_ids = map_ids
         self.num_envs = num_envs
@@ -501,6 +514,23 @@ class Drive(pufferlib.PufferEnv):
             env_ids.append(env_id)
 
         self.c_envs = binding.vectorize(*env_ids)
+
+    def preload_shared_resources(self):
+        if not self.preload_map_cache or self._map_cache_preloaded:
+            return 0
+        preload_kwargs = {
+            "map_files": self.map_files[: self.num_maps],
+            "use_neighbor_cache": self.use_neighbor_cache,
+            "obs_lane_stride": self.obs_lane_stride,
+            "obs_boundary_stride": self.obs_boundary_stride,
+            "obs_range_road_front_m": self.obs_range_road_front_m,
+            "obs_range_road_behind_m": self.obs_range_road_behind_m,
+            "obs_range_road_side_m": self.obs_range_road_side_m,
+        }
+        cached = binding.map_cache_preload(**preload_kwargs)
+        self._preloaded_map_cache_kwargs = preload_kwargs
+        self._map_cache_preloaded = True
+        return cached
 
     def _env_init_kwargs(self, map_file, max_agents):
         # render_mode_flag: 0 = live viewer (RENDER_WINDOW), 1 = headless batch
@@ -956,7 +986,14 @@ class Drive(pufferlib.PufferEnv):
         )
 
     def close(self):
+        if self._map_cache_preloaded:
+            binding.map_cache_release(**self._preloaded_map_cache_kwargs)
+            self._map_cache_preloaded = False
+            self._preloaded_map_cache_kwargs = None
+        if self.c_envs is None:
+            return
         binding.vec_close(self.c_envs)
+        self.c_envs = None
 
     def get_state(self):
         try:

--- a/pufferlib/ocean/drive/map_data.h
+++ b/pufferlib/ocean/drive/map_data.h
@@ -91,6 +91,8 @@ static int init_grid_map(Drive *env) {
     float grid_height = top_left_y - bottom_right_y;
     if (!first_valid_point || !isfinite(grid_width) || !isfinite(grid_height)) {
         fprintf(stderr, "[ERROR] -> Map has no valid road geometry extent for grid\n");
+        free(env->grid_map);
+        env->grid_map = NULL;
         return 1;
     }
     env->grid_map->grid_cols = ceil(grid_width / GRID_CELL_SIZE);
@@ -104,6 +106,8 @@ static int init_grid_map(Drive *env) {
             env->grid_map->grid_rows,
             grid_width,
             grid_height);
+        free(env->grid_map);
+        env->grid_map = NULL;
         return 1;
     }
     int grid_cell_count = (int) grid_cell_count_wide;
@@ -748,6 +752,22 @@ static void map_cache_insert(struct SharedMapData *entry) {
     g_map_cache
         = (struct SharedMapData **) realloc(g_map_cache, (g_map_cache_count + 1) * sizeof(struct SharedMapData *));
     g_map_cache[g_map_cache_count++] = entry;
+}
+
+static struct SharedMapData *map_cache_store(Drive *env) {
+    struct SharedMapData *entry = (struct SharedMapData *) calloc(1, sizeof(struct SharedMapData));
+    entry->map_name = strdup(env->map_name);
+    entry->road_elements = env->road_elements;
+    entry->num_road_elements = env->num_road_elements;
+    entry->grid_map = env->grid_map;
+    entry->neighbor_offsets = env->neighbor_offsets;
+    entry->lane_graph = env->lane_graph;
+    entry->obs_lane_stride = env->obs_lane_stride;
+    entry->obs_boundary_stride = env->obs_boundary_stride;
+    entry->ref_count = 1;
+    entry->owner_pid = getpid();
+    map_cache_insert(entry);
+    return entry;
 }
 
 static void free_grid_map(GridMap *grid_map) {

--- a/pufferlib/ocean/drive/map_data.h
+++ b/pufferlib/ocean/drive/map_data.h
@@ -5,6 +5,14 @@
 // Grid Map Functions
 // ========================================
 
+// Odd grid width covering the furthest configured road-observation distance.
+static int compute_vision_range(Drive *env) {
+    int vision_half_range = (int) ceilf(
+        fmaxf(fmaxf(env->obs_range_road_front_m, env->obs_range_road_behind_m), env->obs_range_road_side_m)
+        / GRID_CELL_SIZE);
+    return 2 * vision_half_range + 1;
+}
+
 static int get_grid_index(Drive *env, float x1, float y1) {
     if (env->grid_map->top_left_x >= env->grid_map->bottom_right_x
         || env->grid_map->bottom_right_y >= env->grid_map->top_left_y) {
@@ -812,6 +820,110 @@ static void free_shared_map_data(struct SharedMapData *shared) {
         }
     }
     free(shared);
+}
+
+// Free binary-loaded scenario data and owned geometry, or release borrowed geometry.
+static void free_loaded_map_data(Drive *env) {
+    for (int i = 0; i < env->num_total_agents; i++) {
+        free_agent(&env->agents[i]);
+    }
+    for (int i = 0; i < env->num_traffic_elements; i++) {
+        free_traffic_element(&env->traffic_elements[i]);
+    }
+    free(env->agents);
+    free(env->traffic_elements);
+    if (env->shared_map != NULL) {
+        env->shared_map->ref_count--;
+        if (env->shared_map->ref_count <= 0 && env->shared_map->owner_pid == getpid()) {
+            free_shared_map_data(env->shared_map);
+        }
+        env->shared_map = NULL;
+    } else {
+        for (int i = 0; i < env->num_road_elements; i++) {
+            free_road_element(&env->road_elements[i]);
+        }
+        free(env->road_elements);
+        free(env->neighbor_offsets);
+        free_grid_map(env->grid_map);
+        free_lane_graph(&env->lane_graph);
+    }
+    free(env->objects_of_interest);
+    free(env->tracks_to_predict);
+    free(env->map_name);
+}
+
+// Release all preload references atomically; restore prior references on a cache miss.
+static int release_preloaded_map_cache(Drive *config, const char **map_files, int num_map_files) {
+    if (num_map_files == 0) {
+        return 0;
+    }
+    struct SharedMapData **released = (struct SharedMapData **) malloc(num_map_files * sizeof(struct SharedMapData *));
+    if (released == NULL) {
+        return -1;
+    }
+    for (int i = 0; i < num_map_files; i++) {
+        Drive env = *config;
+        env.map_name = (char *) map_files[i];
+        struct SharedMapData *shared = map_cache_lookup(&env);
+        if (shared == NULL || shared->ref_count <= 0) {
+            for (int released_idx = 0; released_idx < i; released_idx++) {
+                released[released_idx]->ref_count++;
+            }
+            fprintf(stderr, "[ERROR] -> map_cache release miss (config drift): %s\n", env.map_name);
+            free(released);
+            return -1;
+        }
+        shared->ref_count--;
+        released[i] = shared;
+    }
+    free(released);
+    for (int cache_idx = 0; cache_idx < g_map_cache_count; cache_idx++) {
+        struct SharedMapData *shared = g_map_cache[cache_idx];
+        if (shared != NULL && shared->ref_count == 0 && shared->owner_pid == getpid()) {
+            free_shared_map_data(shared);
+        }
+    }
+    return 0;
+}
+
+// Keep one cache reference per map and discard temporary per-scenario data after loading.
+static int preload_map_cache(Drive *config, const char **map_files, int num_map_files) {
+    for (int i = 0; i < num_map_files; i++) {
+        Drive env = *config;
+        env.map_name = strdup(map_files[i]);
+        struct SharedMapData *shared = map_cache_lookup(&env);
+        if (shared != NULL) {
+            env.grid_map = shared->grid_map;
+            env.neighbor_offsets = shared->neighbor_offsets;
+            if (env.use_neighbor_cache && env.grid_map->neighbor_cache_entities == NULL) {
+                cache_neighbor_offsets(&env);
+            }
+            shared->ref_count++;
+            free(env.map_name);
+            continue;
+        }
+        if (load_map_binary(env.map_name, &env) != 0) {
+            fprintf(stderr, "[ERROR] -> Failed to load map binary: %s\n", env.map_name);
+            free_loaded_map_data(&env);
+            release_preloaded_map_cache(config, map_files, i);
+            return -1;
+        }
+        if (init_grid_map(&env) != 0) {
+            fprintf(stderr, "[ERROR] -> Failed to build grid map for map: %s\n", env.map_name);
+            free_loaded_map_data(&env);
+            release_preloaded_map_cache(config, map_files, i);
+            return -1;
+        }
+        env.grid_map->vision_range = compute_vision_range(&env);
+        init_neighbor_offsets(&env);
+        if (env.use_neighbor_cache) {
+            cache_neighbor_offsets(&env);
+        }
+        env.shared_map = map_cache_store(&env);
+        env.shared_map->ref_count++;
+        free_loaded_map_data(&env);
+    }
+    return g_map_cache_count;
 }
 
 #endif

--- a/pufferlib/vector.py
+++ b/pufferlib/vector.py
@@ -5,6 +5,7 @@ import inspect
 import numpy as np
 import time
 import psutil
+from multiprocessing import get_all_start_methods, get_context
 
 from pufferlib import PufferEnv, set_buffers
 import pufferlib.spaces
@@ -373,19 +374,25 @@ class Multiprocessing:
 
         agents_per_env = driver_env.num_agents
 
-        from multiprocessing import RawArray, get_start_method
+        preload_shared_resources = getattr(driver_env, "preload_shared_resources", None)
+        self._driver_env_open = False
+        if "fork" in get_all_start_methods() and callable(preload_shared_resources):
+            self._driver_env_open = bool(preload_shared_resources())
+        process_context = get_context("fork") if self._driver_env_open else get_context()
+        if not self._driver_env_open:
+            driver_env.close()
 
         # Mac breaks without setting fork... but setting it breaks sweeps on 2nd run
         # set_start_method('fork')
         self.shm = dict(
-            observations=RawArray(obs_ctype, num_agents * int(np.prod(obs_shape))),
-            actions=RawArray(atn_ctype, num_agents * int(np.prod(atn_shape))),
-            rewards=RawArray("f", num_agents),
-            terminals=RawArray("b", num_agents),
-            truncateds=RawArray("b", num_agents),
-            masks=RawArray("b", num_agents),
-            semaphores=RawArray("c", num_workers),
-            notify=RawArray("b", num_workers),
+            observations=process_context.RawArray(obs_ctype, num_agents * int(np.prod(obs_shape))),
+            actions=process_context.RawArray(atn_ctype, num_agents * int(np.prod(atn_shape))),
+            rewards=process_context.RawArray("f", num_agents),
+            terminals=process_context.RawArray("b", num_agents),
+            truncateds=process_context.RawArray("b", num_agents),
+            masks=process_context.RawArray("b", num_agents),
+            semaphores=process_context.RawArray("c", num_workers),
+            notify=process_context.RawArray("b", num_workers),
         )
         shape = (num_workers, agents_per_worker)
         self.obs_batch_shape = (self.agents_per_batch, *obs_shape)
@@ -402,18 +409,9 @@ class Multiprocessing:
         )
         self.buf["semaphores"][:] = MAIN
 
-        from multiprocessing import Pipe, Process
-
-        self.send_pipes, w_recv_pipes = zip(*[Pipe() for _ in range(num_workers)])
-        w_send_pipes, self.recv_pipes = zip(*[Pipe() for _ in range(num_workers)])
+        self.send_pipes, w_recv_pipes = zip(*[process_context.Pipe() for _ in range(num_workers)])
+        w_send_pipes, self.recv_pipes = zip(*[process_context.Pipe() for _ in range(num_workers)])
         self.recv_pipe_dict = {p: i for i, p in enumerate(self.recv_pipes)}
-
-        preload_shared_resources = getattr(driver_env, "preload_shared_resources", None)
-        self._driver_env_open = False
-        if get_start_method() == "fork" and callable(preload_shared_resources):
-            self._driver_env_open = bool(preload_shared_resources())
-        if not self._driver_env_open:
-            driver_env.close()
 
         worker_ss = np.random.SeedSequence(seed).spawn(num_workers) if seed is not None else [None] * num_workers
         worker_seeds = [int(ss.generate_state(1)[0]) & 0x7FFFFFFF if ss is not None else None for ss in worker_ss]
@@ -422,7 +420,7 @@ class Multiprocessing:
         for i in range(num_workers):
             start = i * envs_per_worker
             end = start + envs_per_worker
-            p = Process(
+            p = process_context.Process(
                 target=_worker_process,
                 args=(
                     env_creators[start:end],

--- a/pufferlib/vector.py
+++ b/pufferlib/vector.py
@@ -1,6 +1,7 @@
 # TODO: Check actions passed to envs are right shape? On first call at least
 
 
+import inspect
 import numpy as np
 import time
 import psutil
@@ -71,6 +72,12 @@ def step(vecenv, actions):
     return obs, rewards, terminals, truncations, infos  # include env_ids or no?
 
 
+def make_config_env(creator, args, kwargs):
+    if "config_only" in inspect.signature(creator).parameters:
+        return creator(*args, **kwargs, config_only=True)
+    return creator(*args, **kwargs)
+
+
 class Serial:
     reset = reset
     step = step
@@ -80,14 +87,17 @@ class Serial:
         return self.agents_per_batch
 
     def __init__(self, env_creators, env_args, env_kwargs, num_envs, buf=None, seed=0, **kwargs):
-        self.driver_env = env_creators[0](*env_args[0], **env_kwargs[0])
-        self.agents_per_batch = self.driver_env.num_agents * num_envs
+        driver_env = make_config_env(env_creators[0], env_args[0], env_kwargs[0])
+        num_agents_per_env = driver_env.num_agents
+        self.agents_per_batch = num_agents_per_env * num_envs
         self.num_agents = self.agents_per_batch
 
-        self.single_observation_space = self.driver_env.single_observation_space
-        self.single_action_space = self.driver_env.single_action_space
+        self.single_observation_space = driver_env.single_observation_space
+        self.single_action_space = driver_env.single_action_space
         self.action_space = pufferlib.spaces.joint_space(self.single_action_space, self.agents_per_batch)
         self.observation_space = pufferlib.spaces.joint_space(self.single_observation_space, self.agents_per_batch)
+
+        driver_env.close()
 
         set_buffers(self, buf)
 
@@ -95,7 +105,7 @@ class Serial:
         ptr = 0
         child_seeds = np.random.SeedSequence(seed).spawn(len(env_creators)) if seed is not None else None
         for i in range(num_envs):
-            end = ptr + self.driver_env.num_agents
+            end = ptr + num_agents_per_env
             buf_i = dict(
                 observations=self.observations[ptr:end],
                 rewards=self.rewards[ptr:end],
@@ -112,8 +122,6 @@ class Serial:
             env = env_creators[i](*env_args[i], buf=buf_i, seed=seed_i, **env_kwargs[i])
             self.envs.append(env)
 
-        # Close the initial driver_env used only for configuration (it's not in self.envs)
-        self.driver_env.close()
         self.driver_env = driver = self.envs[0]
         self.emulated = self.driver_env.emulated
         check_envs(self.envs, self.driver_env)
@@ -339,7 +347,7 @@ class Multiprocessing:
         # with the resource tracker that spams warnings and does not work with
         # forked processes. So for now, RawArray is much more reliable.
         # You can't send a RawArray through a pipe.
-        self.driver_env = driver_env = env_creators[0](*env_args[0], **env_kwargs[0])
+        self.driver_env = driver_env = make_config_env(env_creators[0], env_args[0], env_kwargs[0])
         is_native = isinstance(driver_env, PufferEnv)
         self.emulated = False if is_native else driver_env.emulated
         self.num_agents = num_agents = driver_env.num_agents * num_envs
@@ -363,11 +371,9 @@ class Multiprocessing:
         self.observation_space = pufferlib.spaces.joint_space(self.single_observation_space, self.agents_per_batch)
         self.agent_ids = np.arange(num_agents).reshape(num_workers, agents_per_worker)
 
-        # Close driver env 0 after setup is done and args are read to free memory (which can be significant in the case of nuPlan evals).
         agents_per_env = driver_env.num_agents
-        driver_env.close()
 
-        from multiprocessing import RawArray
+        from multiprocessing import RawArray, get_start_method
 
         # Mac breaks without setting fork... but setting it breaks sweeps on 2nd run
         # set_start_method('fork')
@@ -401,6 +407,13 @@ class Multiprocessing:
         self.send_pipes, w_recv_pipes = zip(*[Pipe() for _ in range(num_workers)])
         w_send_pipes, self.recv_pipes = zip(*[Pipe() for _ in range(num_workers)])
         self.recv_pipe_dict = {p: i for i, p in enumerate(self.recv_pipes)}
+
+        preload_shared_resources = getattr(driver_env, "preload_shared_resources", None)
+        self._driver_env_open = False
+        if get_start_method() == "fork" and callable(preload_shared_resources):
+            self._driver_env_open = bool(preload_shared_resources())
+        if not self._driver_env_open:
+            driver_env.close()
 
         worker_ss = np.random.SeedSequence(seed).spawn(num_workers) if seed is not None else [None] * num_workers
         worker_seeds = [int(ss.generate_state(1)[0]) & 0x7FFFFFFF if ss is not None else None for ss in worker_ss]
@@ -571,8 +584,14 @@ class Multiprocessing:
         self.buf["notify"][:] = True
 
     def close(self):
+        if self.processes is None:
+            return
         for p in self.processes:
             p.terminate()
+        if self._driver_env_open:
+            self.driver_env.close()
+            self._driver_env_open = False
+        self.processes = None
 
 
 class Ray:
@@ -595,7 +614,7 @@ class Ray:
         self.workers_per_batch = batch_size // envs_per_worker
         self.num_workers = num_workers
 
-        driver_env = env_creators[0](*env_args[0], **env_kwargs[0])
+        driver_env = make_config_env(env_creators[0], env_args[0], env_kwargs[0])
         self.driver_env = driver_env
         self.emulated = driver_env.emulated
         self.num_agents = num_agents = driver_env.num_agents * num_envs
@@ -616,6 +635,8 @@ class Ray:
         self.observation_space = pufferlib.spaces.joint_space(self.single_observation_space, self.agents_per_batch)
 
         self.agent_ids = np.arange(num_agents).reshape(num_workers, agents_per_worker)
+
+        driver_env.close()
 
         import ray
 

--- a/tests/drive/test_drive_map_cache.c
+++ b/tests/drive/test_drive_map_cache.c
@@ -220,6 +220,69 @@ static int test_forked_child_owns_and_frees_new_map_cache_entry(void) {
     return 0;
 }
 
+static int test_forked_child_reuses_preloaded_map_cache_entry(void) {
+    drive_map_cache_clear();
+    Drive preload_config = drive_test_env_config(drive_carla_map(), SIMULATION_MODE_GIGAFLOW, 8, 1);
+    preload_config.use_neighbor_cache = 1;
+    const char *map_files[] = {drive_carla_map()};
+    pid_t parent_pid = getpid();
+
+    EXPECT_EQ_INT(preload_map_cache(&preload_config, map_files, 1), 1);
+    EXPECT_EQ_INT(drive_map_cache_live_count(), 1);
+    struct SharedMapData *preloaded = map_cache_lookup(&preload_config);
+    EXPECT_TRUE(preloaded != NULL);
+    EXPECT_EQ_INT(preloaded->ref_count, 1);
+    EXPECT_EQ_INT(preloaded->owner_pid, parent_pid);
+
+    int fds[2];
+    EXPECT_EQ_INT(pipe(fds), 0);
+    pid_t pid = fork();
+    if (pid == 0) {
+        close(fds[0]);
+        Drive child = create_test_env_with_cache_modes(1, 1, 8);
+        int payload[] = {
+            child.shared_map == preloaded,
+            child.grid_map == preloaded->grid_map,
+            child.road_elements == preloaded->road_elements,
+            child.shared_map->owner_pid == parent_pid,
+            drive_map_cache_live_count(),
+            child.shared_map->ref_count,
+            0,
+            0,
+        };
+        free_allocated(&child);
+        payload[6] = drive_map_cache_live_count();
+        payload[7] = preloaded->ref_count;
+        write(fds[1], payload, sizeof(payload));
+        close(fds[1]);
+        _exit(0);
+    }
+
+    close(fds[1]);
+    int payload[8] = {0};
+    int status = 0;
+    read(fds[0], payload, sizeof(payload));
+    close(fds[0]);
+    waitpid(pid, &status, 0);
+    EXPECT_TRUE(WIFEXITED(status));
+    EXPECT_EQ_INT(WEXITSTATUS(status), 0);
+    EXPECT_EQ_INT(payload[0], 1);
+    EXPECT_EQ_INT(payload[1], 1);
+    EXPECT_EQ_INT(payload[2], 1);
+    EXPECT_EQ_INT(payload[3], 1);
+    EXPECT_EQ_INT(payload[4], 1);
+    EXPECT_EQ_INT(payload[5], 2);
+    EXPECT_EQ_INT(payload[6], 1);
+    EXPECT_EQ_INT(payload[7], 1);
+    EXPECT_EQ_INT(preloaded->ref_count, 1);
+
+    EXPECT_EQ_INT(release_preloaded_map_cache(&preload_config, map_files, 1), 0);
+    EXPECT_EQ_INT(drive_map_cache_live_count(), 0);
+    free(preload_config.map_name);
+    drive_map_cache_clear();
+    return 0;
+}
+
 int main(void) {
     int failures = 0;
     RUN_TEST(test_all_cache_modes_produce_identical_step_outputs);
@@ -227,5 +290,6 @@ int main(void) {
     RUN_TEST(test_mixed_neighbor_modes_share_map_and_populate_neighbor_cache);
     RUN_TEST(test_repeated_single_map_lifetimes_reuse_one_cache_slot);
     RUN_TEST(test_forked_child_owns_and_frees_new_map_cache_entry);
+    RUN_TEST(test_forked_child_reuses_preloaded_map_cache_entry);
     return test_summary(failures);
 }

--- a/tests/unit_tests/test_vector_driver.py
+++ b/tests/unit_tests/test_vector_driver.py
@@ -4,6 +4,8 @@ The driver builds one env of its own purely to read spaces off, which must not
 stay resident for the run.
 """
 
+import multiprocessing
+
 import gymnasium
 import numpy as np
 
@@ -12,6 +14,7 @@ from pufferlib import PufferEnv
 
 OBSERVATION_SIZE = 4
 ACTION_COUNT = 2
+PRELOADED = False
 
 
 class MinimalEnv(PufferEnv):
@@ -39,8 +42,39 @@ class MinimalEnv(PufferEnv):
         self.close_count += 1
 
 
+class PreloadEnv(MinimalEnv):
+    def __init__(self, buf=None, seed=0, config_only=False):
+        self.preload_count = 0
+        super().__init__(buf=buf, seed=seed)
+
+    def preload_shared_resources(self):
+        global PRELOADED
+        PRELOADED = True
+        self.preload_count += 1
+        return 1
+
+    def reset(self, seed=None):
+        self.observations[:] = PRELOADED
+        return self.observations, []
+
+
 def _make_minimal_env(**kwargs):
     return MinimalEnv(**kwargs)
+
+
+def _run_preload_from_forkserver(queue):
+    vecenv = pufferlib.vector.make(
+        PreloadEnv,
+        backend="Multiprocessing",
+        num_envs=1,
+        num_workers=1,
+        batch_size=1,
+    )
+    try:
+        obs, _ = vecenv.reset()
+        queue.put((multiprocessing.get_start_method(), vecenv.driver_env.preload_count, bool(obs[0, 0])))
+    finally:
+        vecenv.close()
 
 
 def test_driver_env_is_released_but_stays_readable():
@@ -70,3 +104,14 @@ def test_driver_env_is_released_but_stays_readable():
         vecenv.close()
     # close() must not close it a second time; on a native env that double frees.
     assert vecenv.driver_env.close_count == 1
+
+
+def test_preloaded_resources_are_inherited_when_default_is_forkserver():
+    context = multiprocessing.get_context("forkserver")
+    queue = context.Queue()
+    process = context.Process(target=_run_preload_from_forkserver, args=(queue,))
+    process.start()
+    process.join()
+
+    assert process.exitcode == 0
+    assert queue.get() == ("forkserver", 1, True)


### PR DESCRIPTION
  ## What

  - Add preload_map_cache configuration for PufferDrive.
  - Load configured maps once in the parent process before workers start.
  - Share immutable road geometry, grid maps, lane graphs, and neighbor caches with workers through fork copy-on-write.
  - Add C bindings to preload and release map-cache entries.
  - Add lightweight config_only environment initialization to avoid constructing an unnecessary driver environment.
  - Correctly manage cache ownership and cleanup across parent and worker processes.
  - Use a local fork context when preloading, including when Python 3.14 defaults to forkserver.
  - Add C and Python regression coverage for inherited cache reuse and forkserver compatibility.

  ## Why

  Each multiprocessing worker previously loaded and retained its own copy of every map. Large multi-worker training jobs therefore duplicated static map data and consumed significantly more RAM.

  Preloading static geometry before forking lets workers inherit the same memory pages through copy-on-write. This restores the intended memory reduction without globally changing the application’s multiprocessing start method.

  ## Notes

  - Disabled by default with preload_map_cache: 0.
  - Requires use_map_cache: 1.
  - Non-preloaded environments retain the platform-default multiprocessing behavior.
  - Compatible with Python 3.14 and previous Python versions on platforms supporting fork.