### PR TITLE
Improve goal rendering and enrich evaluation replays

### DIFF
--- a/pufferlib/ocean/drive/binding.c
+++ b/pufferlib/ocean/drive/binding.c
@@ -1739,8 +1739,15 @@ static PyObject *my_shared(PyObject *self, PyObject *args, PyObject *kwargs) {
 
         int offset = 0;
         for (int i = 0; i < env_count; i++) {
+            int map_id;
+            if (eval_mode) {
+                map_id = use_eval_map_indices ? (int) PyLong_AsLong(PyList_GetItem(eval_map_indices, i))
+                                              : (s_map_counter + i) % num_maps;
+            } else {
+                map_id = rng_below(&shared_rng, num_maps);
+            }
             PyList_SetItem(agent_offsets, i, PyLong_FromLong(offset));
-            PyList_SetItem(map_ids_list, i, PyLong_FromLong(rng_below(&shared_rng, num_maps)));
+            PyList_SetItem(map_ids_list, i, PyLong_FromLong(map_id));
             offset += agent_counts[i];
         }
         PyList_SetItem(agent_offsets, env_count, PyLong_FromLong(offset));

--- a/pufferlib/ocean/drive/constants.h
+++ b/pufferlib/ocean/drive/constants.h
@@ -313,6 +313,7 @@ static const int ROAD_OFFSETS[25][2]
     12 // sim_x/y/z, heading, length, width, speed, steering, accel_long, accel_lat, jerk_long, jerk_lat
 #define AGENT_I32_FIELDS                                                                                               \
     10 // id, type, sim_valid, active_agent, stopped, removed, lane_idx, active_idx, blindness_active, braking_active
+#define GOAL_XY_FIELDS 2               // goal x, y per goal slot; reached slots stay zeroed
 #define METRICS_F32_FIELDS NUM_METRICS // must equal NUM_METRICS
 #define SCORE_F32_FIELDS 15            // Log struct fields: puffer_score .. weighted_average
 #define TRAFFIC_I16_FIELDS 3           // is_valid, type, state

--- a/pufferlib/ocean/drive/constants.h
+++ b/pufferlib/ocean/drive/constants.h
@@ -317,5 +317,20 @@ static const int ROAD_OFFSETS[25][2]
 #define METRICS_F32_FIELDS NUM_METRICS // must equal NUM_METRICS
 #define SCORE_F32_FIELDS 15            // Log struct fields: puffer_score .. weighted_average
 #define TRAFFIC_I16_FIELDS 3           // is_valid, type, state
+#define REWARD_F32_EPISODE_RETURN_IDX 0
+#define REWARD_F32_COLLISION_IDX 1
+#define REWARD_F32_OFFROAD_IDX 2
+#define REWARD_F32_RED_LIGHT_IDX 3
+#define REWARD_F32_STOP_SIGN_IDX 4
+#define REWARD_F32_GOAL_IDX 5
+#define REWARD_F32_LANE_ALIGN_IDX 6
+#define REWARD_F32_LANE_CENTER_IDX 7
+#define REWARD_F32_COMFORT_IDX 8
+#define REWARD_F32_VELOCITY_IDX 9
+#define REWARD_F32_TIMESTEP_IDX 10
+#define REWARD_F32_REVERSE_IDX 11
+#define REWARD_F32_OVERSPEED_IDX 12
+#define REWARD_F32_ADE_IDX 13
+#define REWARD_F32_FIELDS 14
 
 #endif

--- a/pufferlib/ocean/drive/constants.h
+++ b/pufferlib/ocean/drive/constants.h
@@ -309,8 +309,9 @@ static const int ROAD_OFFSETS[25][2]
 // =====================================================================================
 
 // obs_html_frame array field counts
+#define AGENT_F32_GOAL_RADIUS_IDX 12
 #define AGENT_F32_FIELDS                                                                                               \
-    12 // sim_x/y/z, heading, length, width, speed, steering, accel_long, accel_lat, jerk_long, jerk_lat
+    13 // sim_x/y/z, heading, length, width, speed, steering, accel_long, accel_lat, jerk_long, jerk_lat, goal_radius
 #define AGENT_I32_FIELDS                                                                                               \
     10 // id, type, sim_valid, active_agent, stopped, removed, lane_idx, active_idx, blindness_active, braking_active
 #define GOAL_XY_FIELDS 2               // goal x, y per goal slot; reached slots stay zeroed

--- a/pufferlib/ocean/drive/drive.py
+++ b/pufferlib/ocean/drive/drive.py
@@ -794,7 +794,16 @@ class Drive(pufferlib.PufferEnv):
             "agent_capacity": len(scenario["agents"] or []),
             "traffic_capacity": len(scenario["traffic_elements"] or []),
             "frames": {
-                key: [] for key in ("agent_f32", "agent_i32", "metrics_f32", "puffer_f32", "traffic_i16", "goals_f32")
+                key: []
+                for key in (
+                    "agent_f32",
+                    "agent_i32",
+                    "metrics_f32",
+                    "puffer_f32",
+                    "traffic_i16",
+                    "goals_f32",
+                    "rewards_f32",
+                )
             },
         }
 
@@ -836,6 +845,10 @@ class Drive(pufferlib.PufferEnv):
                 (env_count, agent_capacity, self.num_goals * binding.GOAL_XY_FIELDS),
                 dtype=np.float32,
             ),
+            "rewards_f32": np.empty(
+                (env_count, agent_capacity, binding.REWARD_F32_FIELDS),
+                dtype=np.float32,
+            ),
         }
 
     def _capture_replay_step(self):
@@ -846,11 +859,12 @@ class Drive(pufferlib.PufferEnv):
             self._replay_frame_arrays["puffer_f32"],
             self._replay_frame_arrays["traffic_i16"],
             self._replay_frame_arrays["goals_f32"],
+            self._replay_frame_arrays["rewards_f32"],
         )
         for env_idx, capture in enumerate(self._replay_captures):
             agent_capacity = capture["agent_capacity"]
             traffic_capacity = max(capture["traffic_capacity"], 1)
-            for key in ("agent_f32", "agent_i32", "metrics_f32", "puffer_f32", "goals_f32"):
+            for key in ("agent_f32", "agent_i32", "metrics_f32", "puffer_f32", "goals_f32", "rewards_f32"):
                 capture["frames"][key].append(self._replay_frame_arrays[key][env_idx, :agent_capacity].copy())
             capture["frames"]["traffic_i16"].append(
                 self._replay_frame_arrays["traffic_i16"][env_idx, :traffic_capacity].copy()
@@ -897,7 +911,7 @@ class Drive(pufferlib.PufferEnv):
         except Exception:
             return binding.env_get(self.c_envs)
 
-    def get_obs_html_frame(self, agent_f32, agent_i32, metrics_f32, puffer_f32, traffic_i16, goals_f32):
+    def get_obs_html_frame(self, agent_f32, agent_i32, metrics_f32, puffer_f32, traffic_i16, goals_f32, rewards_f32):
         binding.vec_get_obs_html_frame(
             self.c_envs,
             agent_f32,
@@ -906,6 +920,7 @@ class Drive(pufferlib.PufferEnv):
             puffer_f32,
             traffic_i16,
             goals_f32,
+            rewards_f32,
         )
 
 

--- a/pufferlib/ocean/drive/drive.py
+++ b/pufferlib/ocean/drive/drive.py
@@ -803,6 +803,7 @@ class Drive(pufferlib.PufferEnv):
                     "traffic_i16",
                     "goals_f32",
                     "rewards_f32",
+                    "coefs_f32",
                 )
             },
         }
@@ -849,6 +850,10 @@ class Drive(pufferlib.PufferEnv):
                 (env_count, agent_capacity, binding.REWARD_F32_FIELDS),
                 dtype=np.float32,
             ),
+            "coefs_f32": np.empty(
+                (env_count, agent_capacity, binding.NUM_REWARD_COEFS),
+                dtype=np.float32,
+            ),
         }
 
     def _capture_replay_step(self):
@@ -860,11 +865,20 @@ class Drive(pufferlib.PufferEnv):
             self._replay_frame_arrays["traffic_i16"],
             self._replay_frame_arrays["goals_f32"],
             self._replay_frame_arrays["rewards_f32"],
+            self._replay_frame_arrays["coefs_f32"],
         )
         for env_idx, capture in enumerate(self._replay_captures):
             agent_capacity = capture["agent_capacity"]
             traffic_capacity = max(capture["traffic_capacity"], 1)
-            for key in ("agent_f32", "agent_i32", "metrics_f32", "puffer_f32", "goals_f32", "rewards_f32"):
+            for key in (
+                "agent_f32",
+                "agent_i32",
+                "metrics_f32",
+                "puffer_f32",
+                "goals_f32",
+                "rewards_f32",
+                "coefs_f32",
+            ):
                 capture["frames"][key].append(self._replay_frame_arrays[key][env_idx, :agent_capacity].copy())
             capture["frames"]["traffic_i16"].append(
                 self._replay_frame_arrays["traffic_i16"][env_idx, :traffic_capacity].copy()
@@ -911,7 +925,17 @@ class Drive(pufferlib.PufferEnv):
         except Exception:
             return binding.env_get(self.c_envs)
 
-    def get_obs_html_frame(self, agent_f32, agent_i32, metrics_f32, puffer_f32, traffic_i16, goals_f32, rewards_f32):
+    def get_obs_html_frame(
+        self,
+        agent_f32,
+        agent_i32,
+        metrics_f32,
+        puffer_f32,
+        traffic_i16,
+        goals_f32,
+        rewards_f32,
+        coefs_f32,
+    ):
         binding.vec_get_obs_html_frame(
             self.c_envs,
             agent_f32,
@@ -921,6 +945,7 @@ class Drive(pufferlib.PufferEnv):
             traffic_i16,
             goals_f32,
             rewards_f32,
+            coefs_f32,
         )
 
 

--- a/pufferlib/ocean/drive/drive.py
+++ b/pufferlib/ocean/drive/drive.py
@@ -793,7 +793,9 @@ class Drive(pufferlib.PufferEnv):
             "scenario": scenario,
             "agent_capacity": len(scenario["agents"] or []),
             "traffic_capacity": len(scenario["traffic_elements"] or []),
-            "frames": {key: [] for key in ("agent_f32", "agent_i32", "metrics_f32", "puffer_f32", "traffic_i16")},
+            "frames": {
+                key: [] for key in ("agent_f32", "agent_i32", "metrics_f32", "puffer_f32", "traffic_i16", "goals_f32")
+            },
         }
 
     def _initialize_replay_captures(self):
@@ -830,6 +832,10 @@ class Drive(pufferlib.PufferEnv):
                 (env_count, traffic_capacity, binding.TRAFFIC_I16_FIELDS),
                 dtype=np.int16,
             ),
+            "goals_f32": np.empty(
+                (env_count, agent_capacity, self.num_goals * binding.GOAL_XY_FIELDS),
+                dtype=np.float32,
+            ),
         }
 
     def _capture_replay_step(self):
@@ -839,11 +845,12 @@ class Drive(pufferlib.PufferEnv):
             self._replay_frame_arrays["metrics_f32"],
             self._replay_frame_arrays["puffer_f32"],
             self._replay_frame_arrays["traffic_i16"],
+            self._replay_frame_arrays["goals_f32"],
         )
         for env_idx, capture in enumerate(self._replay_captures):
             agent_capacity = capture["agent_capacity"]
             traffic_capacity = max(capture["traffic_capacity"], 1)
-            for key in ("agent_f32", "agent_i32", "metrics_f32", "puffer_f32"):
+            for key in ("agent_f32", "agent_i32", "metrics_f32", "puffer_f32", "goals_f32"):
                 capture["frames"][key].append(self._replay_frame_arrays[key][env_idx, :agent_capacity].copy())
             capture["frames"]["traffic_i16"].append(
                 self._replay_frame_arrays["traffic_i16"][env_idx, :traffic_capacity].copy()
@@ -890,7 +897,7 @@ class Drive(pufferlib.PufferEnv):
         except Exception:
             return binding.env_get(self.c_envs)
 
-    def get_obs_html_frame(self, agent_f32, agent_i32, metrics_f32, puffer_f32, traffic_i16):
+    def get_obs_html_frame(self, agent_f32, agent_i32, metrics_f32, puffer_f32, traffic_i16, goals_f32):
         binding.vec_get_obs_html_frame(
             self.c_envs,
             agent_f32,
@@ -898,6 +905,7 @@ class Drive(pufferlib.PufferEnv):
             metrics_f32,
             puffer_f32,
             traffic_i16,
+            goals_f32,
         )
 
 

--- a/pufferlib/ocean/env_binding.h
+++ b/pufferlib/ocean/env_binding.h
@@ -801,8 +801,8 @@ static PyObject *vec_get(PyObject *self, PyObject *args) {
 }
 
 static PyObject *vec_get_obs_html_frame(PyObject *self, PyObject *args) {
-    if (PyTuple_Size(args) != 8) {
-        PyErr_SetString(PyExc_TypeError, "vec_get_obs_html_frame requires 8 arguments");
+    if (PyTuple_Size(args) != 9) {
+        PyErr_SetString(PyExc_TypeError, "vec_get_obs_html_frame requires 9 arguments");
         return NULL;
     }
 
@@ -818,10 +818,11 @@ static PyObject *vec_get_obs_html_frame(PyObject *self, PyObject *args) {
     PyArrayObject *traffic_i16_array = (PyArrayObject *) PyTuple_GetItem(args, 5);
     PyArrayObject *goals_f32_array = (PyArrayObject *) PyTuple_GetItem(args, 6);
     PyArrayObject *rewards_f32_array = (PyArrayObject *) PyTuple_GetItem(args, 7);
+    PyArrayObject *coefs_f32_array = (PyArrayObject *) PyTuple_GetItem(args, 8);
 
     if (!PyArray_Check(agent_f32_array) || !PyArray_Check(agent_i32_array) || !PyArray_Check(metrics_f32_array)
         || !PyArray_Check(puffer_f32_array) || !PyArray_Check(traffic_i16_array) || !PyArray_Check(goals_f32_array)
-        || !PyArray_Check(rewards_f32_array)) {
+        || !PyArray_Check(rewards_f32_array) || !PyArray_Check(coefs_f32_array)) {
         PyErr_SetString(PyExc_TypeError, "All output arrays must be NumPy arrays");
         return NULL;
     }
@@ -833,6 +834,7 @@ static PyObject *vec_get_obs_html_frame(PyObject *self, PyObject *args) {
     memset(PyArray_DATA(traffic_i16_array), 0, PyArray_NBYTES(traffic_i16_array));
     memset(PyArray_DATA(goals_f32_array), 0, PyArray_NBYTES(goals_f32_array));
     memset(PyArray_DATA(rewards_f32_array), 0, PyArray_NBYTES(rewards_f32_array));
+    memset(PyArray_DATA(coefs_f32_array), 0, PyArray_NBYTES(coefs_f32_array));
 
     float *agent_f32 = (float *) PyArray_DATA(agent_f32_array);
     int *agent_i32 = (int *) PyArray_DATA(agent_i32_array);
@@ -841,6 +843,7 @@ static PyObject *vec_get_obs_html_frame(PyObject *self, PyObject *args) {
     short *traffic_i16 = (short *) PyArray_DATA(traffic_i16_array);
     float *goals_f32 = (float *) PyArray_DATA(goals_f32_array);
     float *rewards_f32 = (float *) PyArray_DATA(rewards_f32_array);
+    float *coefs_f32 = (float *) PyArray_DATA(coefs_f32_array);
 
     int env_cap = (int) PyArray_DIM(agent_f32_array, 0);
     int env_count = vec->num_envs < env_cap ? vec->num_envs : env_cap;
@@ -854,6 +857,12 @@ static PyObject *vec_get_obs_html_frame(PyObject *self, PyObject *args) {
     int goal_fields = (int) PyArray_DIM(goals_f32_array, 2);
     int goal_slots = goal_fields / GOAL_XY_FIELDS;
     int reward_fields = (int) PyArray_DIM(rewards_f32_array, 2);
+    int coef_fields = (int) PyArray_DIM(coefs_f32_array, 2);
+
+    if (coef_fields != NUM_REWARD_COEFS) {
+        PyErr_SetString(PyExc_ValueError, "coefs_f32 must have NUM_REWARD_COEFS fields");
+        return NULL;
+    }
 
     for (int e = 0; e < env_count; e++) {
         Drive *drive = (Drive *) vec->envs[e];
@@ -892,6 +901,7 @@ static PyObject *vec_get_obs_html_frame(PyObject *self, PyObject *args) {
             agent_i32[i32_base + 9] = a->phantom_braking_counter > 0;
 
             memcpy(&metrics_f32[metrics_base], a->metrics_array, sizeof(float) * NUM_METRICS);
+            memcpy(&coefs_f32[(e * agent_cap + i) * coef_fields], a->reward_coefs, sizeof(float) * NUM_REWARD_COEFS);
         }
 
         if (drive->active_agent_indices) {

--- a/pufferlib/ocean/env_binding.h
+++ b/pufferlib/ocean/env_binding.h
@@ -878,6 +878,7 @@ static PyObject *vec_get_obs_html_frame(PyObject *self, PyObject *args) {
             agent_f32[f32_base + 9] = a->accel_lat;
             agent_f32[f32_base + 10] = a->jerk_long;
             agent_f32[f32_base + 11] = a->jerk_lat;
+            agent_f32[f32_base + AGENT_F32_GOAL_RADIUS_IDX] = a->reward_coefs[REWARD_COEF_GOAL_RADIUS];
 
             agent_i32[i32_base + 0] = i;
             agent_i32[i32_base + 1] = a->type;
@@ -1427,6 +1428,7 @@ PyMODINIT_FUNC PyInit_binding(void) {
     PyModule_AddIntConstant(m, "GOAL_FEATURES", GOAL_FEATURES);
     PyModule_AddIntConstant(m, "MAX_GOALS", MAX_GOALS);
     PyModule_AddIntConstant(m, "AGENT_F32_FIELDS", AGENT_F32_FIELDS);
+    PyModule_AddIntConstant(m, "AGENT_F32_GOAL_RADIUS_IDX", AGENT_F32_GOAL_RADIUS_IDX);
     PyModule_AddIntConstant(m, "AGENT_I32_FIELDS", AGENT_I32_FIELDS);
     PyModule_AddIntConstant(m, "GOAL_XY_FIELDS", GOAL_XY_FIELDS);
     PyModule_AddIntConstant(m, "METRICS_F32_FIELDS", METRICS_F32_FIELDS);

--- a/pufferlib/ocean/env_binding.h
+++ b/pufferlib/ocean/env_binding.h
@@ -801,8 +801,8 @@ static PyObject *vec_get(PyObject *self, PyObject *args) {
 }
 
 static PyObject *vec_get_obs_html_frame(PyObject *self, PyObject *args) {
-    if (PyTuple_Size(args) != 6) {
-        PyErr_SetString(PyExc_TypeError, "vec_get_obs_html_frame requires 6 arguments");
+    if (PyTuple_Size(args) != 7) {
+        PyErr_SetString(PyExc_TypeError, "vec_get_obs_html_frame requires 7 arguments");
         return NULL;
     }
 
@@ -816,9 +816,10 @@ static PyObject *vec_get_obs_html_frame(PyObject *self, PyObject *args) {
     PyArrayObject *metrics_f32_array = (PyArrayObject *) PyTuple_GetItem(args, 3);
     PyArrayObject *puffer_f32_array = (PyArrayObject *) PyTuple_GetItem(args, 4);
     PyArrayObject *traffic_i16_array = (PyArrayObject *) PyTuple_GetItem(args, 5);
+    PyArrayObject *goals_f32_array = (PyArrayObject *) PyTuple_GetItem(args, 6);
 
     if (!PyArray_Check(agent_f32_array) || !PyArray_Check(agent_i32_array) || !PyArray_Check(metrics_f32_array)
-        || !PyArray_Check(puffer_f32_array) || !PyArray_Check(traffic_i16_array)) {
+        || !PyArray_Check(puffer_f32_array) || !PyArray_Check(traffic_i16_array) || !PyArray_Check(goals_f32_array)) {
         PyErr_SetString(PyExc_TypeError, "All output arrays must be NumPy arrays");
         return NULL;
     }
@@ -828,12 +829,14 @@ static PyObject *vec_get_obs_html_frame(PyObject *self, PyObject *args) {
     memset(PyArray_DATA(metrics_f32_array), 0, PyArray_NBYTES(metrics_f32_array));
     memset(PyArray_DATA(puffer_f32_array), 0, PyArray_NBYTES(puffer_f32_array));
     memset(PyArray_DATA(traffic_i16_array), 0, PyArray_NBYTES(traffic_i16_array));
+    memset(PyArray_DATA(goals_f32_array), 0, PyArray_NBYTES(goals_f32_array));
 
     float *agent_f32 = (float *) PyArray_DATA(agent_f32_array);
     int *agent_i32 = (int *) PyArray_DATA(agent_i32_array);
     float *metrics_f32 = (float *) PyArray_DATA(metrics_f32_array);
     float *puffer_f32 = (float *) PyArray_DATA(puffer_f32_array);
     short *traffic_i16 = (short *) PyArray_DATA(traffic_i16_array);
+    float *goals_f32 = (float *) PyArray_DATA(goals_f32_array);
 
     int env_cap = (int) PyArray_DIM(agent_f32_array, 0);
     int env_count = vec->num_envs < env_cap ? vec->num_envs : env_cap;
@@ -844,6 +847,8 @@ static PyObject *vec_get_obs_html_frame(PyObject *self, PyObject *args) {
     int puffer_fields = (int) PyArray_DIM(puffer_f32_array, 2);
     int traffic_cap = (int) PyArray_DIM(traffic_i16_array, 1);
     int traffic_fields = (int) PyArray_DIM(traffic_i16_array, 2);
+    int goal_fields = (int) PyArray_DIM(goals_f32_array, 2);
+    int goal_slots = goal_fields / GOAL_XY_FIELDS;
 
     for (int e = 0; e < env_count; e++) {
         Drive *drive = (Drive *) vec->envs[e];
@@ -892,6 +897,14 @@ static PyObject *vec_get_obs_html_frame(PyObject *self, PyObject *args) {
                 int i32_base = (e * agent_cap + agent_idx) * agent_i32_fields;
                 int puffer_base = (e * agent_cap + agent_idx) * puffer_fields;
                 agent_i32[i32_base + 7] = j;
+
+                Agent *active = &drive->agents[agent_idx];
+                int goal_count = active->goal_count < goal_slots ? active->goal_count : goal_slots;
+                int goal_base = (e * agent_cap + agent_idx) * goal_fields;
+                for (int goal_idx = active->current_goal_idx; goal_idx < goal_count; goal_idx++) {
+                    goals_f32[goal_base + goal_idx * GOAL_XY_FIELDS] = active->list_goal_x[goal_idx];
+                    goals_f32[goal_base + goal_idx * GOAL_XY_FIELDS + 1] = active->list_goal_y[goal_idx];
+                }
 
                 if (!drive->compute_eval_metrics || !drive->logs || j >= drive->logs_capacity) {
                     continue;
@@ -1394,6 +1407,7 @@ PyMODINIT_FUNC PyInit_binding(void) {
     PyModule_AddIntConstant(m, "MAX_GOALS", MAX_GOALS);
     PyModule_AddIntConstant(m, "AGENT_F32_FIELDS", AGENT_F32_FIELDS);
     PyModule_AddIntConstant(m, "AGENT_I32_FIELDS", AGENT_I32_FIELDS);
+    PyModule_AddIntConstant(m, "GOAL_XY_FIELDS", GOAL_XY_FIELDS);
     PyModule_AddIntConstant(m, "METRICS_F32_FIELDS", METRICS_F32_FIELDS);
     PyModule_AddIntConstant(m, "SCORE_F32_FIELDS", SCORE_F32_FIELDS);
     PyModule_AddIntConstant(m, "TRAFFIC_I16_FIELDS", TRAFFIC_I16_FIELDS);

--- a/pufferlib/ocean/env_binding.h
+++ b/pufferlib/ocean/env_binding.h
@@ -801,8 +801,8 @@ static PyObject *vec_get(PyObject *self, PyObject *args) {
 }
 
 static PyObject *vec_get_obs_html_frame(PyObject *self, PyObject *args) {
-    if (PyTuple_Size(args) != 7) {
-        PyErr_SetString(PyExc_TypeError, "vec_get_obs_html_frame requires 7 arguments");
+    if (PyTuple_Size(args) != 8) {
+        PyErr_SetString(PyExc_TypeError, "vec_get_obs_html_frame requires 8 arguments");
         return NULL;
     }
 
@@ -817,9 +817,11 @@ static PyObject *vec_get_obs_html_frame(PyObject *self, PyObject *args) {
     PyArrayObject *puffer_f32_array = (PyArrayObject *) PyTuple_GetItem(args, 4);
     PyArrayObject *traffic_i16_array = (PyArrayObject *) PyTuple_GetItem(args, 5);
     PyArrayObject *goals_f32_array = (PyArrayObject *) PyTuple_GetItem(args, 6);
+    PyArrayObject *rewards_f32_array = (PyArrayObject *) PyTuple_GetItem(args, 7);
 
     if (!PyArray_Check(agent_f32_array) || !PyArray_Check(agent_i32_array) || !PyArray_Check(metrics_f32_array)
-        || !PyArray_Check(puffer_f32_array) || !PyArray_Check(traffic_i16_array) || !PyArray_Check(goals_f32_array)) {
+        || !PyArray_Check(puffer_f32_array) || !PyArray_Check(traffic_i16_array) || !PyArray_Check(goals_f32_array)
+        || !PyArray_Check(rewards_f32_array)) {
         PyErr_SetString(PyExc_TypeError, "All output arrays must be NumPy arrays");
         return NULL;
     }
@@ -830,6 +832,7 @@ static PyObject *vec_get_obs_html_frame(PyObject *self, PyObject *args) {
     memset(PyArray_DATA(puffer_f32_array), 0, PyArray_NBYTES(puffer_f32_array));
     memset(PyArray_DATA(traffic_i16_array), 0, PyArray_NBYTES(traffic_i16_array));
     memset(PyArray_DATA(goals_f32_array), 0, PyArray_NBYTES(goals_f32_array));
+    memset(PyArray_DATA(rewards_f32_array), 0, PyArray_NBYTES(rewards_f32_array));
 
     float *agent_f32 = (float *) PyArray_DATA(agent_f32_array);
     int *agent_i32 = (int *) PyArray_DATA(agent_i32_array);
@@ -837,6 +840,7 @@ static PyObject *vec_get_obs_html_frame(PyObject *self, PyObject *args) {
     float *puffer_f32 = (float *) PyArray_DATA(puffer_f32_array);
     short *traffic_i16 = (short *) PyArray_DATA(traffic_i16_array);
     float *goals_f32 = (float *) PyArray_DATA(goals_f32_array);
+    float *rewards_f32 = (float *) PyArray_DATA(rewards_f32_array);
 
     int env_cap = (int) PyArray_DIM(agent_f32_array, 0);
     int env_count = vec->num_envs < env_cap ? vec->num_envs : env_cap;
@@ -849,6 +853,7 @@ static PyObject *vec_get_obs_html_frame(PyObject *self, PyObject *args) {
     int traffic_fields = (int) PyArray_DIM(traffic_i16_array, 2);
     int goal_fields = (int) PyArray_DIM(goals_f32_array, 2);
     int goal_slots = goal_fields / GOAL_XY_FIELDS;
+    int reward_fields = (int) PyArray_DIM(rewards_f32_array, 2);
 
     for (int e = 0; e < env_count; e++) {
         Drive *drive = (Drive *) vec->envs[e];
@@ -896,6 +901,7 @@ static PyObject *vec_get_obs_html_frame(PyObject *self, PyObject *args) {
                 }
                 int i32_base = (e * agent_cap + agent_idx) * agent_i32_fields;
                 int puffer_base = (e * agent_cap + agent_idx) * puffer_fields;
+                int reward_base = (e * agent_cap + agent_idx) * reward_fields;
                 agent_i32[i32_base + 7] = j;
 
                 Agent *active = &drive->agents[agent_idx];
@@ -925,6 +931,21 @@ static PyObject *vec_get_obs_html_frame(PyObject *self, PyObject *args) {
                 puffer_f32[puffer_base + 12] = log->speed_violation_sum;
                 puffer_f32[puffer_base + 13] = log->multiplier;
                 puffer_f32[puffer_base + 14] = log->weighted_average;
+
+                rewards_f32[reward_base + REWARD_F32_EPISODE_RETURN_IDX] = log->episode_return;
+                rewards_f32[reward_base + REWARD_F32_COLLISION_IDX] = log->reward_collision;
+                rewards_f32[reward_base + REWARD_F32_OFFROAD_IDX] = log->reward_offroad;
+                rewards_f32[reward_base + REWARD_F32_RED_LIGHT_IDX] = log->reward_red_light;
+                rewards_f32[reward_base + REWARD_F32_STOP_SIGN_IDX] = log->reward_stop_sign;
+                rewards_f32[reward_base + REWARD_F32_GOAL_IDX] = log->reward_goal;
+                rewards_f32[reward_base + REWARD_F32_LANE_ALIGN_IDX] = log->reward_lane_align;
+                rewards_f32[reward_base + REWARD_F32_LANE_CENTER_IDX] = log->reward_lane_center;
+                rewards_f32[reward_base + REWARD_F32_COMFORT_IDX] = log->reward_comfort;
+                rewards_f32[reward_base + REWARD_F32_VELOCITY_IDX] = log->reward_velocity;
+                rewards_f32[reward_base + REWARD_F32_TIMESTEP_IDX] = log->reward_timestep;
+                rewards_f32[reward_base + REWARD_F32_REVERSE_IDX] = log->reward_reverse;
+                rewards_f32[reward_base + REWARD_F32_OVERSPEED_IDX] = log->reward_overspeed;
+                rewards_f32[reward_base + REWARD_F32_ADE_IDX] = log->reward_ade;
             }
         }
 
@@ -1411,6 +1432,7 @@ PyMODINIT_FUNC PyInit_binding(void) {
     PyModule_AddIntConstant(m, "METRICS_F32_FIELDS", METRICS_F32_FIELDS);
     PyModule_AddIntConstant(m, "SCORE_F32_FIELDS", SCORE_F32_FIELDS);
     PyModule_AddIntConstant(m, "TRAFFIC_I16_FIELDS", TRAFFIC_I16_FIELDS);
+    PyModule_AddIntConstant(m, "REWARD_F32_FIELDS", REWARD_F32_FIELDS);
     PyModule_AddIntConstant(m, "NUM_REWARD_COEFS", NUM_REWARD_COEFS);
     PyModule_AddIntConstant(m, "GOAL_REGEN_FINITE", GOAL_REGEN_FINITE);
     PyModule_AddIntConstant(m, "GOAL_REGEN_ROLLING", GOAL_REGEN_ROLLING);

--- a/pufferlib/viz.py
+++ b/pufferlib/viz.py
@@ -1095,7 +1095,7 @@ def _render_interactive_replay_payload(compressed_payload, filename):
             <div class="label">Policy</div><div id="policy-grid" class="grid"></div>
             <button type="button" id="reward-header" class="toggle-header" data-target="reward-grid"><span>Reward</span><span>&#9662;</span></button>
             <div id="reward-grid" class="grid toggle-body"></div>
-            <button type="button" id="coef-header" class="toggle-header is-collapsed" data-target="coef-grid"><span>Reward coefs</span><span>&#9662;</span></button>
+            <button type="button" id="coef-header" class="toggle-header is-collapsed" data-target="coef-grid"><span>Conditioning</span><span>&#9662;</span></button>
             <div id="coef-grid" class="grid toggle-body is-collapsed"></div>
             <button type="button" class="toggle-header" data-target="puffer-score-body"><span>Puffer score</span><span>&#9662;</span></button>
             <div id="puffer-score-body" class="toggle-body"><div id="tel-ps" class="score-num">0.000</div></div>

--- a/pufferlib/viz.py
+++ b/pufferlib/viz.py
@@ -879,6 +879,8 @@ def encode_interactive_replay(scenario, replay):
         "value": replay["value"].astype(np.float32, copy=False),
         "entropy": replay["entropy"].astype(np.float32, copy=False),
     }
+    if replay.get("goals_f32") is not None:
+        chunks["goals_f32"] = replay["goals_f32"].astype(np.float32, copy=False)
     if quantized_observations is not None:
         chunks["obs"] = quantized_observations
     if replay.get("policy_probs") is not None:
@@ -1222,7 +1224,7 @@ self.onmessage = async event => {
             H = JSON.parse(new TextDecoder().decode(new Uint8Array(buf, 4, headerLen)));
             H.buffer = buf; H.dataStart = 4 + headerLen + ((-(4 + headerLen)) & 3);
             for (const name of Object.keys(H.chunks)) C[name] = chunk(name);
-            F = {af:H.chunks.agent_f32.shape[2], ai:H.chunks.agent_i32.shape[2], mf:H.chunks.metrics_f32.shape[2], pf:H.chunks.puffer_f32.shape[2], tf:H.chunks.traffic_i16.shape[2]};
+            F = {af:H.chunks.agent_f32.shape[2], ai:H.chunks.agent_i32.shape[2], mf:H.chunks.metrics_f32.shape[2], pf:H.chunks.puffer_f32.shape[2], tf:H.chunks.traffic_i16.shape[2], gf:H.chunks.goals_f32 ? H.chunks.goals_f32.shape[2] : 0};
             expertAgentIndices = new Set(H.expert_indices);
             document.getElementById('meta-map').textContent = String(H.map_name).split('/').pop();
             document.getElementById('meta-id').textContent = H.scenario_id || "-";
@@ -1387,19 +1389,13 @@ self.onmessage = async event => {
         function poolColor(t) { t = t < 0 ? 0 : (t > 1 ? 1 : t); const f = t * (POOL_STOPS.length - 1), i = Math.floor(f), k = f - i, a = POOL_STOPS[i], b = POOL_STOPS[Math.min(i + 1, POOL_STOPS.length - 1)]; return `rgb(${Math.round(a[0]+(b[0]-a[0])*k)},${Math.round(a[1]+(b[1]-a[1])*k)},${Math.round(a[2]+(b[2]-a[2])*k)})`; }
         function drawPoolLegend(maxN) { const w = 116*dpr, h = 9*dpr, x = obsC.width - w - 12*dpr, y = obsC.height - 20*dpr, grad = obsCtx.createLinearGradient(x, 0, x+w, 0); for (let i=0;i<=10;i++) grad.addColorStop(i/10, poolColor(i/10)); obsCtx.fillStyle = grad; obsCtx.fillRect(x, y, w, h); obsCtx.strokeStyle = "rgba(0,0,0,.45)"; obsCtx.lineWidth = dpr; obsCtx.strokeRect(x, y, w, h); obsCtx.fillStyle = "#111"; obsCtx.font = `bold ${9.5*dpr}px system-ui`; obsCtx.textAlign = "left"; obsCtx.fillText("pool wins  1", x, y - 4*dpr); obsCtx.textAlign = "right"; obsCtx.fillText(maxN, x+w, y - 4*dpr); }
         function selectedGoals(frame, agent) {
-            if (!C.obs || !agent || agent.slot < 0) return [];
-            const base = (frame * H.active_count + agent.slot) * H.obs_dim, obs = C.obs, Q = H.obs_scale === undefined ? 1 : H.obs_scale;
-            let p = base + H.ego_dim;
-            if (H.reward_conditioning) p += H.reward_coef_count;
-            const scale = H.scales.obs_norm_goal_offset_m * Q;
-            const out = [];
+            // World-frame goals from the replay log, so goals render without captured observations.
+            if (!C.goals_f32 || !agent || agent.slot < 0) return [];
+            const base = (frame * H.agent_cap + agent.idx) * F.gf, stride = F.gf / H.num_goals, goals = C.goals_f32, out = [];
             for (let i=0;i<H.num_goals;i++) {
-                const o = p + i * H.goal_features;
-                let empty = true;
-                for (let j=0;j<H.goal_features;j++) if (obs[o+j] !== 0) empty = false;
-                if (empty) continue;
-                const rx = obs[o] * scale, ry = obs[o+1] * scale, ch = Math.cos(agent.h), sh = Math.sin(agent.h);
-                out.push({x:agent.x + rx * ch - ry * sh, y:agent.y + rx * sh + ry * ch});
+                const o = base + i * stride;
+                if (goals[o] === 0 && goals[o+1] === 0) continue;
+                out.push({x:goals[o], y:goals[o+1]});
             }
             return out;
         }

--- a/pufferlib/viz.py
+++ b/pufferlib/viz.py
@@ -934,6 +934,8 @@ def encode_interactive_replay(scenario, replay):
         "eval_overrides": replay.get("eval_overrides") or {},
         "frames": int(replay["agent_f32"].shape[0]),
         "agent_cap": int(replay["agent_f32"].shape[1]),
+        "agent_goal_radius_field": int(binding.AGENT_F32_GOAL_RADIUS_IDX),
+        "default_goal_radius_meters": float(env_cfg["goal_radius"]),
         "traffic_cap": int(replay["traffic_i16"].shape[1]),
         "active_count": int(replay["raw_action"].shape[1]),
         "obs_dim": int(replay["obs"].shape[2]) if replay.get("obs") is not None else 0,
@@ -1120,6 +1122,7 @@ __PAYLOAD_CHUNKS__
         const PARTNER_BLINDNESS_OUTLINE_COLOR = "#6d28d9";
         const PHANTOM_BRAKING_OUTLINE_COLOR = "#b45309";
         const INFRACTION_METRIC_COUNT = 4;
+        const DEFAULT_GOAL_RADIUS_METERS = 2;
         const SVG_PLAY = '<svg viewBox="0 0 16 16" width="13" height="13"><path d="M4.5 2.5v11l9-5.5z" fill="currentColor"/></svg>';
         const SVG_PAUSE = '<svg viewBox="0 0 16 16" width="13" height="13"><path d="M4 2.5h3v11H4zM9 2.5h3v11H9z" fill="currentColor"/></svg>';
         let H, C = {}, F, paths = {0:new Path2D(),1:new Path2D(),2:new Path2D()}, lastDrawn = -1;
@@ -1329,7 +1332,10 @@ self.onmessage = async event => {
             const isExpert = expertAgentIndices.has(idx);
             const hasInfraction = agentType === 1 && agentHasInfraction(frame, idx);
             const agentColor = colorForAgent(C.agent_i32[ib], isActive, isExpert, hasInfraction);
-            return {idx:idx, id:C.agent_i32[ib], type:agentType, cl:C.agent_i32[ib+6], slot:C.agent_i32[ib+7], partnerBlindnessActive:C.agent_i32[ib+8] === 1, phantomBrakingActive:C.agent_i32[ib+9] === 1, x:C.agent_f32[fb], y:C.agent_f32[fb+1], h:C.agent_f32[fb+3], l:C.agent_f32[fb+4], w:C.agent_f32[fb+5], s:C.agent_f32[fb+6], st:C.agent_f32[fb+7], al:C.agent_f32[fb+8], alat:C.agent_f32[fb+9], jl:C.agent_f32[fb+10], jlat:C.agent_f32[fb+11], c:agentColor};
+            const goalRadiusField = H.agent_goal_radius_field;
+            const defaultGoalRadius = H.default_goal_radius_meters || DEFAULT_GOAL_RADIUS_METERS;
+            const goalRadius = Number.isInteger(goalRadiusField) && goalRadiusField < F.af ? C.agent_f32[fb+goalRadiusField] : defaultGoalRadius;
+            return {idx:idx, id:C.agent_i32[ib], type:agentType, cl:C.agent_i32[ib+6], slot:C.agent_i32[ib+7], partnerBlindnessActive:C.agent_i32[ib+8] === 1, phantomBrakingActive:C.agent_i32[ib+9] === 1, x:C.agent_f32[fb], y:C.agent_f32[fb+1], h:C.agent_f32[fb+3], l:C.agent_f32[fb+4], w:C.agent_f32[fb+5], s:C.agent_f32[fb+6], st:C.agent_f32[fb+7], al:C.agent_f32[fb+8], alat:C.agent_f32[fb+9], jl:C.agent_f32[fb+10], jlat:C.agent_f32[fb+11], goalRadius:goalRadius, c:agentColor};
         }
         function getFrameAgents(frame) { const out = []; for (let i=0;i<H.agent_cap;i++) { const a = agentAt(frame, i); if (a) out.push(a); } return out; }
         function drawGhosts(f) {
@@ -1400,7 +1406,7 @@ self.onmessage = async event => {
             for (let i=0;i<H.num_goals;i++) {
                 const o = base + i * stride;
                 if (goals[o] === 0 && goals[o+1] === 0) continue;
-                out.push({x:goals[o], y:goals[o+1]});
+                out.push({x:goals[o], y:goals[o+1], radius:agent.goalRadius});
             }
             return out;
         }
@@ -1557,7 +1563,7 @@ self.onmessage = async event => {
             drawGhosts(f);
             for(const a of getFrameAgents(f)){ ctx.save(); ctx.translate(a.x,a.y); ctx.rotate(a.h); drawAgentBody(a, darkMode?'#fff':'#111'); drawPerturbationOutlines(a); ctx.restore(); ctx.save(); ctx.translate(a.x,a.y); if(isEgoCam && target) ctx.rotate(-Math.PI/2 + target.h); else ctx.scale(1,-1); ctx.fillStyle=colors.text; ctx.font='600 '+(14/cam.z)+'px system-ui'; ctx.textAlign='center'; ctx.fillText(a.id,0,(isEgoCam && target)?a.w/2+.5:-a.w/2-.5); ctx.restore(); if(a.id === followedId){ ctx.save(); ctx.translate(a.x,a.y); ctx.strokeStyle=colors.accent; ctx.lineWidth=3/cam.z; ctx.beginPath(); ctx.arc(0,0,Math.max(a.l,a.w)*1.2,0,7); ctx.stroke(); ctx.restore(); } }
             for(let i=0;i<H.traffic_static_count;i++){ const t=trafficAt(f,i); if(!t) continue; const sl=t.stop_line; ctx.lineCap='butt'; if(t.type === 1){ ctx.strokeStyle=trafficColor(t); ctx.lineWidth=Math.min(1.5,3/cam.z); } else { ctx.strokeStyle=t.type === 2 ? '#ff0000' : '#ffd700'; ctx.lineWidth=Math.min(1.2,2.5/cam.z); ctx.setLineDash([6/cam.z,4/cam.z]); } ctx.beginPath(); ctx.moveTo(sl[0],sl[1]); ctx.lineTo(sl[3],sl[4]); ctx.stroke(); ctx.setLineDash([]); }
-            if(target){ for(const g of selectedGoals(f,target)){ const r=Math.max(1.8,8/cam.z); ctx.strokeStyle='#38bdf8'; ctx.fillStyle='rgba(56,189,248,.22)'; ctx.lineWidth=Math.max(.25,2.5/cam.z); ctx.beginPath(); ctx.arc(g.x,g.y,r,0,7); ctx.fill(); ctx.stroke(); } }
+            if(target){ for(const g of selectedGoals(f,target)){ ctx.strokeStyle='#38bdf8'; ctx.fillStyle='rgba(56,189,248,.22)'; ctx.lineWidth=Math.max(.25,2.5/cam.z); ctx.beginPath(); ctx.arc(g.x,g.y,g.radius,0,7); ctx.fill(); ctx.stroke(); } }
             ctx.restore(); lastDrawn = f;
         }
         function toggle(){ play=!play; lastTick=performance.now(); updateBtn(); if(play) requestAnimationFrame(loop); }

--- a/pufferlib/viz.py
+++ b/pufferlib/viz.py
@@ -815,7 +815,8 @@ def encode_interactive_replay(scenario, replay):
     road_points = []
     road_lengths = []
     road_types = []
-    for elem in scenario.get("road_elements", []) or []:
+    road_ids = []
+    for road_idx, elem in enumerate(scenario.get("road_elements", []) or []):
         if not isinstance(elem, dict):
             continue
         elem_type = int(elem.get("type", 0))
@@ -834,6 +835,7 @@ def encode_interactive_replay(scenario, replay):
         count = min(len(xs), len(ys))
         road_lengths.append(count)
         road_types.append(draw_type)
+        road_ids.append(int(elem.get("id", road_idx)))
         for i in range(count):
             road_points.append((float(xs[i]), float(ys[i])))
 
@@ -867,6 +869,7 @@ def encode_interactive_replay(scenario, replay):
         "road_points": np.asarray(road_points or [(0.0, 0.0)], dtype=np.float32),
         "road_lengths": np.asarray(road_lengths or [0], dtype=np.int32),
         "road_types": np.asarray(road_types or [0], dtype=np.int16),
+        "road_ids": np.asarray(road_ids or [0], dtype=np.int32),
         "traffic_stop_lines": np.asarray(traffic_stop_lines or [[0, 0, 0, 0, 0, 0]], dtype=np.float32),
         "traffic_types": np.asarray(traffic_types or [0], dtype=np.int16),
         "agent_f32": replay["agent_f32"].astype(np.float32, copy=False),
@@ -883,6 +886,8 @@ def encode_interactive_replay(scenario, replay):
         chunks["goals_f32"] = replay["goals_f32"].astype(np.float32, copy=False)
     if replay.get("rewards_f32") is not None:
         chunks["rewards_f32"] = replay["rewards_f32"].astype(np.float32, copy=False)
+    if replay.get("coefs_f32") is not None:
+        chunks["coefs_f32"] = replay["coefs_f32"].astype(np.float32, copy=False)
     if quantized_observations is not None:
         chunks["obs"] = quantized_observations
     if replay.get("policy_probs") is not None:
@@ -1090,6 +1095,8 @@ def _render_interactive_replay_payload(compressed_payload, filename):
             <div class="label">Policy</div><div id="policy-grid" class="grid"></div>
             <button type="button" id="reward-header" class="toggle-header" data-target="reward-grid"><span>Reward</span><span>&#9662;</span></button>
             <div id="reward-grid" class="grid toggle-body"></div>
+            <button type="button" id="coef-header" class="toggle-header is-collapsed" data-target="coef-grid"><span>Reward coefs</span><span>&#9662;</span></button>
+            <div id="coef-grid" class="grid toggle-body is-collapsed"></div>
             <button type="button" class="toggle-header" data-target="puffer-score-body"><span>Puffer score</span><span>&#9662;</span></button>
             <div id="puffer-score-body" class="toggle-body"><div id="tel-ps" class="score-num">0.000</div></div>
             <button type="button" class="toggle-header" data-target="puffer-grid"><span>Puffer metrics</span><span>&#9662;</span></button>
@@ -1113,6 +1120,8 @@ __PAYLOAD_CHUNKS__
         const VEHICLE_COLORS = __VEHICLE_COLORS__;
         // Order must match the Log fields written in env_binding.h vec_get_obs_html_frame (15 values).
         const PUFFER_LABELS = ["score","no at fault","no offroad","no red light","progress > .2","direction","ttc","progress ratio","speed limit","comfort","multi lane","wrong way dist","speed violation","multiplier","weighted avg"];
+        // Order must match the REWARD_COEF_* indices in constants.h.
+        const COEF_LABELS = ["goal radius","goal speed","collision","offroad","comfort","lane align","vel align","lane center","center bias","velocity","reverse","stop line","timestep","overspeed","throttle","steer","acc","speed"];
         const REWARD_LABELS = ["collision","offroad","red light","stop sign","goal","lane align","lane center","comfort","velocity","timestep","reverse","overspeed","ADE"];
         const ACCEL = [-4,-2.667,-1.333,0,1.333,2.667,4], STEER = [-0.667,-0.5,-0.333,-0.167,0,0.167,0.333,0.5,0.667];
         const JLONG = [-15,-4,0,4], JLAT = [-4,0,4];
@@ -1125,7 +1134,7 @@ __PAYLOAD_CHUNKS__
         const DEFAULT_GOAL_RADIUS_METERS = 2;
         const SVG_PLAY = '<svg viewBox="0 0 16 16" width="13" height="13"><path d="M4.5 2.5v11l9-5.5z" fill="currentColor"/></svg>';
         const SVG_PAUSE = '<svg viewBox="0 0 16 16" width="13" height="13"><path d="M4 2.5h3v11H4zM9 2.5h3v11H9z" fill="currentColor"/></svg>';
-        let H, C = {}, F, paths = {0:new Path2D(),1:new Path2D(),2:new Path2D()}, lastDrawn = -1;
+        let H, C = {}, F, paths = {0:new Path2D(),1:new Path2D(),2:new Path2D()}, roadPathsById = new Map(), lastDrawn = -1;
         const c = document.getElementById('c'), ctx = c.getContext('2d');
         const obsC = document.getElementById('obs-canvas'), obsCtx = obsC.getContext('2d');
         const dpr = window.devicePixelRatio || 1;
@@ -1232,7 +1241,7 @@ self.onmessage = async event => {
             H = JSON.parse(new TextDecoder().decode(new Uint8Array(buf, 4, headerLen)));
             H.buffer = buf; H.dataStart = 4 + headerLen + ((-(4 + headerLen)) & 3);
             for (const name of Object.keys(H.chunks)) C[name] = chunk(name);
-            F = {af:H.chunks.agent_f32.shape[2], ai:H.chunks.agent_i32.shape[2], mf:H.chunks.metrics_f32.shape[2], pf:H.chunks.puffer_f32.shape[2], tf:H.chunks.traffic_i16.shape[2], gf:H.chunks.goals_f32 ? H.chunks.goals_f32.shape[2] : 0, rf:H.chunks.rewards_f32 ? H.chunks.rewards_f32.shape[2] : 0};
+            F = {af:H.chunks.agent_f32.shape[2], ai:H.chunks.agent_i32.shape[2], mf:H.chunks.metrics_f32.shape[2], pf:H.chunks.puffer_f32.shape[2], tf:H.chunks.traffic_i16.shape[2], gf:H.chunks.goals_f32 ? H.chunks.goals_f32.shape[2] : 0, rf:H.chunks.rewards_f32 ? H.chunks.rewards_f32.shape[2] : 0, cf:H.chunks.coefs_f32 ? H.chunks.coefs_f32.shape[2] : 0};
             expertAgentIndices = new Set(H.expert_indices);
             document.getElementById('meta-map').textContent = String(H.map_name).split('/').pop();
             document.getElementById('meta-id').textContent = H.scenario_id || "-";
@@ -1253,12 +1262,19 @@ self.onmessage = async event => {
 
         function buildMapPaths() {
             paths = {0:new Path2D(),1:new Path2D(),2:new Path2D()};
+            roadPathsById = new Map();
             let p = 0;
             for (let i=0;i<H.road_polyline_count;i++) {
-                const len = C.road_lengths[i], type = C.road_types[i], path = paths[type];
+                const len = C.road_lengths[i], type = C.road_types[i], path = paths[type], roadId = C.road_ids[i];
                 if (len <= 0) continue;
+                const roadPath = new Path2D();
                 path.moveTo(C.road_points[p*2], C.road_points[p*2+1]);
-                for (let j=1;j<len;j++) path.lineTo(C.road_points[(p+j)*2], C.road_points[(p+j)*2+1]);
+                roadPath.moveTo(C.road_points[p*2], C.road_points[p*2+1]);
+                for (let j=1;j<len;j++) {
+                    path.lineTo(C.road_points[(p+j)*2], C.road_points[(p+j)*2+1]);
+                    roadPath.lineTo(C.road_points[(p+j)*2], C.road_points[(p+j)*2+1]);
+                }
+                roadPathsById.set(roadId, roadPath);
                 p += len;
             }
         }
@@ -1410,6 +1426,21 @@ self.onmessage = async event => {
             }
             return out;
         }
+        function strokeLanePath(laneId, color, width) {
+            const path = roadPathsById.get(laneId);
+            if (!path) return;
+            ctx.strokeStyle = color;
+            ctx.lineWidth = width;
+            ctx.stroke(path);
+        }
+        function drawCurrentLane(agent, colors) {
+            if (!agent || agent.cl < 0) return;
+            ctx.save();
+            ctx.lineCap = 'round';
+            strokeLanePath(agent.cl, 'rgba(255,255,255,.35)', Math.max(.5, 5.0/cam.z));
+            strokeLanePath(agent.cl, colors.accent, Math.max(.35, 4.0/cam.z));
+            ctx.restore();
+        }
         function decodeObs(frame, slot) {
             if (!C.obs || slot < 0 || slot >= H.active_count) return null;
             const base = (frame * H.active_count + slot) * H.obs_dim, obs = C.obs, Q = H.obs_scale === undefined ? 1 : H.obs_scale, LF = H.lane_features, BF = H.boundary_features, TF = H.traffic_features;
@@ -1467,6 +1498,10 @@ self.onmessage = async event => {
             const rewardLabels = ["return (cum)","total (step)"].concat(REWARD_LABELS.slice(0, Math.max(0, F.rf - 1)));
             rg.innerHTML = C.rewards_f32 ? rewardLabels.map(l=>`<div class="item"><span class="name">${l}</span><span class="num">-</span></div>`).join('') : '';
             document.getElementById('reward-header').style.display = C.rewards_f32 ? '' : 'none';
+            const cg = document.getElementById('coef-grid');
+            const coefLabels = COEF_LABELS.slice(0, F.cf);
+            cg.innerHTML = C.coefs_f32 ? coefLabels.map(l=>`<div class="item"><span class="name">${l}</span><span class="num">-</span></div>`).join('') : '';
+            document.getElementById('coef-header').style.display = C.coefs_f32 ? '' : 'none';
             const pol = document.getElementById('policy-grid');
             let html = '<div class="item"><span class="name">value</span><span class="num" data-pol="v">-</span></div><div class="item"><span class="name">entropy</span><span class="num" data-pol="e">-</span></div>';
             let labels = [];
@@ -1487,6 +1522,7 @@ self.onmessage = async event => {
                 metric: [...mg.querySelectorAll('.num')],
                 puffer: [...pg.querySelectorAll('.num')],
                 rewardCells: [...rg.querySelectorAll('.num')],
+                coefCells: [...cg.querySelectorAll('.num')],
                 polV: pol.querySelector('[data-pol=v]'), polE: pol.querySelector('[data-pol=e]'),
                 heat: [...pol.querySelectorAll('.heat-cell')],
                 acts: [...pol.querySelectorAll('.pol-act')], means: [...pol.querySelectorAll('.pol-mean')], stds: [...pol.querySelectorAll('.pol-std')],
@@ -1523,6 +1559,10 @@ self.onmessage = async event => {
             }
             if (C.policy_mean) { for (let i=0;i<refs.means.length;i++){ refs.means[i].textContent = C.policy_mean[ab+i].toFixed(3); refs.stds[i].textContent = C.policy_std[ab+i].toFixed(3); } refs.polLp.textContent = C.policy_log_prob[s].toFixed(3); }
         }
+        function formatCoef(value) {
+            if (value === 0) return "0";
+            return Math.abs(value) >= 1e-3 ? value.toFixed(4) : value.toExponential(1);
+        }
         function updateUI(agent=null) {
             const f = Math.max(0, Math.min(frameMax(), Math.floor(step)));
             document.getElementById('stepNow').textContent = f;
@@ -1545,6 +1585,10 @@ self.onmessage = async event => {
                 refs.rewardCells[1].textContent = formatReward(stepReward(0));
                 for (let i=2;i<refs.rewardCells.length;i++) refs.rewardCells[i].textContent = formatReward(stepReward(i-1));
             }
+            if (refs.coefCells.length) {
+                const cb = (f * H.agent_cap + agent.idx) * F.cf;
+                for (let i=0;i<refs.coefCells.length;i++) refs.coefCells[i].textContent = formatCoef(C.coefs_f32[cb+i]);
+            }
             updatePolicy(f, agent);
             const warnings = []; if(C.metrics_f32[mb] === 1) warnings.push("COLLISION"); if(C.metrics_f32[mb+1] === 1) warnings.push("OFFROAD"); if(C.metrics_f32[mb+2] === 1) warnings.push("RED LIGHT"); if(C.metrics_f32[mb+3] === 1) warnings.push("STOP SIGN");
             const warnKey = warnings.join('|'), warnRow = document.getElementById('warn-row');
@@ -1560,6 +1604,7 @@ self.onmessage = async event => {
             updateUI(target);
             const colors = getColors(); ctx.fillStyle = colors.bg; ctx.fillRect(0,0,c.width,c.height); ctx.save(); ctx.translate(c.width/2,c.height/2); ctx.scale(cam.z,-cam.z); if(isEgoCam && target) ctx.rotate(Math.PI/2 - target.h); ctx.translate(-cam.x,-cam.y);
             ctx.lineCap='round'; ctx.strokeStyle=colors.road; ctx.lineWidth=.5; ctx.stroke(paths[0]); ctx.strokeStyle=colors.line; ctx.setLineDash([1,1]); ctx.stroke(paths[1]); ctx.setLineDash([]); ctx.strokeStyle=colors.edge; ctx.lineWidth=.8; ctx.stroke(paths[2]);
+            drawCurrentLane(target, colors);
             drawGhosts(f);
             for(const a of getFrameAgents(f)){ ctx.save(); ctx.translate(a.x,a.y); ctx.rotate(a.h); drawAgentBody(a, darkMode?'#fff':'#111'); drawPerturbationOutlines(a); ctx.restore(); ctx.save(); ctx.translate(a.x,a.y); if(isEgoCam && target) ctx.rotate(-Math.PI/2 + target.h); else ctx.scale(1,-1); ctx.fillStyle=colors.text; ctx.font='600 '+(14/cam.z)+'px system-ui'; ctx.textAlign='center'; ctx.fillText(a.id,0,(isEgoCam && target)?a.w/2+.5:-a.w/2-.5); ctx.restore(); if(a.id === followedId){ ctx.save(); ctx.translate(a.x,a.y); ctx.strokeStyle=colors.accent; ctx.lineWidth=3/cam.z; ctx.beginPath(); ctx.arc(0,0,Math.max(a.l,a.w)*1.2,0,7); ctx.stroke(); ctx.restore(); } }
             for(let i=0;i<H.traffic_static_count;i++){ const t=trafficAt(f,i); if(!t) continue; const sl=t.stop_line; ctx.lineCap='butt'; if(t.type === 1){ ctx.strokeStyle=trafficColor(t); ctx.lineWidth=Math.min(1.5,3/cam.z); } else { ctx.strokeStyle=t.type === 2 ? '#ff0000' : '#ffd700'; ctx.lineWidth=Math.min(1.2,2.5/cam.z); ctx.setLineDash([6/cam.z,4/cam.z]); } ctx.beginPath(); ctx.moveTo(sl[0],sl[1]); ctx.lineTo(sl[3],sl[4]); ctx.stroke(); ctx.setLineDash([]); }

--- a/pufferlib/viz.py
+++ b/pufferlib/viz.py
@@ -881,6 +881,8 @@ def encode_interactive_replay(scenario, replay):
     }
     if replay.get("goals_f32") is not None:
         chunks["goals_f32"] = replay["goals_f32"].astype(np.float32, copy=False)
+    if replay.get("rewards_f32") is not None:
+        chunks["rewards_f32"] = replay["rewards_f32"].astype(np.float32, copy=False)
     if quantized_observations is not None:
         chunks["obs"] = quantized_observations
     if replay.get("policy_probs") is not None:
@@ -1084,6 +1086,8 @@ def _render_interactive_replay_payload(compressed_payload, filename):
             <div class="label">Position x / y / heading</div>
             <div class="mono dim" style="font-size:11.5px"><span id="tel-x">0</span>, <span id="tel-y">0</span>, <span id="tel-h">0</span></div>
             <div class="label">Policy</div><div id="policy-grid" class="grid"></div>
+            <button type="button" id="reward-header" class="toggle-header" data-target="reward-grid"><span>Reward</span><span>&#9662;</span></button>
+            <div id="reward-grid" class="grid toggle-body"></div>
             <button type="button" class="toggle-header" data-target="puffer-score-body"><span>Puffer score</span><span>&#9662;</span></button>
             <div id="puffer-score-body" class="toggle-body"><div id="tel-ps" class="score-num">0.000</div></div>
             <button type="button" class="toggle-header" data-target="puffer-grid"><span>Puffer metrics</span><span>&#9662;</span></button>
@@ -1107,6 +1111,7 @@ __PAYLOAD_CHUNKS__
         const VEHICLE_COLORS = __VEHICLE_COLORS__;
         // Order must match the Log fields written in env_binding.h vec_get_obs_html_frame (15 values).
         const PUFFER_LABELS = ["score","no at fault","no offroad","no red light","progress > .2","direction","ttc","progress ratio","speed limit","comfort","multi lane","wrong way dist","speed violation","multiplier","weighted avg"];
+        const REWARD_LABELS = ["collision","offroad","red light","stop sign","goal","lane align","lane center","comfort","velocity","timestep","reverse","overspeed","ADE"];
         const ACCEL = [-4,-2.667,-1.333,0,1.333,2.667,4], STEER = [-0.667,-0.5,-0.333,-0.167,0,0.167,0.333,0.5,0.667];
         const JLONG = [-15,-4,0,4], JLAT = [-4,0,4];
         const DYNAMIC_EXPERT_COLOR = "#c4c8cf";
@@ -1224,7 +1229,7 @@ self.onmessage = async event => {
             H = JSON.parse(new TextDecoder().decode(new Uint8Array(buf, 4, headerLen)));
             H.buffer = buf; H.dataStart = 4 + headerLen + ((-(4 + headerLen)) & 3);
             for (const name of Object.keys(H.chunks)) C[name] = chunk(name);
-            F = {af:H.chunks.agent_f32.shape[2], ai:H.chunks.agent_i32.shape[2], mf:H.chunks.metrics_f32.shape[2], pf:H.chunks.puffer_f32.shape[2], tf:H.chunks.traffic_i16.shape[2], gf:H.chunks.goals_f32 ? H.chunks.goals_f32.shape[2] : 0};
+            F = {af:H.chunks.agent_f32.shape[2], ai:H.chunks.agent_i32.shape[2], mf:H.chunks.metrics_f32.shape[2], pf:H.chunks.puffer_f32.shape[2], tf:H.chunks.traffic_i16.shape[2], gf:H.chunks.goals_f32 ? H.chunks.goals_f32.shape[2] : 0, rf:H.chunks.rewards_f32 ? H.chunks.rewards_f32.shape[2] : 0};
             expertAgentIndices = new Set(H.expert_indices);
             document.getElementById('meta-map').textContent = String(H.map_name).split('/').pop();
             document.getElementById('meta-id').textContent = H.scenario_id || "-";
@@ -1452,6 +1457,10 @@ self.onmessage = async event => {
             mg.innerHTML = METRIC_LABELS.map(l=>`<div class="item"><span class="name">${l}</span><span class="num">-</span></div>`).join('');
             const pg = document.getElementById('puffer-grid');
             pg.innerHTML = PUFFER_LABELS.map(l=>`<div class="item"><span class="name">${l}</span><span class="num">-</span></div>`).join('');
+            const rg = document.getElementById('reward-grid');
+            const rewardLabels = ["return (cum)","total (step)"].concat(REWARD_LABELS.slice(0, Math.max(0, F.rf - 1)));
+            rg.innerHTML = C.rewards_f32 ? rewardLabels.map(l=>`<div class="item"><span class="name">${l}</span><span class="num">-</span></div>`).join('') : '';
+            document.getElementById('reward-header').style.display = C.rewards_f32 ? '' : 'none';
             const pol = document.getElementById('policy-grid');
             let html = '<div class="item"><span class="name">value</span><span class="num" data-pol="v">-</span></div><div class="item"><span class="name">entropy</span><span class="num" data-pol="e">-</span></div>';
             let labels = [];
@@ -1471,6 +1480,7 @@ self.onmessage = async event => {
             refs = {
                 metric: [...mg.querySelectorAll('.num')],
                 puffer: [...pg.querySelectorAll('.num')],
+                rewardCells: [...rg.querySelectorAll('.num')],
                 polV: pol.querySelector('[data-pol=v]'), polE: pol.querySelector('[data-pol=e]'),
                 heat: [...pol.querySelectorAll('.heat-cell')],
                 acts: [...pol.querySelectorAll('.pol-act')], means: [...pol.querySelectorAll('.pol-mean')], stds: [...pol.querySelectorAll('.pol-std')],
@@ -1519,6 +1529,16 @@ self.onmessage = async event => {
             for (const [id,val] of [["tel-id",agent.id],["tel-speed",(agent.s*3.6).toFixed(1)],["tel-st",(agent.st*180/Math.PI).toFixed(1)],["tel-al",agent.al.toFixed(2)],["tel-alat",agent.alat.toFixed(2)],["tel-jl",agent.jl.toFixed(2)],["tel-jlat",agent.jlat.toFixed(2)],["tel-x",agent.x.toFixed(1)],["tel-y",agent.y.toFixed(1)],["tel-h",agent.h.toFixed(3)],["tel-lane",agent.cl],["tel-ps",C.puffer_f32[pb].toFixed(3)]]) document.getElementById(id).textContent = val;
             for (let i=0;i<refs.metric.length;i++) refs.metric[i].textContent = C.metrics_f32[mb+i].toFixed(2);
             for (let i=0;i<refs.puffer.length;i++) refs.puffer[i].textContent = C.puffer_f32[pb+i].toFixed(3);
+            if (refs.rewardCells.length) {
+                // rewards_f32 rows are cumulative Log sums; step value = difference to the previous frame.
+                const rb = (f * H.agent_cap + agent.idx) * F.rf, rbPrev = ((f-1) * H.agent_cap + agent.idx) * F.rf;
+                const cumulativeReward = i => C.rewards_f32[rb + i];
+                const stepReward = i => f > 0 ? cumulativeReward(i) - C.rewards_f32[rbPrev + i] : cumulativeReward(i);
+                const formatReward = value => value === 0 ? "0" : (Math.abs(value) >= 1e-4 ? value.toFixed(5) : value.toExponential(1));
+                refs.rewardCells[0].textContent = cumulativeReward(0).toFixed(3);
+                refs.rewardCells[1].textContent = formatReward(stepReward(0));
+                for (let i=2;i<refs.rewardCells.length;i++) refs.rewardCells[i].textContent = formatReward(stepReward(i-1));
+            }
             updatePolicy(f, agent);
             const warnings = []; if(C.metrics_f32[mb] === 1) warnings.push("COLLISION"); if(C.metrics_f32[mb+1] === 1) warnings.push("OFFROAD"); if(C.metrics_f32[mb+2] === 1) warnings.push("RED LIGHT"); if(C.metrics_f32[mb+3] === 1) warnings.push("STOP SIGN");
             const warnKey = warnings.join('|'), warnRow = document.getElementById('warn-row');

--- a/tests/eval/test_eval.py
+++ b/tests/eval/test_eval.py
@@ -436,6 +436,7 @@ def test_multiprocess_replay_capture_renders_zlib_to_html(tmp_path, monkeypatch)
         "agent_i32",
         "metrics_f32",
         "traffic_i16",
+        "goals_f32",
         "obs",
         "raw_action",
         "policy_probs",

--- a/tests/eval/test_eval.py
+++ b/tests/eval/test_eval.py
@@ -466,7 +466,11 @@ def test_multiprocess_replay_capture_renders_zlib_to_html(tmp_path, monkeypatch,
         assert header["active_count"] == 1
         assert (header["obs_dim"] > 0) is capture_observations
         assert required_chunks <= set(header["chunks"])
+        assert header["agent_goal_radius_field"] == 12
+        assert header["chunks"]["agent_f32"]["shape"][2] == 13
         assert header["chunks"]["rewards_f32"]["shape"][2] == 14
+        agent_frames = _read_replay_float32_chunk(replay_path, "agent_f32")
+        assert np.any(agent_frames[..., header["agent_goal_radius_field"]] > 0.0)
         rewards = _read_replay_float32_chunk(replay_path, "rewards_f32")
         assert np.any(rewards[..., 0] != 0.0)
         np.testing.assert_allclose(rewards[..., 0], rewards[..., 1:].sum(axis=-1), atol=1e-4)
@@ -478,6 +482,7 @@ def test_multiprocess_replay_capture_renders_zlib_to_html(tmp_path, monkeypatch,
     rendered_html = [page.read_text() for page in rendered_pages]
     assert all('class="payload-chunk"' in html for html in rendered_html)
     assert all('id="reward-grid"' in html and '"return (cum)"' in html for html in rendered_html)
+    assert all("ctx.arc(g.x,g.y,g.radius" in html for html in rendered_html)
     assert all(replay_path.is_file() for replay_path in replay_paths)
 
     drive_eval_replay._render_eval_replays(summaries, str(tmp_path), keep_zlib_replays=False)

--- a/tests/eval/test_eval.py
+++ b/tests/eval/test_eval.py
@@ -15,6 +15,7 @@ import yaml
 import pufferlib
 from pufferlib import pufferl
 from pufferlib.config_schema import validate_puffer_drive_config
+from pufferlib.ocean.drive import binding
 from pufferlib.ocean.drive.drive import Drive
 from pufferlib.ocean.evaluation_utils import evaluation_utils as drive_benchmark
 from pufferlib.ocean.evaluation_utils import eval_replay as drive_eval_replay
@@ -455,6 +456,7 @@ def test_multiprocess_replay_capture_renders_zlib_to_html(tmp_path, monkeypatch,
         "traffic_i16",
         "goals_f32",
         "rewards_f32",
+        "coefs_f32",
         "raw_action",
         "policy_probs",
     }
@@ -474,6 +476,12 @@ def test_multiprocess_replay_capture_renders_zlib_to_html(tmp_path, monkeypatch,
         rewards = _read_replay_float32_chunk(replay_path, "rewards_f32")
         assert np.any(rewards[..., 0] != 0.0)
         np.testing.assert_allclose(rewards[..., 0], rewards[..., 1:].sum(axis=-1), atol=1e-4)
+
+        coefs = _read_replay_float32_chunk(replay_path, "coefs_f32")
+        assert header["chunks"]["coefs_f32"]["shape"][2] == binding.NUM_REWARD_COEFS
+        goal_radius_coefs = coefs[..., 0]
+        agent_goal_radii = agent_frames[..., header["agent_goal_radius_field"]]
+        np.testing.assert_allclose(goal_radius_coefs, agent_goal_radii, atol=1e-6)
 
     render_dir = Path(drive_eval_replay._render_eval_replays(summaries, str(tmp_path), keep_zlib_replays=True))
     rendered_pages = sorted(path for path in render_dir.glob("*.html") if path.name != "index.html")

--- a/tests/eval/test_eval.py
+++ b/tests/eval/test_eval.py
@@ -394,7 +394,24 @@ def _read_replay_header(replay_path):
     return json.loads(payload[4 : 4 + header_length])
 
 
-def test_multiprocess_replay_capture_renders_zlib_to_html(tmp_path, monkeypatch):
+def _read_replay_float32_chunk(replay_path, chunk_name):
+    payload = zlib.decompress(replay_path.read_bytes())
+    header_length = struct.unpack_from("<I", payload)[0]
+    header = json.loads(payload[4 : 4 + header_length])
+    chunk = header["chunks"][chunk_name]
+    assert chunk["dtype"] == "float32"
+    data_start = 4 + header_length + (-(4 + header_length) % 4)
+    values = np.frombuffer(
+        payload,
+        dtype=np.float32,
+        count=chunk["nbytes"] // np.dtype(np.float32).itemsize,
+        offset=data_start + chunk["offset"],
+    )
+    return values.reshape(chunk["shape"])
+
+
+@pytest.mark.parametrize("capture_observations", [False, True], ids=["without_observations", "with_observations"])
+def test_multiprocess_replay_capture_renders_zlib_to_html(tmp_path, monkeypatch, capture_observations):
     args = _replay_render_args()
     map_seed_pairs = [(0, 1234), (0, 5678)]
     worker_env_kwargs, total_steps = drive_benchmark._plan_failure_replay_workers(
@@ -421,7 +438,7 @@ def test_multiprocess_replay_capture_renders_zlib_to_html(tmp_path, monkeypatch)
         expected_episodes=2,
         policy=ZeroPolicy(action_count=12),
         replay_output_dir=replay_output_dir,
-        capture_observations=True,
+        capture_observations=capture_observations,
     )
 
     assert len(multiprocessing_calls) == 1
@@ -437,22 +454,30 @@ def test_multiprocess_replay_capture_renders_zlib_to_html(tmp_path, monkeypatch)
         "metrics_f32",
         "traffic_i16",
         "goals_f32",
-        "obs",
+        "rewards_f32",
         "raw_action",
         "policy_probs",
     }
+    if capture_observations:
+        required_chunks.add("obs")
     for replay_path in replay_paths:
         header = _read_replay_header(replay_path)
         assert header["frames"] == 64
         assert header["active_count"] == 1
-        assert header["obs_dim"] > 0
+        assert (header["obs_dim"] > 0) is capture_observations
         assert required_chunks <= set(header["chunks"])
+        assert header["chunks"]["rewards_f32"]["shape"][2] == 14
+        rewards = _read_replay_float32_chunk(replay_path, "rewards_f32")
+        assert np.any(rewards[..., 0] != 0.0)
+        np.testing.assert_allclose(rewards[..., 0], rewards[..., 1:].sum(axis=-1), atol=1e-4)
 
     render_dir = Path(drive_eval_replay._render_eval_replays(summaries, str(tmp_path), keep_zlib_replays=True))
     rendered_pages = sorted(path for path in render_dir.glob("*.html") if path.name != "index.html")
     assert len(rendered_pages) == 2
     assert (render_dir / "index.html").is_file()
-    assert all('class="payload-chunk"' in page.read_text() for page in rendered_pages)
+    rendered_html = [page.read_text() for page in rendered_pages]
+    assert all('class="payload-chunk"' in html for html in rendered_html)
+    assert all('id="reward-grid"' in html and '"return (cum)"' in html for html in rendered_html)
     assert all(replay_path.is_file() for replay_path in replay_paths)
 
     drive_eval_replay._render_eval_replays(summaries, str(tmp_path), keep_zlib_replays=False)


### PR DESCRIPTION
  ## What

  - Capture world-space goals and configured goal radius in replay data.
  - Display cumulative and per-step reward components and reward coefficients.
  - Track road IDs and highlight the selected agent’s current lane.
  - Assign evaluation maps deterministically, respecting explicit map indices.

  ## Why

  Goals previously depended on captured policy observations, causing them to disappear or render
  incorrectly. Evaluation map selection could also mismatch replay scenarios. These changes make replays
  reliable and provide better debugging context for goals, lanes, and rewards.

  ## Notes

  The replay payload now includes goals_f32, rewards_f32, coefs_f32, road IDs, and per-agent goal radii.
